### PR TITLE
Language features: arrays, generics, traits, concurrency, modules, stdlib, C FFI

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -460,6 +460,8 @@ target_link_libraries(tocin_runtime PUBLIC Threads::Threads)
 target_link_libraries(tocin PRIVATE tocin_core tocin_runtime)
 # Tell the driver where to find the runtime archive when linking AOT binaries.
 target_compile_definitions(tocin PRIVATE TOCIN_RUNTIME_LIB="$<TARGET_FILE:tocin_runtime>")
+# Default search path for `import` of standard-library modules.
+target_compile_definitions(tocin PRIVATE TOCIN_STDLIB_PATH="${CMAKE_SOURCE_DIR}/stdlib")
 
 # Export symbols dynamically so the JIT can resolve the Tocin runtime
 # (channels, goroutines, etc.) from within the running compiler process.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -300,6 +300,9 @@ list(REMOVE_ITEM SOURCES "${CMAKE_CURRENT_SOURCE_DIR}/src/test.cpp")
 # Exclude the driver main() from the core library; it is linked into the
 # tocin executable directly so the same core can be reused by the test binary.
 list(REMOVE_ITEM SOURCES "${CMAKE_CURRENT_SOURCE_DIR}/src/main.cpp")
+# The concurrency runtime is a small, LLVM-free static library so it can be
+# linked into both the compiler (for the JIT) and AOT-produced executables.
+list(REMOVE_ITEM SOURCES "${CMAKE_CURRENT_SOURCE_DIR}/src/runtime/concurrency_runtime.cpp")
 
 # Find all header files
 file(GLOB_RECURSE HEADERS
@@ -448,7 +451,21 @@ endif()
 # Propagate all library dependencies through the core library so both the
 # tocin executable and the test binary inherit them automatically.
 target_link_libraries(tocin_core PUBLIC ${LINK_LIBS})
-target_link_libraries(tocin PRIVATE tocin_core)
+# Standalone Tocin runtime (channels/goroutines) — no LLVM dependency, so it
+# can be linked into native executables produced by the AOT path.
+add_library(tocin_runtime STATIC ${CMAKE_CURRENT_SOURCE_DIR}/src/runtime/concurrency_runtime.cpp)
+set_target_properties(tocin_runtime PROPERTIES POSITION_INDEPENDENT_CODE ON)
+target_link_libraries(tocin_runtime PUBLIC Threads::Threads)
+
+target_link_libraries(tocin PRIVATE tocin_core tocin_runtime)
+# Tell the driver where to find the runtime archive when linking AOT binaries.
+target_compile_definitions(tocin PRIVATE TOCIN_RUNTIME_LIB="$<TARGET_FILE:tocin_runtime>")
+
+# Export symbols dynamically so the JIT can resolve the Tocin runtime
+# (channels, goroutines, etc.) from within the running compiler process.
+if(NOT WIN32)
+    target_link_options(tocin PRIVATE -rdynamic)
+endif()
 
 # -------------------------
 # Compiler Flags & Optimizations

--- a/README.md
+++ b/README.md
@@ -20,10 +20,22 @@ clear what is implemented versus planned.
   annotated; a real type checker reports genuine type errors.
 - **Functions** — parameters, recursion, mutual recursion, and use-before-definition
   (declarations are order-independent via two-pass code generation).
-- **Control flow** — `if / elif / else`, `while`, and range-based `for i in a..b`.
+- **Control flow** — `if / elif / else`, `while`, range-based `for i in a..b`, and
+  `match` / `case` / `default`.
 - **Classes / structs** — fields, methods with `self`, construction, field read and
   mutation, and method calls.
+- **Traits & impl** — `trait` interfaces and `impl [Trait for] Type` blocks with
+  per-type method dispatch.
+- **Generics** — `def f<T>(...)` monomorphized per concrete type at the call site.
+- **Arrays** — array literals, indexing (read/write), `len`, iteration, and arrays
+  as reference-typed function parameters.
+- **Concurrency** — `go f(args)` goroutines (real OS threads) and typed `channel<T>`
+  send/receive, in both JIT and native builds.
+- **Modules** — `import a.b.c` / `import "path"` resolves and merges other `.to`
+  files; a small standard library ships in `stdlib/std/` (math, list).
+- **C FFI** — call C library functions via `extern def name(...) -> T;`.
 - **Strings** — string literals and concatenation with `+`.
+- **Math builtins** — `sqrt`, `pow`, `abs`, `min`, `max`, `floor`, trig, and more.
 - **Formatted output** — `print` / `println`, including `println("x = {}", x)`.
 
 ## Quick start
@@ -118,6 +130,47 @@ def main() {
 }
 ```
 
+Generics, traits, arrays, and the standard library:
+
+```tocin
+import std.list;                          // listSum, listMax, ...
+
+def max<T>(a: T, b: T) -> T {             // monomorphized per type
+    if a > b { return a; }
+    return b;
+}
+
+trait Shape { def area(self) -> int; }
+struct Square { side: int; }
+impl Shape for Square {
+    def area(self) -> int { return self.side * self.side; }
+}
+
+def main() {
+    let nums = [3, 1, 4, 1, 5, 9];        // array literal
+    println("len={} sum={} max={}", len(nums), listSum(nums), listMax(nums));
+    println("max(2, 7) = {}", max(2, 7)); // generic
+    let s = Square(5);
+    println("area = {}", s.area());       // trait method = 25
+    return s.area();
+}
+```
+
+Goroutines and channels:
+
+```tocin
+def worker(ch: channel<int>, n: int) { ch <- n * n; }
+
+def main() {
+    let ch = channel<int>();
+    for i in 1..6 { go worker(ch, i); }   // 5 goroutines (OS threads)
+    let total = 0;
+    for i in 0..5 { total = total + <-ch; }
+    println("sum of squares = {}", total); // 55
+    return total;
+}
+```
+
 ## How it works
 
 ```
@@ -163,27 +216,30 @@ bash scripts/run_to_tests.sh                      # .to integration programs
 
 ## Roadmap
 
-These features are partially scaffolded in the source tree and/or planned, but are
-**not yet fully working end-to-end**. They are listed here honestly so expectations
-match reality:
+These features are planned or partially scaffolded but **not yet fully working
+end-to-end**. They are listed honestly so expectations match reality:
 
-- **Traits & `impl` blocks** — AST/parsing groundwork exists; resolution and codegen pending.
-- **Generics** — generic syntax is recognized; monomorphization is pending.
-- **Collections & LINQ** — arrays/lists with indexing, and `where`/`select`/`aggregate`.
-- **Pattern matching** — `match` with destructuring patterns.
+- **Generic classes** — generic *functions* are monomorphized today; generic
+  `class C<T>` instantiation is still pending (generic free functions work).
+- **LINQ-style collections** — `where` / `select` / `aggregate` over collections.
+- **Pattern matching destructuring** — `match` works on values today; binding
+  sub-patterns (e.g. `case Some(x)`) is pending.
 - **Null safety** — `?.`, `?:`, `!!` operators and nullable-type flow analysis.
-- **`Option` / `Result`** — types are defined; exhaustiveness checking and ergonomics pending.
-- **Concurrency** — `go`, channels, and `select` parse today; a fiber scheduler exists in
-  `src/runtime` but is not yet wired to codegen. `async` / `await`.
-- **FFI** — Python (CPython) and C/C++ (`dlopen`) backends are largely implemented;
-  JavaScript is a stub. V8 is gated behind `-DWITH_V8=ON` and is **not** bundled
-  (it is not installable from standard package managers), so CI builds with `-DWITH_V8=OFF`.
-- **Macros** — a macro engine exists but is not yet invoked by the compile pipeline.
+- **`Option` / `Result`** — types are defined; exhaustiveness checking and `?`
+  propagation pending.
+- **`async` / `await`** — goroutines and channels work; structured async is pending.
+- **`select`** over multiple channels.
+- **Error handling** — `try` / `catch` / `throw` and **enums**.
+- **Python / JavaScript FFI** — C FFI works via `extern`; deep CPython and V8
+  integration is gated behind build flags (V8 is not bundled — it is not
+  installable from standard package managers, so CI builds with `-DWITH_V8=OFF`).
+- **Macros** — a macro engine exists but is not yet invoked by the pipeline.
 - **WebAssembly target**, **package manager**, and an **interactive debugger**
   (behind their respective CMake flags).
 - **Advanced optimization** — the standard LLVM `-O0..-O3` pipelines are wired and
-  working today (e.g. constant folding); profile-guided/interprocedural/polyhedral
-  passes in `src/compiler/advanced_optimizations.cpp` are not yet on the default path.
+  working today (e.g. constant folding); profile-guided / interprocedural /
+  polyhedral passes in `src/compiler/advanced_optimizations.cpp` are not yet on
+  the default path.
 
 Contributions toward any of these are very welcome.
 

--- a/examples/concurrency.to
+++ b/examples/concurrency.to
@@ -1,0 +1,21 @@
+// Goroutines and channels. Run with:
+//   tocin examples/concurrency.to --run
+//   tocin examples/concurrency.to -o conc && ./conc
+def worker(ch: channel<int>, n: int) {
+    ch <- n * n;          // send this worker's result
+}
+
+def main() {
+    let ch = channel<int>();
+    // Spawn goroutines that each compute a square concurrently.
+    for i in 1..6 {
+        go worker(ch, i);
+    }
+    // Collect the 5 results from the channel.
+    let total = 0;
+    for i in 0..5 {
+        total = total + <-ch;
+    }
+    println("sum of squares 1..5 = {}", total);   // 1+4+9+16+25 = 55
+    return total;
+}

--- a/src/ast/ast.h
+++ b/src/ast/ast.h
@@ -68,6 +68,7 @@ namespace ast
     class SelectStmt;
     class GoStmt;
     class ArrayLiteralExpr;
+    class IndexExpr;
 
     // Define shared pointers for common types - Type is already defined in types.h
     using ExprPtr = std::shared_ptr<Expression>;
@@ -113,6 +114,7 @@ namespace ast
         virtual void visitSelectStmt(SelectStmt *stmt) = 0;
         virtual void visitGoStmt(GoStmt *stmt) = 0;
         virtual void visitArrayLiteralExpr(ArrayLiteralExpr *expr) = 0;
+        virtual void visitIndexExpr(IndexExpr *expr) = 0;
         virtual void visitTraitStmt(TraitStmt *stmt) = 0;
         virtual void visitImplStmt(ImplStmt *stmt) = 0;
 
@@ -886,6 +888,20 @@ namespace ast
     };
 
     /**
+     * @brief Index/subscript expression (e.g., arr[i]).
+     */
+    class IndexExpr : public Expression
+    {
+    public:
+        IndexExpr(const lexer::Token &token, ExprPtr object, ExprPtr index)
+            : Expression(token), object(std::move(object)), index(std::move(index)) {}
+        void accept(Visitor &visitor) override;
+        ExprPtr object;
+        ExprPtr index;
+        TypePtr getType() const override { return nullptr; }
+    };
+
+    /**
      * @brief Trait statement - defines a trait
      */
     class TraitStmt : public Statement
@@ -957,6 +973,7 @@ namespace ast
     inline void SelectStmt::accept(Visitor &visitor) { visitor.visitSelectStmt(this); }
     inline void GoStmt::accept(Visitor &visitor) { visitor.visitGoStmt(this); }
     inline void ArrayLiteralExpr::accept(Visitor &visitor) { visitor.visitArrayLiteralExpr(this); }
+    inline void IndexExpr::accept(Visitor &visitor) { visitor.visitIndexExpr(this); }
 
 } // namespace ast
 

--- a/src/codegen/ir_generator.cpp
+++ b/src/codegen/ir_generator.cpp
@@ -753,6 +753,14 @@ void IRGenerator::visitFunctionStmt(ast::FunctionStmt *stmt)
         return;
     }
 
+    // A body-less function is an external (C/FFI) declaration: emit only the
+    // prototype and let the linker/JIT resolve the real symbol.
+    if (!stmt->body)
+    {
+        declareFunctionProto(stmt);
+        return;
+    }
+
     // Handle regular functions
     std::string funcName = stmt->name;
     

--- a/src/codegen/ir_generator.cpp
+++ b/src/codegen/ir_generator.cpp
@@ -1044,6 +1044,73 @@ void IRGenerator::visitCallExpr(ast::CallExpr *expr)
             return;
         }
 
+        // Math standard library: unary libm functions (double -> double).
+        static const std::set<std::string> unaryMath = {
+            "sqrt", "sin", "cos", "tan", "asin", "acos", "atan",
+            "exp", "log", "log2", "log10", "floor", "ceil", "round", "fabs"};
+        llvm::Type *dbl = llvm::Type::getDoubleTy(context);
+        if (unaryMath.count(funcName) && expr->arguments.size() == 1)
+        {
+            expr->arguments[0]->accept(*this);
+            if (!lastValue) return;
+            llvm::Value *x = lastValue;
+            if (x->getType()->isIntegerTy())
+                x = builder.CreateSIToFP(x, dbl, "tofp");
+            llvm::Function *f = module->getFunction(funcName);
+            if (!f)
+                f = llvm::Function::Create(llvm::FunctionType::get(dbl, {dbl}, false),
+                                           llvm::Function::ExternalLinkage, funcName, *module);
+            lastValue = builder.CreateCall(f, {x}, funcName);
+            return;
+        }
+        if (funcName == "pow" && expr->arguments.size() == 2)
+        {
+            expr->arguments[0]->accept(*this); llvm::Value *a = lastValue;
+            expr->arguments[1]->accept(*this); llvm::Value *b = lastValue;
+            if (!a || !b) return;
+            if (a->getType()->isIntegerTy()) a = builder.CreateSIToFP(a, dbl, "tofp");
+            if (b->getType()->isIntegerTy()) b = builder.CreateSIToFP(b, dbl, "tofp");
+            llvm::Function *f = module->getFunction("pow");
+            if (!f)
+                f = llvm::Function::Create(llvm::FunctionType::get(dbl, {dbl, dbl}, false),
+                                           llvm::Function::ExternalLinkage, "pow", *module);
+            lastValue = builder.CreateCall(f, {a, b}, "pow");
+            return;
+        }
+        if (funcName == "abs" && expr->arguments.size() == 1)
+        {
+            expr->arguments[0]->accept(*this);
+            if (!lastValue) return;
+            llvm::Value *x = lastValue;
+            if (x->getType()->isFloatingPointTy())
+            {
+                llvm::Value *neg = builder.CreateFNeg(x, "fneg");
+                llvm::Value *lt = builder.CreateFCmpOLT(x, llvm::ConstantFP::get(x->getType(), 0.0), "ltz");
+                lastValue = builder.CreateSelect(lt, neg, x, "fabs");
+            }
+            else
+            {
+                llvm::Value *neg = builder.CreateNeg(x, "neg");
+                llvm::Value *lt = builder.CreateICmpSLT(x, llvm::ConstantInt::get(x->getType(), 0), "ltz");
+                lastValue = builder.CreateSelect(lt, neg, x, "abs");
+            }
+            return;
+        }
+        if ((funcName == "min" || funcName == "max") && expr->arguments.size() == 2)
+        {
+            expr->arguments[0]->accept(*this); llvm::Value *a = lastValue;
+            expr->arguments[1]->accept(*this); llvm::Value *b = lastValue;
+            if (!a || !b) return;
+            bool wantMin = (funcName == "min");
+            llvm::Value *cmp;
+            if (a->getType()->isFloatingPointTy() || b->getType()->isFloatingPointTy())
+                cmp = wantMin ? builder.CreateFCmpOLT(a, b, "cmp") : builder.CreateFCmpOGT(a, b, "cmp");
+            else
+                cmp = wantMin ? builder.CreateICmpSLT(a, b, "cmp") : builder.CreateICmpSGT(a, b, "cmp");
+            lastValue = builder.CreateSelect(cmp, a, b, funcName);
+            return;
+        }
+
         // print()/println() are built-ins forwarded to printf. println appends
         // a newline. Two calling styles are supported:
         //   * format style: print("x = {}, y = {}", x, y)  (first arg is a

--- a/src/codegen/ir_generator.cpp
+++ b/src/codegen/ir_generator.cpp
@@ -611,6 +611,21 @@ void IRGenerator::visitVariableStmt(ast::VariableStmt *stmt)
     if (!vcls.empty())
         varClasses[stmt->name] = vcls;
 
+    // Track array element type so indexing into this variable loads/stores the
+    // right element type.
+    if (auto lst = std::dynamic_pointer_cast<ast::ListExpr>(stmt->initializer))
+    {
+        varArrayElem[stmt->name] =
+            lst->elements.empty() ? llvm::Type::getInt64Ty(context)
+                                  : inferExprType(lst->elements[0], {});
+    }
+    else if (auto v = std::dynamic_pointer_cast<ast::VariableExpr>(stmt->initializer))
+    {
+        auto it = varArrayElem.find(v->name);
+        if (it != varArrayElem.end())
+            varArrayElem[stmt->name] = it->second;
+    }
+
     // If there's an initializer, store its value
     if (stmt->initializer)
     {
@@ -1012,6 +1027,16 @@ void IRGenerator::visitCallExpr(ast::CallExpr *expr)
     if (auto varExpr = std::dynamic_pointer_cast<ast::VariableExpr>(expr->callee))
     {
         std::string funcName = varExpr->name;
+
+        // len(arr) reads the length stored in the array header (offset 0).
+        if (funcName == "len" && expr->arguments.size() == 1)
+        {
+            expr->arguments[0]->accept(*this);
+            llvm::Value *base = lastValue;
+            if (!base) return;
+            lastValue = builder.CreateLoad(llvm::Type::getInt64Ty(context), base, "len");
+            return;
+        }
 
         // print()/println() are built-ins forwarded to printf. println appends
         // a newline. Two calling styles are supported:
@@ -1755,101 +1780,51 @@ void IRGenerator::visitLambdaExpr(ast::LambdaExpr *expr)
 
 void IRGenerator::visitListExpr(ast::ListExpr *expr)
 {
-    // Use getType() method for type information
-    ast::TypePtr exprType = expr->getType();
-
-    if (expr->elements.empty())
-    {
-        // Create an empty list using the type info
-        createEmptyList(exprType);
-        return;
-    }
-
-    // Evaluate the first element to determine type
-    expr->elements[0]->accept(*this);
-    llvm::Value *firstElement = lastValue;
-    if (!firstElement)
-        return;
-
-    // Get element type
-    llvm::Type *elementType = firstElement->getType();
-
-    // Create list struct type: { int64_t length, elementType* data }
-    std::vector<llvm::Type *> listFields = {
-        llvm::Type::getInt64Ty(context),   // length
-        llvm::PointerType::get(context, 0) // opaque pointer for data
-    };
-    llvm::StructType *listStructType = llvm::StructType::get(context, listFields);
-
-    // Allocate list struct
-    llvm::AllocaInst *listAlloc = builder.CreateAlloca(listStructType, nullptr, "list");
-
-    // Set length
-    llvm::Value *lengthPtr = builder.CreateStructGEP(listStructType, listAlloc, 0, "list.length");
-    builder.CreateStore(llvm::ConstantInt::get(llvm::Type::getInt64Ty(context), expr->elements.size()), lengthPtr);
-
-    // Allocate array for elements using the correct CreateMalloc signature
-    llvm::Value *arraySize = llvm::ConstantInt::get(llvm::Type::getInt64Ty(context), expr->elements.size());
-
-    // Calculate the size of each element
-    llvm::Value *elementSize = llvm::ConstantExpr::getSizeOf(elementType);
-
-    // Calculate total allocation size
-    llvm::Value *totalSize = builder.CreateMul(arraySize, elementSize);
-
-    // Call malloc
-    llvm::FunctionType *mallocType = llvm::FunctionType::get(
-        llvm::PointerType::get(context, 0),
-        {llvm::Type::getInt64Ty(context)},
-        false);
+    llvm::Type *i64 = llvm::Type::getInt64Ty(context);
     llvm::Function *mallocFunc = getStdLibFunction("malloc");
-    if (!mallocFunc)
+
+    // Determine the element type from the first element (default to i64).
+    llvm::Type *elemTy = i64;
+    std::vector<llvm::Value *> elems;
+    for (auto &e : expr->elements)
     {
-        mallocFunc = llvm::Function::Create(
-            mallocType, llvm::Function::ExternalLinkage, "malloc", *module);
+        e->accept(*this);
+        if (!lastValue) return;
+        elems.push_back(lastValue);
     }
+    if (!elems.empty())
+        elemTy = elems[0]->getType();
 
-    llvm::Value *dataPtr = builder.CreateCall(mallocFunc, {totalSize}, "list.data");
+    // Layout: [ i64 length ][ elem0 ][ elem1 ]...  in one heap block.
+    llvm::Value *count = llvm::ConstantInt::get(i64, elems.size());
+    llvm::Value *elemSize = llvm::ConstantExpr::getSizeOf(elemTy);
+    llvm::Value *header = llvm::ConstantInt::get(i64, 8);
+    llvm::Value *total = builder.CreateAdd(header, builder.CreateMul(count, elemSize), "arr.size");
+    llvm::Value *base = builder.CreateCall(mallocFunc->getFunctionType(), mallocFunc, {total}, "arr");
 
-    // Store data pointer
-    llvm::Value *dataStorePtr = builder.CreateStructGEP(listStructType, listAlloc, 1, "list.data_ptr");
-    builder.CreateStore(dataPtr, dataStorePtr);
+    // Store the length in the header.
+    builder.CreateStore(count, base);
 
-    // Store first element - bitcast to the right type first
-    llvm::Value *typedPtr = builder.CreateBitCast(dataPtr,
-                                                  llvm::PointerType::get(elementType, 0), "typed_data");
-
-    llvm::Value *elementPtr = builder.CreateGEP(elementType, typedPtr,
-                                                llvm::ConstantInt::get(llvm::Type::getInt64Ty(context), 0),
-                                                "list.element");
-    builder.CreateStore(firstElement, elementPtr);
-
-    // Process rest of elements
-    for (size_t i = 1; i < expr->elements.size(); ++i)
+    // Store each element at offset 8 + i*sizeof(elem).
+    llvm::Type *i8 = llvm::Type::getInt8Ty(context);
+    for (size_t i = 0; i < elems.size(); ++i)
     {
-        expr->elements[i]->accept(*this);
-        llvm::Value *element = lastValue;
-        if (!element)
-            return;
-
-        // Validate element type
-        if (element->getType() != elementType)
+        llvm::Value *v = elems[i];
+        if (v->getType() != elemTy)
         {
-            errorHandler.reportError(error::ErrorCode::T001_TYPE_MISMATCH,
-                                     "List elements must have the same type",
-                                     "", 0, 0, error::ErrorSeverity::ERROR);
-            return;
+            if (v->getType()->isIntegerTy() && elemTy->isIntegerTy())
+                v = builder.CreateIntCast(v, elemTy, true, "ecast");
+            else if (v->getType()->isFloatingPointTy() && elemTy->isFloatingPointTy())
+                v = builder.CreateFPCast(v, elemTy, "ecast");
         }
-
-        // Store element
-        elementPtr = builder.CreateGEP(elementType, typedPtr,
-                                       llvm::ConstantInt::get(llvm::Type::getInt64Ty(context), i),
-                                       "list.element");
-        builder.CreateStore(element, elementPtr);
+        llvm::Value *off = builder.CreateAdd(
+            header, builder.CreateMul(llvm::ConstantInt::get(i64, i), elemSize), "arr.off");
+        llvm::Value *slot = builder.CreateGEP(i8, base, off, "arr.slot");
+        builder.CreateStore(v, slot);
     }
 
-    // Return list
-    lastValue = listAlloc;
+    lastValue = base;
+    lastExprArrayElem = elemTy;
 }
 
 void IRGenerator::createEmptyList(ast::TypePtr listTypeArg)
@@ -2142,6 +2117,54 @@ std::string IRGenerator::getExprClassName(const ast::ExprPtr &expr)
         }
     }
     return "";
+}
+
+llvm::Type *IRGenerator::getArrayElemType(const ast::ExprPtr &expr)
+{
+    if (!expr)
+        return llvm::Type::getInt64Ty(context);
+    if (auto var = std::dynamic_pointer_cast<ast::VariableExpr>(expr))
+    {
+        auto it = varArrayElem.find(var->name);
+        if (it != varArrayElem.end())
+            return it->second;
+    }
+    if (auto lst = std::dynamic_pointer_cast<ast::ListExpr>(expr))
+    {
+        if (!lst->elements.empty())
+            return inferExprType(lst->elements[0], {});
+    }
+    if (auto idx = std::dynamic_pointer_cast<ast::IndexExpr>(expr))
+    {
+        // Nested arrays: element of an element is the same scalar type for now.
+        return getArrayElemType(idx->object);
+    }
+    return llvm::Type::getInt64Ty(context);
+}
+
+void IRGenerator::visitIndexExpr(ast::IndexExpr *expr)
+{
+    // Evaluate the array base pointer and the index.
+    expr->object->accept(*this);
+    llvm::Value *base = lastValue;
+    if (!base) return;
+    expr->index->accept(*this);
+    llvm::Value *index = lastValue;
+    if (!index) return;
+
+    llvm::Type *i64 = llvm::Type::getInt64Ty(context);
+    llvm::Type *i8 = llvm::Type::getInt8Ty(context);
+    if (!index->getType()->isIntegerTy(64))
+        index = builder.CreateIntCast(index, i64, true, "idx");
+
+    llvm::Type *elemTy = getArrayElemType(expr->object);
+    llvm::Value *elemSize = llvm::ConstantExpr::getSizeOf(elemTy);
+    // Offset = 8 (length header) + index * sizeof(elem).
+    llvm::Value *off = builder.CreateAdd(
+        llvm::ConstantInt::get(i64, 8),
+        builder.CreateMul(index, elemSize), "idx.off");
+    llvm::Value *slot = builder.CreateGEP(i8, base, off, "idx.slot");
+    lastValue = builder.CreateLoad(elemTy, slot, "idx.val");
 }
 
 void IRGenerator::generateMethod(const std::string &className, llvm::StructType *classType, ast::FunctionStmt *method)
@@ -2977,6 +3000,38 @@ void IRGenerator::visitAssignExpr(ast::AssignExpr *expr)
             lastValue = nullptr;
             return;
         }
+    }
+
+    // Handle indexed assignment (arr[i] = value)
+    if (auto idxExpr = std::dynamic_pointer_cast<ast::IndexExpr>(expr->target))
+    {
+        idxExpr->object->accept(*this);
+        llvm::Value *base = lastValue;
+        if (!base) return;
+        idxExpr->index->accept(*this);
+        llvm::Value *index = lastValue;
+        if (!index) return;
+
+        llvm::Type *i64 = llvm::Type::getInt64Ty(context);
+        llvm::Type *i8 = llvm::Type::getInt8Ty(context);
+        if (!index->getType()->isIntegerTy(64))
+            index = builder.CreateIntCast(index, i64, true, "idx");
+        llvm::Type *elemTy = getArrayElemType(idxExpr->object);
+        if (rhs->getType() != elemTy)
+        {
+            if (rhs->getType()->isIntegerTy() && elemTy->isIntegerTy())
+                rhs = builder.CreateIntCast(rhs, elemTy, true, "ecast");
+            else if (rhs->getType()->isFloatingPointTy() && elemTy->isFloatingPointTy())
+                rhs = builder.CreateFPCast(rhs, elemTy, "ecast");
+        }
+        llvm::Value *elemSize = llvm::ConstantExpr::getSizeOf(elemTy);
+        llvm::Value *off = builder.CreateAdd(
+            llvm::ConstantInt::get(i64, 8),
+            builder.CreateMul(index, elemSize), "idx.off");
+        llvm::Value *slot = builder.CreateGEP(i8, base, off, "idx.slot");
+        builder.CreateStore(rhs, slot);
+        lastValue = rhs;
+        return;
     }
 
     // Handle property assignment (obj.prop = value)

--- a/src/codegen/ir_generator.cpp
+++ b/src/codegen/ir_generator.cpp
@@ -285,6 +285,10 @@ llvm::Type *IRGenerator::getLLVMType(ast::TypePtr type)
         std::string baseName = genericType->name;
         const auto &typeArgs = genericType->typeArguments;
 
+        // Channels are opaque runtime handles.
+        if (baseName == "channel" || baseName == "Channel" || baseName == "chan")
+            return llvm::PointerType::get(context, 0);
+
         if (baseName == "list")
         {
             // list<T> is represented as { int64 length, T* data }
@@ -1041,6 +1045,18 @@ void IRGenerator::visitCallExpr(ast::CallExpr *expr)
             llvm::Value *base = lastValue;
             if (!base) return;
             lastValue = builder.CreateLoad(llvm::Type::getInt64Ty(context), base, "len");
+            return;
+        }
+
+        // channel() creation -> __tocin_chan_new().
+        if (funcName == "__chan_new")
+        {
+            llvm::Type *ptrTy = llvm::PointerType::get(context, 0);
+            llvm::Function *f = module->getFunction("__tocin_chan_new");
+            if (!f)
+                f = llvm::Function::Create(llvm::FunctionType::get(ptrTy, {}, false),
+                                           llvm::Function::ExternalLinkage, "__tocin_chan_new", *module);
+            lastValue = builder.CreateCall(f, {}, "chan");
             return;
         }
 
@@ -3989,170 +4005,121 @@ void IRGenerator::visitAwaitExpr(ast::AwaitExpr *expr)
 }
 
 void codegen::IRGenerator::visitGoStmt(ast::GoStmt* stmt) {
-    // Generate IR for goroutine launch (go statement)
-    
-    // First, generate IR for the expression (function call)
-    stmt->expression->accept(*this);
-    llvm::Value* functionCall = lastValue;
-    
-    if (!functionCall) {
+    // go f(args): run f(args) on a new OS thread. Arguments are packed into a
+    // heap struct; a thunk unpacks them and calls f, then frees the pack.
+    llvm::Type *ptr = llvm::PointerType::get(context, 0);
+    auto call = std::dynamic_pointer_cast<ast::CallExpr>(stmt->expression);
+    if (!call) {
         errorHandler.reportError(error::ErrorCode::C013_INVALID_SPAWN_OPERATION,
-                               "Invalid expression in go statement",
-                               std::string(stmt->token.filename), stmt->token.line, stmt->token.column,
-                               error::ErrorSeverity::ERROR);
+                                 "'go' requires a function call",
+                                 std::string(stmt->token.filename), stmt->token.line,
+                                 stmt->token.column, error::ErrorSeverity::ERROR);
         return;
     }
-    
-    // Get the function type
-    llvm::FunctionType* funcType = nullptr;
-    if (auto callInst = llvm::dyn_cast<llvm::CallInst>(functionCall)) {
-        funcType = callInst->getFunctionType();
-    } else {
+    auto calleeVar = std::dynamic_pointer_cast<ast::VariableExpr>(call->callee);
+    llvm::Function *target = calleeVar ? module->getFunction(calleeVar->name) : nullptr;
+    if (!target) {
         errorHandler.reportError(error::ErrorCode::C013_INVALID_SPAWN_OPERATION,
-                               "Go statement requires a function call",
-                               std::string(stmt->token.filename), stmt->token.line, stmt->token.column,
-                               error::ErrorSeverity::ERROR);
+                                 "'go' target must be a known function",
+                                 std::string(stmt->token.filename), stmt->token.line,
+                                 stmt->token.column, error::ErrorSeverity::ERROR);
         return;
     }
-    
-    // Create a wrapper function that will be executed in a goroutine
-    std::string wrapperName = "goroutine_wrapper_" + std::to_string(getNextId());
-    llvm::Function* wrapperFunc = llvm::Function::Create(
-        llvm::FunctionType::get(llvm::Type::getVoidTy(context), false),
-        llvm::Function::InternalLinkage,
-        wrapperName,
-        module.get()
-    );
-    
-    // Create the wrapper function body
-    llvm::BasicBlock* entryBlock = llvm::BasicBlock::Create(context, "entry", wrapperFunc);
-    builder.SetInsertPoint(entryBlock);
-    
-    // Call the original function
-    builder.CreateCall(funcType, functionCall);
-    
-    // Return void
+
+    // Evaluate arguments in the current function.
+    std::vector<llvm::Value *> args;
+    std::vector<llvm::Type *> argTypes;
+    for (auto &a : call->arguments) {
+        a->accept(*this);
+        if (!lastValue) return;
+        args.push_back(lastValue);
+        argTypes.push_back(lastValue->getType());
+    }
+
+    llvm::Function *mallocF = stdLibFunctions["malloc"];
+    llvm::Function *freeF = stdLibFunctions["free"];
+    llvm::StructType *packTy = llvm::StructType::get(context, argTypes);
+    llvm::Value *pack = llvm::ConstantPointerNull::get(llvm::cast<llvm::PointerType>(ptr));
+    if (!argTypes.empty()) {
+        llvm::Value *sz = llvm::ConstantExpr::getSizeOf(packTy);
+        pack = builder.CreateCall(mallocF->getFunctionType(), mallocF, {sz}, "gopack");
+        for (size_t i = 0; i < args.size(); ++i) {
+            llvm::Value *fp = builder.CreateStructGEP(packTy, pack, (unsigned)i, "go.arg");
+            builder.CreateStore(args[i], fp);
+        }
+    }
+
+    // Build the thunk: void thunk(ptr p) { args = unpack(p); f(args); free(p); }
+    std::string thunkName = "go_thunk_" + std::to_string(getNextId());
+    llvm::Function *thunk = llvm::Function::Create(
+        llvm::FunctionType::get(llvm::Type::getVoidTy(context), {ptr}, false),
+        llvm::Function::InternalLinkage, thunkName, module.get());
+    llvm::BasicBlock *savedBlock = builder.GetInsertBlock();
+    llvm::Function *savedFn = currentFunction;
+    llvm::BasicBlock *entry = llvm::BasicBlock::Create(context, "entry", thunk);
+    builder.SetInsertPoint(entry);
+    currentFunction = thunk;
+    llvm::Value *p = thunk->getArg(0);
+    std::vector<llvm::Value *> callArgs;
+    for (size_t i = 0; i < argTypes.size(); ++i) {
+        llvm::Value *fp = builder.CreateStructGEP(packTy, p, (unsigned)i, "th.arg");
+        callArgs.push_back(builder.CreateLoad(argTypes[i], fp, "th.val"));
+    }
+    builder.CreateCall(target->getFunctionType(), target, callArgs);
+    if (!argTypes.empty() && freeF)
+        builder.CreateCall(freeF->getFunctionType(), freeF, {p});
     builder.CreateRetVoid();
-    
-    // Schedule the wrapper function to run in a goroutine
-    // This would typically call a runtime function to schedule the task
-    std::vector<llvm::Value*> args = {
-        llvm::ConstantExpr::getBitCast(wrapperFunc, llvm::PointerType::get(llvm::Type::getInt8Ty(context), 0))
-    };
-    
-    // Get the runtime scheduler function
-    llvm::Function* schedulerFunc = module->getFunction("runtime_schedule_goroutine");
-    if (!schedulerFunc) {
-        // Create the runtime function declaration if it doesn't exist
-        llvm::FunctionType* schedulerType = llvm::FunctionType::get(
-            llvm::Type::getVoidTy(context),
-            {llvm::PointerType::get(llvm::Type::getInt8Ty(context), 0)},
-            false
-        );
-        schedulerFunc = llvm::Function::Create(
-            schedulerType,
-            llvm::Function::ExternalLinkage,
-            "runtime_schedule_goroutine",
-            module.get()
-        );
-    }
-    
-    // Call the scheduler
-    builder.CreateCall(schedulerFunc, args);
-    
-    // Set the current value to void
-    lastValue = llvm::Constant::getNullValue(llvm::Type::getVoidTy(context));
+    builder.SetInsertPoint(savedBlock);
+    currentFunction = savedFn;
+
+    // __tocin_go(thunk, pack)
+    llvm::Function *goF = module->getFunction("__tocin_go");
+    if (!goF)
+        goF = llvm::Function::Create(
+            llvm::FunctionType::get(llvm::Type::getVoidTy(context), {ptr, ptr}, false),
+            llvm::Function::ExternalLinkage, "__tocin_go", *module);
+    builder.CreateCall(goF, {thunk, pack});
+    lastValue = nullptr;
 }
 
 void codegen::IRGenerator::visitChannelSendExpr(ast::ChannelSendExpr* expr) {
-    // Generate IR for channel send operation (channel <- value)
-    
-    // Generate IR for the channel
+    llvm::Type *ptr = llvm::PointerType::get(context, 0);
+    llvm::Type *i64 = llvm::Type::getInt64Ty(context);
     expr->channel->accept(*this);
-    llvm::Value* channel = lastValue;
-    
-    // Generate IR for the value
+    llvm::Value *ch = lastValue;
     expr->value->accept(*this);
-    llvm::Value* value = lastValue;
-    
-    if (!channel || !value) {
-        errorHandler.reportError(error::ErrorCode::C011_INVALID_CHANNEL_OPERATION,
-                               "Invalid channel or value in send operation",
-                               std::string(expr->token.filename), expr->token.line, expr->token.column,
-                               error::ErrorSeverity::ERROR);
-        return;
-    }
-    
-    // Get the runtime channel send function
-    llvm::Function* sendFunc = module->getFunction("runtime_channel_send");
-    if (!sendFunc) {
-        // Create the runtime function declaration if it doesn't exist
-        llvm::FunctionType* sendType = llvm::FunctionType::get(
-            llvm::Type::getInt1Ty(context), // Returns bool (success/failure)
-            {llvm::PointerType::get(llvm::Type::getInt8Ty(context), 0), llvm::PointerType::get(llvm::Type::getInt8Ty(context), 0)}, // channel, value
-            false
-        );
-        sendFunc = llvm::Function::Create(
-            sendType,
-            llvm::Function::ExternalLinkage,
-            "runtime_channel_send",
-            module.get()
-        );
-    }
-    
-    // Cast channel and value to void pointers for the runtime call
-    llvm::Value* channelPtr = builder.CreateBitCast(channel, llvm::PointerType::get(llvm::Type::getInt8Ty(context), 0));
-    llvm::Value* valuePtr = builder.CreateBitCast(value, llvm::PointerType::get(llvm::Type::getInt8Ty(context), 0));
-    
-    // Call the runtime send function
-    std::vector<llvm::Value*> args = {channelPtr, valuePtr};
-    llvm::Value* result = builder.CreateCall(sendFunc, args);
-    
-    // Set the current value to the result
-    lastValue = result;
+    llvm::Value *v = lastValue;
+    if (!ch || !v) { lastValue = nullptr; return; }
+    // Normalize the value into a 64-bit slot.
+    if (v->getType()->isPointerTy())
+        v = builder.CreatePtrToInt(v, i64, "chv");
+    else if (v->getType()->isDoubleTy())
+        v = builder.CreateBitCast(v, i64, "chv");
+    else if (v->getType()->isFloatTy())
+        v = builder.CreateBitCast(builder.CreateFPExt(v, llvm::Type::getDoubleTy(context)), i64, "chv");
+    else if (v->getType()->isIntegerTy() && !v->getType()->isIntegerTy(64))
+        v = builder.CreateIntCast(v, i64, true, "chv");
+    llvm::Function *sendF = module->getFunction("__tocin_chan_send");
+    if (!sendF)
+        sendF = llvm::Function::Create(
+            llvm::FunctionType::get(llvm::Type::getVoidTy(context), {ptr, i64}, false),
+            llvm::Function::ExternalLinkage, "__tocin_chan_send", *module);
+    builder.CreateCall(sendF, {ch, v});
+    lastValue = nullptr;
 }
 
 void codegen::IRGenerator::visitChannelReceiveExpr(ast::ChannelReceiveExpr* expr) {
-    // Generate IR for channel receive operation (<-channel)
-    
-    // Generate IR for the channel
+    llvm::Type *ptr = llvm::PointerType::get(context, 0);
+    llvm::Type *i64 = llvm::Type::getInt64Ty(context);
     expr->channel->accept(*this);
-    llvm::Value* channel = lastValue;
-    
-    if (!channel) {
-        errorHandler.reportError(error::ErrorCode::C011_INVALID_CHANNEL_OPERATION,
-                               "Invalid channel in receive operation",
-                               std::string(expr->token.filename), expr->token.line, expr->token.column,
-                               error::ErrorSeverity::ERROR);
-        return;
-    }
-    
-    // Get the runtime channel receive function
-    llvm::Function* receiveFunc = module->getFunction("runtime_channel_receive");
-    if (!receiveFunc) {
-        // Create the runtime function declaration if it doesn't exist
-        llvm::FunctionType* receiveType = llvm::FunctionType::get(
-            llvm::PointerType::get(llvm::Type::getInt8Ty(context), 0), // Returns void* (received value)
-            {llvm::PointerType::get(llvm::Type::getInt8Ty(context), 0)}, // channel
-            false
-        );
-        receiveFunc = llvm::Function::Create(
-            receiveType,
-            llvm::Function::ExternalLinkage,
-            "runtime_channel_receive",
-            module.get()
-        );
-    }
-    
-    // Cast channel to void pointer for the runtime call
-    llvm::Value* channelPtr = builder.CreateBitCast(channel, llvm::PointerType::get(llvm::Type::getInt8Ty(context), 0));
-    
-    // Call the runtime receive function
-    std::vector<llvm::Value*> args = {channelPtr};
-    llvm::Value* result = builder.CreateCall(receiveFunc, args);
-    
-    // Set the current value to the received value
-    lastValue = result;
+    llvm::Value *ch = lastValue;
+    if (!ch) { lastValue = nullptr; return; }
+    llvm::Function *recvF = module->getFunction("__tocin_chan_recv");
+    if (!recvF)
+        recvF = llvm::Function::Create(
+            llvm::FunctionType::get(i64, {ptr}, false),
+            llvm::Function::ExternalLinkage, "__tocin_chan_recv", *module);
+    lastValue = builder.CreateCall(recvF, {ch}, "recv");
 }
 
 void codegen::IRGenerator::visitSelectStmt(ast::SelectStmt* stmt) {

--- a/src/codegen/ir_generator.cpp
+++ b/src/codegen/ir_generator.cpp
@@ -222,6 +222,11 @@ llvm::Type *IRGenerator::getLLVMType(ast::TypePtr type)
     {
         std::string typeName = simpleType->toString();
 
+        // Resolve active generic type-parameter bindings first (e.g. T -> i64).
+        auto bound = typeBindings.find(typeName);
+        if (bound != typeBindings.end())
+            return bound->second;
+
         // Check for basic type names
         if (typeName == "int" || typeName == "i64")
         {
@@ -751,10 +756,11 @@ void IRGenerator::visitFunctionStmt(ast::FunctionStmt *stmt)
         return;
     }
 
-    // Handle generic functions
+    // Generic functions are templates: record them and instantiate lazily
+    // (monomorphize) when called with concrete argument types.
     if (stmt->isGeneric())
     {
-        // ... existing generic function implementation ...
+        genericFunctions[stmt->name] = stmt;
         return;
     }
 
@@ -1127,6 +1133,53 @@ void IRGenerator::visitCallExpr(ast::CallExpr *expr)
                 format += "\n";
             printfArgs[0] = builder.CreateGlobalString(format, "fmt");
             lastValue = builder.CreateCall(printfFunc->getFunctionType(), printfFunc, printfArgs);
+            return;
+        }
+
+        // Generic function call: monomorphize for the concrete argument types.
+        auto git = genericFunctions.find(funcName);
+        if (git != genericFunctions.end())
+        {
+            ast::FunctionStmt *tmpl = git->second;
+            std::vector<llvm::Value *> argVals;
+            for (const auto &a : expr->arguments)
+            {
+                a->accept(*this);
+                if (!lastValue) return;
+                argVals.push_back(lastValue);
+            }
+            // Infer type-parameter bindings from argument types.
+            std::map<std::string, llvm::Type *> bindings;
+            std::set<std::string> tparams;
+            for (const auto &tp : tmpl->typeParameters)
+                tparams.insert(tp.getName());
+            for (size_t i = 0; i < tmpl->parameters.size() && i < argVals.size(); ++i)
+            {
+                std::string pt = tmpl->parameters[i].type ? tmpl->parameters[i].type->toString() : "";
+                if (tparams.count(pt) && !bindings.count(pt))
+                    bindings[pt] = argVals[i]->getType();
+            }
+            for (const auto &tp : tmpl->typeParameters)
+                if (!bindings.count(tp.getName()))
+                    bindings[tp.getName()] = llvm::Type::getInt64Ty(context);
+
+            llvm::Function *inst = emitGenericInstance(tmpl, bindings);
+            llvm::FunctionType *ift = inst->getFunctionType();
+            std::vector<llvm::Value *> callArgs;
+            for (size_t i = 0; i < argVals.size(); ++i)
+            {
+                llvm::Value *v = argVals[i];
+                if (i < ift->getNumParams() && v->getType() != ift->getParamType(i))
+                {
+                    llvm::Type *pt = ift->getParamType(i);
+                    if (v->getType()->isIntegerTy() && pt->isIntegerTy())
+                        v = builder.CreateIntCast(v, pt, true, "argcast");
+                    else if (v->getType()->isFloatingPointTy() && pt->isFloatingPointTy())
+                        v = builder.CreateFPCast(v, pt, "argcast");
+                }
+                callArgs.push_back(v);
+            }
+            lastValue = builder.CreateCall(ift, inst, callArgs);
             return;
         }
 
@@ -2167,6 +2220,98 @@ void IRGenerator::visitIndexExpr(ast::IndexExpr *expr)
     lastValue = builder.CreateLoad(elemTy, slot, "idx.val");
 }
 
+std::string IRGenerator::llvmTypeName(llvm::Type *t)
+{
+    if (t->isIntegerTy(1)) return "i1";
+    if (t->isIntegerTy(64)) return "i64";
+    if (t->isIntegerTy()) return "i" + std::to_string(t->getIntegerBitWidth());
+    if (t->isDoubleTy()) return "f64";
+    if (t->isFloatTy()) return "f32";
+    if (t->isPointerTy()) return "ptr";
+    return "t";
+}
+
+llvm::Function *IRGenerator::emitGenericInstance(ast::FunctionStmt *stmt,
+                                                const std::map<std::string, llvm::Type *> &bindings)
+{
+    // Mangle the instance name from the concrete type arguments.
+    std::string mangled = stmt->name;
+    for (const auto &tp : stmt->typeParameters)
+    {
+        auto it = bindings.find(tp.getName());
+        mangled += "$" + (it != bindings.end() ? llvmTypeName(it->second) : "t");
+    }
+    if (llvm::Function *existing = module->getFunction(mangled))
+        return existing;
+
+    // Save codegen state.
+    auto savedBindings = typeBindings;
+    auto savedNamed = namedValues;
+    auto savedVarClasses = varClasses;
+    auto savedArrayElem = varArrayElem;
+    llvm::Function *savedFunction = currentFunction;
+    llvm::BasicBlock *savedBlock = builder.GetInsertBlock();
+    typeBindings = bindings;
+
+    // Build the concrete signature (getLLVMType resolves type params).
+    std::vector<llvm::Type *> paramTypes;
+    for (const auto &p : stmt->parameters)
+    {
+        llvm::Type *t = getLLVMType(p.type);
+        paramTypes.push_back(t ? t : llvm::Type::getInt64Ty(context));
+    }
+    llvm::Type *retType = stmt->returnType ? getLLVMType(stmt->returnType)
+                                           : inferFunctionReturnType(stmt);
+    if (!retType)
+        retType = llvm::Type::getVoidTy(context);
+    auto *ft = llvm::FunctionType::get(retType, paramTypes, false);
+    auto *function = llvm::Function::Create(ft, llvm::Function::ExternalLinkage, mangled, module.get());
+
+    // Generate the body.
+    auto *entry = llvm::BasicBlock::Create(context, "entry", function);
+    builder.SetInsertPoint(entry);
+    currentFunction = function;
+    namedValues.clear();
+    varClasses.clear();
+    varArrayElem.clear();
+    unsigned i = 0;
+    for (auto &arg : function->args())
+    {
+        const std::string &pname = stmt->parameters[i].name;
+        arg.setName(pname);
+        llvm::AllocaInst *alloca = createEntryBlockAlloca(function, pname, arg.getType());
+        builder.CreateStore(&arg, alloca);
+        namedValues[pname] = alloca;
+        ++i;
+    }
+    if (stmt->body)
+        stmt->body->accept(*this);
+    if (!builder.GetInsertBlock()->getTerminator())
+    {
+        if (retType->isVoidTy())
+            builder.CreateRetVoid();
+        else if (retType->isIntegerTy())
+            builder.CreateRet(llvm::ConstantInt::get(retType, 0));
+        else if (retType->isFloatingPointTy())
+            builder.CreateRet(llvm::ConstantFP::get(retType, 0.0));
+        else if (retType->isPointerTy())
+            builder.CreateRet(llvm::ConstantPointerNull::get(llvm::cast<llvm::PointerType>(retType)));
+        else
+            builder.CreateRet(llvm::UndefValue::get(retType));
+    }
+    llvm::verifyFunction(*function);
+
+    // Restore state.
+    typeBindings = savedBindings;
+    namedValues = savedNamed;
+    varClasses = savedVarClasses;
+    varArrayElem = savedArrayElem;
+    currentFunction = savedFunction;
+    if (savedBlock)
+        builder.SetInsertPoint(savedBlock);
+    return function;
+}
+
 void IRGenerator::generateMethod(const std::string &className, llvm::StructType *classType, ast::FunctionStmt *method)
 {
     llvm::Type *opaquePtr = llvm::PointerType::get(context, 0);
@@ -2892,7 +3037,12 @@ void IRGenerator::predeclareTopLevel(ast::StmtPtr ast)
     for (auto &s : stmts)
     {
         if (auto fn = std::dynamic_pointer_cast<ast::FunctionStmt>(s))
-            declareFunctionProto(fn.get());
+        {
+            if (fn->isGeneric())
+                genericFunctions[fn->name] = fn.get();  // record template for lazy instantiation
+            else
+                declareFunctionProto(fn.get());
+        }
         else if (auto cls = std::dynamic_pointer_cast<ast::ClassStmt>(s))
         {
             auto cit = classTypes.find(cls->name);

--- a/src/codegen/ir_generator.cpp
+++ b/src/codegen/ir_generator.cpp
@@ -3052,6 +3052,16 @@ void IRGenerator::predeclareTopLevel(ast::StmtPtr ast)
                 if (auto method = std::dynamic_pointer_cast<ast::FunctionStmt>(m))
                     declareMethodProto(cls->name, cit->second.classType, method.get());
         }
+        else if (auto impl = std::dynamic_pointer_cast<ast::ImplStmt>(s))
+        {
+            std::string typeName = impl->type ? impl->type->toString() : "";
+            auto cit = classTypes.find(typeName);
+            if (cit == classTypes.end())
+                continue;
+            for (auto &m : impl->methods)
+                if (m && m->body)
+                    declareMethodProto(typeName, cit->second.classType, m.get());
+        }
     }
 }
 
@@ -4168,36 +4178,31 @@ int IRGenerator::getNextId() {
 }
 
 void codegen::IRGenerator::visitTraitStmt(ast::TraitStmt* stmt) {
-    // Generate IR for trait statement
-    // Traits are compile-time constructs, so we mainly need to register them
-    
-    // For now, just visit all method signatures to ensure they're valid
-    for (const auto& method : stmt->methods) {
-        if (method) {
-            // Visit the method to ensure it's syntactically valid
-            // In practice, we would register the trait interface
-            method->accept(*this);
-        }
-    }
-    
-    // Trait statements don't generate runtime code
-    lastValue = llvm::Constant::getNullValue(llvm::Type::getVoidTy(context));
+    // Traits are interfaces: signature-only methods generate no code. Default
+    // methods (with bodies) are materialized per implementing type at the impl
+    // site, so nothing is emitted here.
+    (void)stmt;
+    lastValue = nullptr;
 }
 
 void codegen::IRGenerator::visitImplStmt(ast::ImplStmt* stmt) {
-    // Generate IR for implementation statement
-    // This generates the actual method implementations for the trait
-    
-    // Visit all method implementations
-    for (const auto& method : stmt->methods) {
-        if (method) {
-            // Generate IR for each method implementation
-            method->accept(*this);
-        }
+    // An impl block adds methods to a concrete type. Generate each method as a
+    // method of that type (TypeName_methodName) so receiver.method(...) resolves.
+    std::string typeName = stmt->type ? stmt->type->toString() : "";
+    auto it = classTypes.find(typeName);
+    if (it == classTypes.end()) {
+        errorHandler.reportError(error::ErrorCode::T031_UNDEFINED_TYPE,
+                                 "impl target '" + typeName + "' is not a known type",
+                                 "", 0, 0, error::ErrorSeverity::ERROR);
+        lastValue = nullptr;
+        return;
     }
-    
-    // Implementation statements don't have a return value
-    lastValue = llvm::Constant::getNullValue(llvm::Type::getVoidTy(context));
+    llvm::StructType* st = it->second.classType;
+    for (const auto& method : stmt->methods) {
+        if (method && method->body)
+            generateMethod(typeName, st, method.get());
+    }
+    lastValue = nullptr;
 }
 
 llvm::Value *IRGenerator::getVariable(const std::string &name) {

--- a/src/codegen/ir_generator.cpp
+++ b/src/codegen/ir_generator.cpp
@@ -285,31 +285,16 @@ llvm::Type *IRGenerator::getLLVMType(ast::TypePtr type)
         std::string baseName = genericType->name;
         const auto &typeArgs = genericType->typeArguments;
 
-        // Channels are opaque runtime handles.
-        if (baseName == "channel" || baseName == "Channel" || baseName == "chan")
+        // Channels, lists and arrays are opaque heap handles (pointers).
+        // Arrays use the flat [i64 length][elems...] layout produced by
+        // visitListExpr, so a list/array value is just a pointer.
+        if (baseName == "channel" || baseName == "Channel" || baseName == "chan" ||
+            baseName == "list" || baseName == "array" || baseName == "List" ||
+            baseName == "Array")
             return llvm::PointerType::get(context, 0);
 
-        if (baseName == "list")
+        if (false)
         {
-            // list<T> is represented as { int64 length, T* data }
-            if (!typeArgs.empty())
-            {
-                llvm::Type *elementType = getLLVMType(typeArgs[0]);
-                std::vector<llvm::Type *> fields = {
-                    llvm::Type::getInt64Ty(context),
-                    llvm::PointerType::get(context, 0) // opaque pointer for data array
-                };
-
-                // Create or get a struct type for this list
-                std::string mangledName = mangleGenericName("list", typeArgs);
-                llvm::StructType *listType = llvm::StructType::getTypeByName(context, mangledName);
-                if (!listType)
-                {
-                    listType = llvm::StructType::create(context, fields, mangledName);
-                }
-
-                return listType;
-            }
         }
         else if (baseName == "dict")
         {
@@ -837,6 +822,7 @@ void IRGenerator::visitFunctionStmt(ast::FunctionStmt *stmt)
                 arg.getType(), nullptr, stmt->parameters[idx].name);
             builder.CreateStore(&arg, alloca);
             namedValues[stmt->parameters[idx].name] = alloca;
+            recordArrayParam(stmt->parameters[idx].name, stmt->parameters[idx].type);
         }
         idx++;
     }
@@ -2255,6 +2241,16 @@ std::string IRGenerator::getExprClassName(const ast::ExprPtr &expr)
     return "";
 }
 
+void IRGenerator::recordArrayParam(const std::string &name, const ast::TypePtr &type)
+{
+    if (auto g = std::dynamic_pointer_cast<ast::GenericType>(type))
+    {
+        if ((g->name == "list" || g->name == "array" || g->name == "List" || g->name == "Array") &&
+            !g->typeArguments.empty())
+            varArrayElem[name] = getLLVMType(g->typeArguments[0]);
+    }
+}
+
 llvm::Type *IRGenerator::getArrayElemType(const ast::ExprPtr &expr)
 {
     if (!expr)
@@ -2365,6 +2361,7 @@ llvm::Function *IRGenerator::emitGenericInstance(ast::FunctionStmt *stmt,
         llvm::AllocaInst *alloca = createEntryBlockAlloca(function, pname, arg.getType());
         builder.CreateStore(&arg, alloca);
         namedValues[pname] = alloca;
+        recordArrayParam(pname, stmt->parameters[i].type);
         ++i;
     }
     if (stmt->body)
@@ -2451,6 +2448,7 @@ void IRGenerator::generateMethod(const std::string &className, llvm::StructType 
         llvm::AllocaInst *alloca = createEntryBlockAlloca(function, pname, arg.getType());
         builder.CreateStore(&arg, alloca);
         namedValues[pname] = alloca;
+        recordArrayParam(pname, method->parameters[ai].type);
         if (pname == "self")
             varClasses["self"] = className;
         ++ai;

--- a/src/codegen/ir_generator.h
+++ b/src/codegen/ir_generator.h
@@ -256,6 +256,10 @@ namespace codegen
         // Determine the element LLVM type of an array-valued expression.
         llvm::Type *getArrayElemType(const ast::ExprPtr &expr);
 
+        // If a parameter is typed list<T>/array<T>, remember its element type
+        // so indexing the parameter inside the function uses the right type.
+        void recordArrayParam(const std::string &name, const ast::TypePtr &type);
+
         // Monomorphize a generic function for a concrete set of type bindings.
         llvm::Function *emitGenericInstance(ast::FunctionStmt *stmt,
                                             const std::map<std::string, llvm::Type *> &bindings);

--- a/src/codegen/ir_generator.h
+++ b/src/codegen/ir_generator.h
@@ -119,6 +119,7 @@ namespace codegen
         void visitDeleteExpr(ast::DeleteExpr *expr) override;
         void visitStringInterpolationExpr(ast::StringInterpolationExpr *expr) override;
         void visitArrayLiteralExpr(ast::ArrayLiteralExpr *expr) override;
+        void visitIndexExpr(ast::IndexExpr *expr) override;
         void visitMoveExpr(void *expr) override;
         void visitGoExpr(void *expr) override;
         void visitRuntimeChannelSendExpr(void *expr) override;
@@ -158,8 +159,10 @@ namespace codegen
         // Symbol tables
         std::map<std::string, llvm::AllocaInst *> namedValues;                     // Variable symbol table
         std::map<std::string, std::string> varClasses;                            // Variable name -> class name
+        std::map<std::string, llvm::Type *> varArrayElem;                         // Variable name -> array element LLVM type
         std::string currentClassName;                                              // Enclosing class while generating a method
         std::string lastExprClassName;                                             // Class name of the most recent expression value
+        llvm::Type *lastExprArrayElem = nullptr;                                  // Element type of the most recent array expression
         std::map<std::string, llvm::Function *> stdLibFunctions;                   // Standard library functions
         std::map<std::string, ClassInfo> classTypes;                               // Class type information
         std::map<std::string, llvm::Function *> classMethods;                      // Class method table
@@ -247,6 +250,9 @@ namespace codegen
         // Determine the class name of an expression (self, local variables of
         // class type, and constructor calls), used for field/method resolution.
         std::string getExprClassName(const ast::ExprPtr &expr);
+
+        // Determine the element LLVM type of an array-valued expression.
+        llvm::Type *getArrayElemType(const ast::ExprPtr &expr);
     };
 
     // Pattern visitor for match statements

--- a/src/codegen/ir_generator.h
+++ b/src/codegen/ir_generator.h
@@ -163,6 +163,8 @@ namespace codegen
         std::string currentClassName;                                              // Enclosing class while generating a method
         std::string lastExprClassName;                                             // Class name of the most recent expression value
         llvm::Type *lastExprArrayElem = nullptr;                                  // Element type of the most recent array expression
+        std::map<std::string, ast::FunctionStmt *> genericFunctions;             // name -> generic function template
+        std::map<std::string, llvm::Type *> typeBindings;                        // active type-parameter bindings during instantiation
         std::map<std::string, llvm::Function *> stdLibFunctions;                   // Standard library functions
         std::map<std::string, ClassInfo> classTypes;                               // Class type information
         std::map<std::string, llvm::Function *> classMethods;                      // Class method table
@@ -253,6 +255,11 @@ namespace codegen
 
         // Determine the element LLVM type of an array-valued expression.
         llvm::Type *getArrayElemType(const ast::ExprPtr &expr);
+
+        // Monomorphize a generic function for a concrete set of type bindings.
+        llvm::Function *emitGenericInstance(ast::FunctionStmt *stmt,
+                                            const std::map<std::string, llvm::Type *> &bindings);
+        std::string llvmTypeName(llvm::Type *t);
     };
 
     // Pattern visitor for match statements

--- a/src/compiler/macro_system.cpp
+++ b/src/compiler/macro_system.cpp
@@ -89,6 +89,7 @@ ast::StmtPtr FunctionMacro::expand(const MacroContext& context, error::ErrorHand
         void visitDeleteExpr(ast::DeleteExpr* expr) override {}
         void visitStringInterpolationExpr(ast::StringInterpolationExpr* expr) override {}
         void visitArrayLiteralExpr(ast::ArrayLiteralExpr* expr) override {}
+        void visitIndexExpr(ast::IndexExpr* expr) override {}
         void visitMoveExpr(void* expr) override {}
         void visitGoExpr(void* expr) override {}
         void visitRuntimeChannelSendExpr(void* expr) override {}
@@ -243,6 +244,7 @@ ast::StmtPtr MacroSystem::processMacros(ast::StmtPtr stmt, error::ErrorHandler& 
         void visitDeleteExpr(ast::DeleteExpr* expr) override {}
         void visitStringInterpolationExpr(ast::StringInterpolationExpr* expr) override {}
         void visitArrayLiteralExpr(ast::ArrayLiteralExpr* expr) override {}
+        void visitIndexExpr(ast::IndexExpr* expr) override {}
         void visitMoveExpr(void* expr) override {}
         void visitGoExpr(void* expr) override {}
         void visitRuntimeChannelSendExpr(void* expr) override {}

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -31,6 +31,18 @@
 #include <llvm/IR/LegacyPassManager.h>
 #include <llvm/Support/CodeGen.h>
 #include <cstdlib>
+#include <cstdint>
+
+// The Tocin runtime (channels/goroutines) lives in the static core library.
+// Declared here so the JIT can register their addresses; referencing them in
+// runJIT also forces the runtime objects to be linked into the compiler.
+extern "C" {
+    void *__tocin_chan_new();
+    void __tocin_chan_send(void *, int64_t);
+    int64_t __tocin_chan_recv(void *);
+    void __tocin_go(void (*)(void *), void *);
+    void __tocin_join_all();
+}
 
 // Conditionally include Python
 #ifdef WITH_PYTHON
@@ -313,6 +325,22 @@ public:
             jit->getMainJITDylib().addGenerator(std::move(*gen));
         }
 
+        // Register the Tocin runtime (channels/goroutines) so JIT'd code can
+        // call it. Taking the addresses also forces these symbols to be linked.
+        {
+            llvm::orc::SymbolMap rt;
+            auto def = [&](const char *name, void *addr) {
+                rt[jit->mangleAndIntern(name)] = llvm::orc::ExecutorSymbolDef(
+                    llvm::orc::ExecutorAddr::fromPtr(addr), llvm::JITSymbolFlags::Exported);
+            };
+            def("__tocin_chan_new", reinterpret_cast<void *>(&__tocin_chan_new));
+            def("__tocin_chan_send", reinterpret_cast<void *>(&__tocin_chan_send));
+            def("__tocin_chan_recv", reinterpret_cast<void *>(&__tocin_chan_recv));
+            def("__tocin_go", reinterpret_cast<void *>(&__tocin_go));
+            def("__tocin_join_all", reinterpret_cast<void *>(&__tocin_join_all));
+            llvm::cantFail(jit->getMainJITDylib().define(llvm::orc::absoluteSymbols(std::move(rt))));
+        }
+
         if (auto err = jit->addIRModule(
                 llvm::orc::ThreadSafeModule(std::move(module), std::move(context))))
         {
@@ -389,7 +417,13 @@ public:
     bool linkExecutable(const std::string& objPath, const std::string& exePath)
     {
         std::string cc = std::getenv("CC") ? std::getenv("CC") : "cc";
-        std::string cmd = cc + " \"" + objPath + "\" -o \"" + exePath + "\" -lm -lpthread";
+        std::string cmd = cc + " \"" + objPath + "\" -o \"" + exePath + "\"";
+        // Link the Tocin runtime (channels/goroutines) so programs that use
+        // concurrency resolve their __tocin_* calls.
+#ifdef TOCIN_RUNTIME_LIB
+        cmd += std::string(" \"") + TOCIN_RUNTIME_LIB + "\"";
+#endif
+        cmd += " -lm -lpthread -lstdc++";
         int rc = std::system(cmd.c_str());
         if (rc != 0)
         {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -4,6 +4,10 @@
 #include <string>
 #include <memory>
 #include <vector>
+#include <set>
+#include <functional>
+#include <filesystem>
+#include <iterator>
 
 // Core LLVM headers
 #include <llvm/IR/LLVMContext.h>
@@ -183,6 +187,13 @@ public:
             return false;
         }
 
+        // Resolve `import` statements by loading and merging other modules.
+        program = resolveImports(program, filename);
+        if (errorHandler.hasFatalErrors() || !program)
+        {
+            return false;
+        }
+
         // Create compilation context with advanced features
         tocin::compiler::CompilationContext compilationContext(filename);
 
@@ -201,6 +212,79 @@ public:
         } else {
             return compileToNative(program, filename, options);
         }
+    }
+
+    /**
+     * @brief Resolve `import` statements by loading, parsing and merging the
+     *        imported modules' declarations into a single program.
+     */
+    ast::StmtPtr resolveImports(ast::StmtPtr program, const std::string& mainFile)
+    {
+        namespace fs = std::filesystem;
+        std::set<std::string> loaded;
+        std::vector<ast::StmtPtr> merged;
+
+        auto flatten = [](ast::StmtPtr p) {
+            std::vector<ast::StmtPtr> v;
+            if (auto blk = std::dynamic_pointer_cast<ast::BlockStmt>(p)) v = blk->statements;
+            else if (auto mod = std::dynamic_pointer_cast<ast::ModuleStmt>(p)) v = mod->body;
+            else if (p) v.push_back(p);
+            return v;
+        };
+
+        auto resolvePath = [&](const std::string& name, const std::string& fromDir) -> std::string {
+            std::string rel = name;
+            if (rel.size() < 3 || rel.substr(rel.size() - 3) != ".to") rel += ".to";
+            std::vector<std::string> candidates;
+            if (!fromDir.empty()) candidates.push_back((fs::path(fromDir) / rel).string());
+            if (const char* envp = std::getenv("TOCIN_PATH"))
+                candidates.push_back((fs::path(envp) / rel).string());
+#ifdef TOCIN_STDLIB_PATH
+            candidates.push_back((fs::path(TOCIN_STDLIB_PATH) / rel).string());
+#endif
+            for (auto& c : candidates)
+            {
+                std::error_code ec;
+                if (fs::exists(c, ec)) return fs::absolute(c, ec).string();
+            }
+            return "";
+        };
+
+        std::function<void(ast::StmtPtr, const std::string&)> process =
+            [&](ast::StmtPtr prog, const std::string& fromDir) {
+            for (auto& s : flatten(prog))
+            {
+                if (auto imp = std::dynamic_pointer_cast<ast::ImportStmt>(s))
+                {
+                    std::string file = resolvePath(imp->moduleName, fromDir);
+                    if (file.empty())
+                    {
+                        errorHandler.reportError(error::ErrorCode::I001_FILE_NOT_FOUND,
+                                                 "Cannot resolve import '" + imp->moduleName + "'",
+                                                 mainFile, 0, 0);
+                        continue;
+                    }
+                    if (loaded.count(file)) continue;
+                    loaded.insert(file);
+                    std::ifstream f(file);
+                    std::string src((std::istreambuf_iterator<char>(f)),
+                                    std::istreambuf_iterator<char>());
+                    lexer::Lexer lx(src, file, 4);
+                    auto toks = lx.tokenize();
+                    parser::Parser ps(toks);
+                    auto sub = ps.parse();
+                    process(sub, fs::path(file).parent_path().string()); // imported module's imports first
+                }
+                else if (s)
+                {
+                    merged.push_back(s);
+                }
+            }
+        };
+
+        process(program, fs::path(mainFile).parent_path().string());
+        return std::make_shared<ast::BlockStmt>(
+            lexer::Token(lexer::TokenType::IDENTIFIER, "", mainFile, 0, 0), merged);
     }
 
     bool compileToNative(ast::StmtPtr program, const std::string& filename,

--- a/src/parser/parser.cpp
+++ b/src/parser/parser.cpp
@@ -57,9 +57,17 @@ namespace parser
             {
                 return functionDeclaration();
             }
-            if (match(lexer::TokenType::CLASS))
+            if (match(lexer::TokenType::CLASS) || match(lexer::TokenType::STRUCT))
             {
                 return classDeclaration();
+            }
+            if (match(lexer::TokenType::TRAIT))
+            {
+                return traitDeclaration();
+            }
+            if (match(lexer::TokenType::IMPL))
+            {
+                return implDeclaration();
             }
             if (match(lexer::TokenType::IMPORT))
             {
@@ -185,6 +193,82 @@ namespace parser
                                                     nullptr, std::vector<ast::TypePtr>{},
                                                     fields, methods);
         return std::make_shared<ast::ClassStmt>(name, name.value, fields, methods);
+    }
+
+    std::shared_ptr<ast::FunctionStmt> Parser::methodDeclaration(bool allowNoBody)
+    {
+        bool isAsync = previous().type == lexer::TokenType::ASYNC;
+        auto name = consume(lexer::TokenType::IDENTIFIER, "Expected method name");
+        std::vector<ast::TypeParameter> typeParams = parseTypeParameters();
+        consume(lexer::TokenType::LEFT_PAREN, "Expected '(' after method name");
+        auto parameters = parseParameters();
+        consume(lexer::TokenType::RIGHT_PAREN, "Expected ')' after parameters");
+        ast::TypePtr returnType = nullptr;
+        if (match(lexer::TokenType::ARROW) || match(lexer::TokenType::COLON))
+            returnType = parseType();
+        ast::StmtPtr body = nullptr;
+        if (match(lexer::TokenType::LEFT_BRACE))
+            body = blockStmt();
+        else if (allowNoBody)
+            match(lexer::TokenType::SEMI_COLON); // signature only
+        else
+        {
+            consume(lexer::TokenType::LEFT_BRACE, "Expected '{' before method body");
+            body = blockStmt();
+        }
+        if (!typeParams.empty())
+            return std::make_shared<ast::FunctionStmt>(name, name.value, typeParams,
+                                                       parameters, returnType, body, isAsync);
+        return std::make_shared<ast::FunctionStmt>(name, name.value, parameters, returnType, body, isAsync);
+    }
+
+    ast::StmtPtr Parser::traitDeclaration()
+    {
+        auto name = consume(lexer::TokenType::IDENTIFIER, "Expected trait name");
+        parseTypeParameters(); // optional generic params (ignored for now)
+        consume(lexer::TokenType::LEFT_BRACE, "Expected '{' before trait body");
+        auto trait = std::make_shared<ast::TraitStmt>(name, name.value);
+        while (!check(lexer::TokenType::RIGHT_BRACE) && !isAtEnd())
+        {
+            if (match(lexer::TokenType::DEF) || match(lexer::TokenType::ASYNC))
+                trait->methods.push_back(methodDeclaration(/*allowNoBody=*/true));
+            else
+            {
+                error(peek(), "Expected method declaration in trait");
+                advance();
+            }
+        }
+        consume(lexer::TokenType::RIGHT_BRACE, "Expected '}' after trait body");
+        return trait;
+    }
+
+    ast::StmtPtr Parser::implDeclaration()
+    {
+        auto first = consume(lexer::TokenType::IDENTIFIER, "Expected type or trait name after 'impl'");
+        std::string traitName;
+        lexer::Token typeTok = first;
+        if (match(lexer::TokenType::FOR))
+        {
+            traitName = first.value;
+            typeTok = consume(lexer::TokenType::IDENTIFIER, "Expected type name after 'for'");
+        }
+        parseTypeParameters(); // optional generic params (ignored for now)
+        ast::TypePtr typePtr = std::make_shared<ast::SimpleType>(
+            lexer::Token(lexer::TokenType::IDENTIFIER, typeTok.value, "", typeTok.line, typeTok.column));
+        consume(lexer::TokenType::LEFT_BRACE, "Expected '{' before impl body");
+        auto impl = std::make_shared<ast::ImplStmt>(first, traitName, typePtr);
+        while (!check(lexer::TokenType::RIGHT_BRACE) && !isAtEnd())
+        {
+            if (match(lexer::TokenType::DEF) || match(lexer::TokenType::ASYNC))
+                impl->methods.push_back(methodDeclaration(/*allowNoBody=*/false));
+            else
+            {
+                error(peek(), "Expected method declaration in impl");
+                advance();
+            }
+        }
+        consume(lexer::TokenType::RIGHT_BRACE, "Expected '}' after impl body");
+        return impl;
     }
 
     ast::StmtPtr Parser::statement()

--- a/src/parser/parser.cpp
+++ b/src/parser/parser.cpp
@@ -325,6 +325,11 @@ namespace parser
                 return std::make_shared<ast::SetExpr>(
                     equals, get->object, get->name, value);
             }
+            else if (std::dynamic_pointer_cast<ast::IndexExpr>(expr))
+            {
+                // arr[i] = value -> AssignExpr with the IndexExpr as target.
+                return std::make_shared<ast::AssignExpr>(equals, expr, value);
+            }
 
             errorHandler.reportError(error::ErrorCode::S005_INVALID_ASSIGNMENT_TARGET,
                                      "Invalid assignment target", equals,
@@ -458,6 +463,12 @@ namespace parser
             {
                 auto name = consume(lexer::TokenType::IDENTIFIER, "Expected property name after '.'");
                 expr = std::make_shared<ast::GetExpr>(name, expr, name.value);
+            }
+            else if (match(lexer::TokenType::LEFT_BRACKET))
+            {
+                auto index = expression();
+                auto bracket = consume(lexer::TokenType::RIGHT_BRACKET, "Expected ']' after index");
+                expr = std::make_shared<ast::IndexExpr>(bracket, expr, index);
             }
             else if (match(lexer::TokenType::CHANNEL_SEND))
             {

--- a/src/parser/parser.cpp
+++ b/src/parser/parser.cpp
@@ -546,9 +546,12 @@ namespace parser
         {
             return deleteExpr();
         }
-        if (match(lexer::TokenType::CHANNEL_RECEIVE))
+        // A `<-` (or `-<`) in prefix position is a channel receive: `<-ch`.
+        if (match(lexer::TokenType::CHANNEL_RECEIVE) || match(lexer::TokenType::CHANNEL_SEND))
         {
-            return channelReceiveExpr();
+            lexer::Token op = previous();
+            auto ch = unary();
+            return std::make_shared<ast::ChannelReceiveExpr>(op, ch);
         }
         return call();
     }
@@ -627,6 +630,21 @@ namespace parser
         {
             return std::make_shared<ast::VariableExpr>(previous(), previous().value);
         }
+        if (match(lexer::TokenType::CHANNEL))
+        {
+            // channel<T>() or channel() -> a new channel handle.
+            lexer::Token tok = previous();
+            if (match(lexer::TokenType::LESS))
+            {
+                parseType();
+                consume(lexer::TokenType::GREATER, "Expected '>' after channel element type");
+            }
+            consume(lexer::TokenType::LEFT_PAREN, "Expected '(' after channel");
+            consume(lexer::TokenType::RIGHT_PAREN, "Expected ')' after channel(");
+            return std::make_shared<ast::CallExpr>(
+                tok, std::make_shared<ast::VariableExpr>(tok, "__chan_new"),
+                std::vector<ast::ExprPtr>{});
+        }
         if (match(lexer::TokenType::LEFT_PAREN))
         {
             auto expr = expression();
@@ -686,7 +704,10 @@ namespace parser
 
     ast::TypePtr Parser::parseType()
     {
-        auto token = consume(lexer::TokenType::IDENTIFIER, "Expected type name");
+        // Accept the `channel` keyword as a type name (channel<T>).
+        lexer::Token token = (check(lexer::TokenType::CHANNEL))
+                                 ? advance()
+                                 : consume(lexer::TokenType::IDENTIFIER, "Expected type name");
         if (match(lexer::TokenType::LESS))
         {
             std::vector<ast::TypePtr> typeArgs;
@@ -1043,14 +1064,9 @@ namespace parser
     ast::StmtPtr Parser::goStmt()
     {
         auto keyword = previous();
-        consume(lexer::TokenType::LEFT_PAREN, "Expected '(' after 'go'");
-        
-        // Parse the function call or expression to be executed in goroutine
+        // Accept both `go f(args);` and `go (f(args));`.
         auto expr = expression();
-        
-        consume(lexer::TokenType::RIGHT_PAREN, "Expected ')' after goroutine expression");
         consume(lexer::TokenType::SEMI_COLON, "Expected ';' after goroutine statement");
-        
         return std::make_shared<ast::GoStmt>(keyword, expr);
     }
 

--- a/src/parser/parser.cpp
+++ b/src/parser/parser.cpp
@@ -377,9 +377,28 @@ namespace parser
 
     ast::StmtPtr Parser::importStmt()
     {
-        auto module = consume(lexer::TokenType::IDENTIFIER, "Expected module name");
-        consume(lexer::TokenType::SEMI_COLON, "Expected ';' after import");
-        return std::make_shared<ast::ImportStmt>(module, module.value);
+        lexer::Token tok = peek();
+        std::string path;
+        if (match(lexer::TokenType::STRING))
+        {
+            // import "relative/or/std/path"
+            path = previous().value;
+            if (path.size() >= 2 && (path.front() == '"' || path.front() == '\''))
+                path = path.substr(1, path.size() - 2);
+        }
+        else
+        {
+            // import a.b.c  ->  a/b/c
+            auto first = consume(lexer::TokenType::IDENTIFIER, "Expected module name");
+            path = first.value;
+            while (match(lexer::TokenType::DOT))
+            {
+                auto part = consume(lexer::TokenType::IDENTIFIER, "Expected name after '.'");
+                path += "/" + part.value;
+            }
+        }
+        match(lexer::TokenType::SEMI_COLON); // optional ';'
+        return std::make_shared<ast::ImportStmt>(tok, path);
     }
 
     ast::StmtPtr Parser::matchStmt()

--- a/src/parser/parser.cpp
+++ b/src/parser/parser.cpp
@@ -57,6 +57,12 @@ namespace parser
             {
                 return functionDeclaration();
             }
+            if (match(lexer::TokenType::EXTERN))
+            {
+                // extern def f(params) -> T;  -> external (C) function declaration.
+                consume(lexer::TokenType::DEF, "Expected 'def' after 'extern'");
+                return methodDeclaration(/*allowNoBody=*/true);
+            }
             if (match(lexer::TokenType::CLASS) || match(lexer::TokenType::STRUCT))
             {
                 return classDeclaration();

--- a/src/parser/parser.cpp
+++ b/src/parser/parser.cpp
@@ -96,6 +96,24 @@ namespace parser
         return std::make_shared<ast::VariableStmt>(name, name.value, type, initializer, isConstant);
     }
 
+    std::vector<ast::TypeParameter> Parser::parseTypeParameters()
+    {
+        std::vector<ast::TypeParameter> typeParams;
+        if (match(lexer::TokenType::LESS))
+        {
+            do
+            {
+                auto tpName = consume(lexer::TokenType::IDENTIFIER, "Expected type parameter name");
+                // Optional constraint `: SomeTrait` is parsed and ignored for now.
+                if (match(lexer::TokenType::COLON))
+                    parseType();
+                typeParams.emplace_back(tpName, tpName.value);
+            } while (match(lexer::TokenType::COMMA));
+            consume(lexer::TokenType::GREATER, "Expected '>' after type parameters");
+        }
+        return typeParams;
+    }
+
     ast::StmtPtr Parser::functionDeclaration()
     {
         bool isAsync = previous().type == lexer::TokenType::ASYNC;
@@ -104,6 +122,8 @@ namespace parser
             error(previous(), "Expected 'def' after 'async'");
         }
         auto name = consume(lexer::TokenType::IDENTIFIER, "Expected function name");
+        // Optional generic type parameters: def f<T, U>(...)
+        std::vector<ast::TypeParameter> typeParams = parseTypeParameters();
         consume(lexer::TokenType::LEFT_PAREN, "Expected '(' after function name");
         auto parameters = parseParameters();
         consume(lexer::TokenType::RIGHT_PAREN, "Expected ')' after parameters");
@@ -117,12 +137,16 @@ namespace parser
         }
         consume(lexer::TokenType::LEFT_BRACE, "Expected '{' before function body");
         auto body = blockStmt();
+        if (!typeParams.empty())
+            return std::make_shared<ast::FunctionStmt>(name, name.value, typeParams,
+                                                       parameters, returnType, body, isAsync);
         return std::make_shared<ast::FunctionStmt>(name, name.value, parameters, returnType, body, isAsync);
     }
 
     ast::StmtPtr Parser::classDeclaration()
     {
         auto name = consume(lexer::TokenType::IDENTIFIER, "Expected class name");
+        std::vector<ast::TypeParameter> typeParams = parseTypeParameters();
         consume(lexer::TokenType::LEFT_BRACE, "Expected '{' before class body");
         std::vector<ast::StmtPtr> fields, methods;
         while (!check(lexer::TokenType::RIGHT_BRACE) && !isAtEnd())
@@ -156,6 +180,10 @@ namespace parser
             }
         }
         consume(lexer::TokenType::RIGHT_BRACE, "Expected '}' after class body");
+        if (!typeParams.empty())
+            return std::make_shared<ast::ClassStmt>(name, name.value, typeParams,
+                                                    nullptr, std::vector<ast::TypePtr>{},
+                                                    fields, methods);
         return std::make_shared<ast::ClassStmt>(name, name.value, fields, methods);
     }
 

--- a/src/parser/parser.h
+++ b/src/parser/parser.h
@@ -89,6 +89,7 @@ namespace parser
         ast::ExprPtr channelReceiveExpr();
         ast::TypePtr parseType();
         std::vector<ast::Parameter> parseParameters();
+        std::vector<ast::TypeParameter> parseTypeParameters();
         void synchronize();
 
         bool match(lexer::TokenType type);

--- a/src/parser/parser.h
+++ b/src/parser/parser.h
@@ -61,6 +61,9 @@ namespace parser
         ast::StmtPtr varDeclaration();
         ast::StmtPtr functionDeclaration();
         ast::StmtPtr classDeclaration();
+        ast::StmtPtr traitDeclaration();
+        ast::StmtPtr implDeclaration();
+        std::shared_ptr<ast::FunctionStmt> methodDeclaration(bool allowNoBody);
         ast::StmtPtr statement();
         ast::StmtPtr expressionStmt();
         ast::StmtPtr ifStmt();

--- a/src/runtime/concurrency_runtime.cpp
+++ b/src/runtime/concurrency_runtime.cpp
@@ -1,0 +1,90 @@
+// Tocin concurrency runtime: goroutines (OS threads) and channels.
+//
+// These symbols are linked into the compiler/runtime and resolved by the JIT
+// from the running process, and linked into native executables via the normal
+// C toolchain. Values flowing through channels are passed as 64-bit slots
+// (ints, bit-cast floats, or pointers), matching the codegen ABI.
+#include <atomic>
+#include <condition_variable>
+#include <cstdint>
+#include <cstdlib>
+#include <deque>
+#include <mutex>
+#include <thread>
+#include <vector>
+
+namespace
+{
+    struct Channel
+    {
+        std::mutex m;
+        std::condition_variable cv;
+        std::deque<int64_t> q;
+    };
+
+    // Track spawned goroutines so the program can wait for them to finish.
+    std::mutex g_threadsMutex;
+    std::vector<std::thread> g_threads;
+}
+
+extern "C"
+{
+    // Allocate a new channel and return an opaque handle.
+    void *__tocin_chan_new()
+    {
+        return new Channel();
+    }
+
+    // Send a 64-bit value into the channel and wake a waiting receiver.
+    void __tocin_chan_send(void *handle, int64_t value)
+    {
+        if (!handle)
+            return;
+        auto *ch = static_cast<Channel *>(handle);
+        {
+            std::lock_guard<std::mutex> lock(ch->m);
+            ch->q.push_back(value);
+        }
+        ch->cv.notify_one();
+    }
+
+    // Receive a 64-bit value, blocking until one is available.
+    int64_t __tocin_chan_recv(void *handle)
+    {
+        if (!handle)
+            return 0;
+        auto *ch = static_cast<Channel *>(handle);
+        std::unique_lock<std::mutex> lock(ch->m);
+        ch->cv.wait(lock, [ch] { return !ch->q.empty(); });
+        int64_t value = ch->q.front();
+        ch->q.pop_front();
+        return value;
+    }
+
+    void __tocin_join_all();
+
+    // Spawn a goroutine: run fn(arg) on a new OS thread, tracked for joining.
+    void __tocin_go(void (*fn)(void *), void *arg)
+    {
+        if (!fn)
+            return;
+        // Ensure all goroutines are joined when the program exits.
+        static std::once_flag atexitFlag;
+        std::call_once(atexitFlag, [] { std::atexit(__tocin_join_all); });
+        std::lock_guard<std::mutex> lock(g_threadsMutex);
+        g_threads.emplace_back(fn, arg);
+    }
+
+    // Wait for all spawned goroutines to finish.
+    void __tocin_join_all()
+    {
+        std::vector<std::thread> threads;
+        {
+            std::lock_guard<std::mutex> lock(g_threadsMutex);
+            threads.swap(g_threads);
+        }
+        for (auto &t : threads)
+            if (t.joinable())
+                t.join();
+    }
+}

--- a/src/type/type_checker.cpp
+++ b/src/type/type_checker.cpp
@@ -198,6 +198,27 @@ namespace type_checker
             std::vector<ast::TypePtr>{elementType});
     }
 
+    void TypeChecker::visitIndexExpr(ast::IndexExpr *expr)
+    {
+        // Type-check the object and index expressions.
+        ast::TypePtr objType;
+        if (expr->object) { expr->object->accept(*this); objType = currentType_; }
+        if (expr->index) expr->index->accept(*this);
+
+        // If the object is a known array/list, the result is its element type;
+        // otherwise stay permissive (UNKNOWN) so codegen handles it.
+        if (auto generic = std::dynamic_pointer_cast<ast::GenericType>(objType))
+        {
+            if ((generic->name == "array" || generic->name == "list" || generic->name == "List") &&
+                !generic->typeArguments.empty())
+            {
+                currentType_ = generic->typeArguments[0];
+                return;
+            }
+        }
+        currentType_ = std::make_shared<ast::BasicType>(ast::TypeKind::UNKNOWN);
+    }
+
     void TypeChecker::visitMoveExpr(void *expr)
     {
         // Not supported; no-op

--- a/src/type/type_checker.cpp
+++ b/src/type/type_checker.cpp
@@ -146,7 +146,10 @@ namespace type_checker
         }
         // If the return type is unannotated, default to UNKNOWN so callers stay
         // permissive until it is inferred; otherwise canonicalize the annotation.
-        ast::TypePtr ret = isUnannotatedReturn(fn->returnType)
+        // Generic functions also expose UNKNOWN: their declared return type may
+        // reference type parameters that are only resolved at instantiation, so
+        // callers must not adopt the raw type-parameter as a concrete type.
+        ast::TypePtr ret = (isUnannotatedReturn(fn->returnType) || fn->isGeneric())
                                ? makeBasic(ast::TypeKind::UNKNOWN)
                                : canonicalize(fn->returnType);
         return std::make_shared<ast::FunctionType>(fn->token, std::move(paramTypes), ret, fn->isAsync);
@@ -818,12 +821,27 @@ namespace type_checker
         // New scope for parameters and body.
         pushScope();
 
+        // Inside a generic function, type parameters are abstract: bind any
+        // parameter typed by a type-parameter name to UNKNOWN so the body checks
+        // permissively (operations on T are validated at instantiation).
+        std::unordered_set<std::string> typeParamNames;
+        for (const auto &tp : stmt->typeParameters)
+            typeParamNames.insert(tp.getName());
+        auto resolveParamType = [&](const ast::TypePtr &t) -> ast::TypePtr {
+            if (t)
+            {
+                if (auto s = std::dynamic_pointer_cast<ast::SimpleType>(t))
+                    if (typeParamNames.count(s->toString()))
+                        return makeBasic(ast::TypeKind::UNKNOWN);
+                return canonicalize(t);
+            }
+            return makeBasic(ast::TypeKind::UNKNOWN);
+        };
+
         for (const auto &param : stmt->parameters)
         {
-            ast::TypePtr pType = param.type ? canonicalize(param.type)
-                                            : makeBasic(ast::TypeKind::UNKNOWN);
             if (environment_)
-                environment_->define(param.name, pType, false);
+                environment_->define(param.name, resolveParamType(param.type), false);
         }
 
         // Determine the declared return type (if any) and set up inference.
@@ -831,7 +849,8 @@ namespace type_checker
         currentReturnTypes_ = &returnTypes;
         inAsyncContext_ = stmt->isAsync;
 
-        const bool unannotated = isUnannotatedReturn(stmt->returnType);
+        // Generic functions return an abstract type parameter; check permissively.
+        const bool unannotated = isUnannotatedReturn(stmt->returnType) || stmt->isGeneric();
         if (!unannotated)
         {
             expectedReturnType_ = canonicalize(stmt->returnType);

--- a/src/type/type_checker.h
+++ b/src/type/type_checker.h
@@ -96,6 +96,7 @@ namespace type_checker
         void visitModuleStmt(ast::ModuleStmt *stmt) override;
         void visitMatchStmt(ast::MatchStmt *stmt) override;
         void visitArrayLiteralExpr(ast::ArrayLiteralExpr *expr) override;
+        void visitIndexExpr(ast::IndexExpr *expr) override;
         void visitMoveExpr(void *expr) override;
         void visitGoExpr(void *expr) override;
         void visitRuntimeChannelSendExpr(void *expr) override;

--- a/stdlib/std/list.to
+++ b/stdlib/std/list.to
@@ -1,0 +1,35 @@
+// Tocin standard library: list/array algorithms.
+
+def listSum(xs: list<int>) -> int {
+    let s = 0;
+    for i in 0..len(xs) { s = s + xs[i]; }
+    return s;
+}
+
+def listMax(xs: list<int>) -> int {
+    let m = xs[0];
+    for i in 1..len(xs) { if xs[i] > m { m = xs[i]; } }
+    return m;
+}
+
+def listMin(xs: list<int>) -> int {
+    let m = xs[0];
+    for i in 1..len(xs) { if xs[i] < m { m = xs[i]; } }
+    return m;
+}
+
+def listContains(xs: list<int>, target: int) -> int {
+    for i in 0..len(xs) { if xs[i] == target { return 1; } }
+    return 0;
+}
+
+def listReverse(xs: list<int>) {
+    let n = len(xs);
+    let i = 0;
+    while i < n / 2 {
+        let t = xs[i];
+        xs[i] = xs[n - 1 - i];
+        xs[n - 1 - i] = t;
+        i = i + 1;
+    }
+}

--- a/stdlib/std/math.to
+++ b/stdlib/std/math.to
@@ -1,0 +1,43 @@
+// Tocin standard library: integer/number utilities.
+// (abs, min, max, sqrt, pow, ... are compiler builtins.)
+
+def gcd(a: int, b: int) -> int {
+    let x = a;
+    let y = b;
+    while y != 0 {
+        let t = y;
+        y = x % y;
+        x = t;
+    }
+    return x;
+}
+
+def lcm(a: int, b: int) -> int {
+    return (a / gcd(a, b)) * b;
+}
+
+def factorial(n: int) -> int {
+    let r = 1;
+    let i = 2;
+    while i <= n {
+        r = r * i;
+        i = i + 1;
+    }
+    return r;
+}
+
+def clamp(x: int, lo: int, hi: int) -> int {
+    if x < lo { return lo; }
+    if x > hi { return hi; }
+    return x;
+}
+
+def isPrime(n: int) -> int {
+    if n < 2 { return 0; }
+    let i = 2;
+    while i * i <= n {
+        if n % i == 0 { return 0; }
+        i = i + 1;
+    }
+    return 1;
+}

--- a/tests/cases/array_index.to
+++ b/tests/cases/array_index.to
@@ -1,0 +1,6 @@
+// expect: 5
+def main() {
+    let nums = [1, 2, 3];
+    nums[0] = nums[1] + nums[2];
+    return nums[0];
+}

--- a/tests/cases/array_len.to
+++ b/tests/cases/array_len.to
@@ -1,0 +1,2 @@
+// expect: 3
+def main() { let a = [7, 8, 9]; return len(a); }

--- a/tests/cases/array_params.to
+++ b/tests/cases/array_params.to
@@ -1,0 +1,10 @@
+// expect: 31
+def listSum(xs: list<int>) -> int {
+    let s = 0;
+    for i in 0..len(xs) { s = s + xs[i]; }
+    return s;
+}
+def main() {
+    let a = [3, 1, 4, 1, 5, 9, 2, 6];
+    return listSum(a);
+}

--- a/tests/cases/arrays.to
+++ b/tests/cases/arrays.to
@@ -1,0 +1,8 @@
+// expect: 219
+def main() {
+    let a = [10, 20, 30, 40, 50];
+    a[2] = 99;
+    let sum = 0;
+    for i in 0..len(a) { sum = sum + a[i]; }
+    return sum;
+}

--- a/tests/cases/ffi_extern.to
+++ b/tests/cases/ffi_extern.to
@@ -1,0 +1,6 @@
+// expect: 65
+// expect-output: A
+extern def putchar(c: int) -> int;
+def main() {
+    return putchar(65);   // prints 'A', returns 65
+}

--- a/tests/cases/generic_identity.to
+++ b/tests/cases/generic_identity.to
@@ -1,0 +1,3 @@
+// expect: 42
+def id<T>(x: T) -> T { return x; }
+def main() { return id(42); }

--- a/tests/cases/generic_max.to
+++ b/tests/cases/generic_max.to
@@ -1,0 +1,3 @@
+// expect: 9
+def max<T>(a: T, b: T) -> T { if a > b { return a; } return b; }
+def main() { return max(3, 9); }

--- a/tests/cases/generic_multi.to
+++ b/tests/cases/generic_multi.to
@@ -1,0 +1,3 @@
+// expect: 60
+def sum3<T>(a: T, b: T, c: T) -> T { return a + b + c; }
+def main() { return sum3(10, 20, 30); }

--- a/tests/cases/impl_inherent.to
+++ b/tests/cases/impl_inherent.to
@@ -1,0 +1,7 @@
+// expect: 42
+struct Counter { value: int; }
+impl Counter {
+    def get(self) -> int { return self.value; }
+    def doubled(self) -> int { return self.get() + self.get(); }
+}
+def main() { let c = Counter(21); return c.doubled(); }

--- a/tests/cases/lib/m.to
+++ b/tests/cases/lib/m.to
@@ -1,0 +1,1 @@
+def triple(x: int) -> int { return x * 3; }

--- a/tests/cases/math_stdlib.to
+++ b/tests/cases/math_stdlib.to
@@ -1,0 +1,8 @@
+// expect: 30
+def main() {
+    let a = sqrt(16);          // 4.0
+    let b = pow(3, 2);         // 9.0
+    let c = abs(-7);           // 7
+    let d = max(5, 10);        // 10
+    return c + d + 13;         // 7 + 10 + 13 = 30
+}

--- a/tests/cases/traits.to
+++ b/tests/cases/traits.to
@@ -1,0 +1,11 @@
+// expect: 37
+trait Shape { def area(self) -> int; }
+struct Square { side: int; }
+impl Shape for Square { def area(self) -> int { return self.side * self.side; } }
+struct Rect { w: int; h: int; }
+impl Shape for Rect { def area(self) -> int { return self.w * self.h; } }
+def main() {
+    let s = Square(5);
+    let r = Rect(3, 4);
+    return s.area() + r.area();
+}

--- a/tests/cases/use_import.to
+++ b/tests/cases/use_import.to
@@ -1,0 +1,3 @@
+// expect: 30
+import lib.m;
+def main() { return triple(10); }


### PR DESCRIPTION
## Summary

Builds on the now-working compiler (PR #19) with the major language features from the roadmap. Every feature was implemented with a build-and-run-verified loop; the full suite (**34 `.to` integration tests + ctest unit tests**) is green on a **clean from-scratch build**.

## What's implemented

- **Arrays / collections** — array literals `[…]`, `arr[i]` read/write, `len()`, iteration, and arrays as reference-typed function parameters (new `IndexExpr` AST node; flat `[i64 len][elems…]` heap layout with per-variable element-type tracking).
- **Generics** — `def f<T>(…)` monomorphized per concrete type at the call site (separate `int`/`float` instantiations via type bindings; no AST cloning). The type checker exposes generic returns as `UNKNOWN` and checks generic bodies permissively.
- **Traits & impl** — `trait` interfaces and `impl [Trait for] Type` blocks with per-type method dispatch (reuses the class-method path); inherent impls and method-to-method calls work.
- **Concurrency** — `go f(args)` goroutines on real OS threads (args packed on the heap + a thunk) and typed `channel<T>` send/receive backed by a thread-safe runtime. Works in **JIT** (registered via `absoluteSymbols`) and **native builds** (small LLVM-free `tocin_runtime` archive linked in, plus `-lpthread`).
- **Module system** — `import a.b.c` / `import "path"` resolves, parses and merges other `.to` modules before type-checking (recursive, cycle-safe; searches the source dir, `$TOCIN_PATH`, and the built-in stdlib path).
- **Standard library** — `stdlib/std/math.to` (gcd, lcm, factorial, clamp, isPrime) and `stdlib/std/list.to` (sum/max/min/contains/reverse), plus native math builtins (`sqrt`, `pow`, `abs`, `min`, `max`, `floor`, trig, …).
- **C FFI** — call C library functions via `extern def name(…) -> T;` (verified against libc in JIT and AOT).
- **`match`** dispatch and **`elif`** chains (fixed earlier in the working-compiler PR; exercised further here).

## Bugs fixed along the way

The lexer mapped `<-` only to channel *send*, so prefix `<-ch` receive didn't parse; generic functions leaked the abstract type parameter `T` into callers' inferred return types; and the JIT couldn't resolve the runtime until it was registered explicitly.

## Docs

The README's Highlights and Language Tour now reflect these features (all tour snippets verified to run), and the Roadmap is trimmed to what genuinely remains: generic classes, LINQ, pattern binding, null-safety operators, `Option`/`Result` ergonomics, `async`/`select`, `try`/`catch` + enums, deep Python/JS (V8) FFI, and macros.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Fih5HHhUzVNkusdaXHoSdu

---
_Generated by [Claude Code](https://claude.ai/code/session_01Fih5HHhUzVNkusdaXHoSdu)_