### PR TITLE
Error handling (try/catch/throw/finally) and enums

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,7 +73,7 @@ jobs:
             -DLLVM_DIR=/usr/lib/llvm-${{ env.LLVM_VERSION }}/lib/cmake/llvm
 
       - name: Build compiler and tests
-        run: ninja -C build tocin tocin_tests
+        run: ninja -C build tocin tocin_tests tocin_runtime_shared
 
       - name: Run C++ unit tests (ctest)
         working-directory: build
@@ -130,7 +130,7 @@ jobs:
             -DLLVM_DIR="${LLVM_DIR}"
 
       - name: Build compiler and tests
-        run: ninja -C build tocin tocin_tests
+        run: ninja -C build tocin tocin_tests tocin_runtime_shared
 
       - name: Run C++ unit tests (ctest)
         working-directory: build

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -451,11 +451,19 @@ endif()
 # Propagate all library dependencies through the core library so both the
 # tocin executable and the test binary inherit them automatically.
 target_link_libraries(tocin_core PUBLIC ${LINK_LIBS})
-# Standalone Tocin runtime (channels/goroutines) — no LLVM dependency, so it
-# can be linked into native executables produced by the AOT path.
+# Standalone Tocin runtime (channels/goroutines/exceptions) — no LLVM
+# dependency, so it can be linked into native executables produced by the AOT
+# path.
 add_library(tocin_runtime STATIC ${CMAKE_CURRENT_SOURCE_DIR}/src/runtime/concurrency_runtime.cpp)
 set_target_properties(tocin_runtime PROPERTIES POSITION_INDEPENDENT_CODE ON)
 target_link_libraries(tocin_runtime PUBLIC Threads::Threads)
+
+# A shared-library build of the same runtime, so the LLVM interpreter (lli) used
+# by the .to test suite can `-load` it and resolve the __tocin_* symbols when
+# executing IR for programs that use channels, goroutines or exceptions.
+add_library(tocin_runtime_shared SHARED ${CMAKE_CURRENT_SOURCE_DIR}/src/runtime/concurrency_runtime.cpp)
+set_target_properties(tocin_runtime_shared PROPERTIES OUTPUT_NAME tocin_runtime)
+target_link_libraries(tocin_runtime_shared PUBLIC Threads::Threads)
 
 target_link_libraries(tocin PRIVATE tocin_core tocin_runtime)
 # Tell the driver where to find the runtime archive when linking AOT binaries.

--- a/README.md
+++ b/README.md
@@ -22,6 +22,10 @@ clear what is implemented versus planned.
   (declarations are order-independent via two-pass code generation).
 - **Control flow** — `if / elif / else`, `while`, range-based `for i in a..b`, and
   `match` / `case` / `default`.
+- **Error handling** — `throw`, `try` / `catch (e)` / `finally`; exceptions unwind
+  across function calls (setjmp/longjmp runtime) in both JIT and native builds.
+- **Enums** — `enum Color { Red, Green, Blue }` with auto-incrementing integer
+  constants, usable bare or qualified (`Color.Red`).
 - **Classes / structs** — fields, methods with `self`, construction, field read and
   mutation, and method calls.
 - **Traits & impl** — `trait` interfaces and `impl [Trait for] Type` blocks with
@@ -171,6 +175,27 @@ def main() {
 }
 ```
 
+Error handling with `throw` / `try` / `catch` / `finally`:
+
+```tocin
+def divide(a: int, b: int) -> int {
+    if b == 0 { throw 1; }                 // unwinds to the nearest catch
+    return a / b;
+}
+
+def main() {
+    try {
+        let r = divide(10, 0);
+        println("never printed: {}", r);
+    } catch (e) {
+        println("error code {}", e);       // error code 1
+    } finally {
+        println("done");                   // always runs
+    }
+    return 0;
+}
+```
+
 ## How it works
 
 ```
@@ -209,7 +234,9 @@ tocin-compiler/
 ## Testing
 
 ```bash
-cmake --build build --target tocin tocin_tests
+# tocin_runtime_shared lets the .to runner (lli) resolve the __tocin_* runtime
+# symbols used by concurrency and exception programs.
+cmake --build build --target tocin tocin_tests tocin_runtime_shared
 ctest --test-dir build --output-on-failure       # C++ unit tests
 bash scripts/run_to_tests.sh                      # .to integration programs
 ```
@@ -229,7 +256,8 @@ end-to-end**. They are listed honestly so expectations match reality:
   propagation pending.
 - **`async` / `await`** — goroutines and channels work; structured async is pending.
 - **`select`** over multiple channels.
-- **Error handling** — `try` / `catch` / `throw` and **enums**.
+- **Typed exceptions** — `throw` / `catch` carry an integer code today; throwing and
+  binding arbitrary typed payloads (e.g. error objects) is pending.
 - **Python / JavaScript FFI** — C FFI works via `extern`; deep CPython and V8
   integration is gated behind build flags (V8 is not bundled — it is not
   installable from standard package managers, so CI builds with `-DWITH_V8=OFF`).

--- a/examples/errors.to
+++ b/examples/errors.to
@@ -1,0 +1,32 @@
+// Error handling: throw, try / catch, and finally.
+//   tocin examples/errors.to --run
+//
+// `throw` unwinds to the nearest enclosing `catch`, carrying an integer code.
+// `finally` always runs on the normal and caught paths. A `try` with only a
+// `finally` re-throws to the next handler after the finally block runs.
+
+def divide(a: int, b: int) -> int {
+    if b == 0 {
+        throw 1;            // error code: division by zero
+    }
+    return a / b;
+}
+
+def main() {
+    // Caught error from a called function.
+    try {
+        let r = divide(10, 0);
+        println("10 / 0 = {}", r);          // not reached
+    } catch (e) {
+        println("error code {}", e);        // error code 1
+    }
+
+    // Success path still runs finally.
+    try {
+        println("10 / 2 = {}", divide(10, 2));   // 10 / 2 = 5
+    } finally {
+        println("done");                          // done
+    }
+
+    return 0;
+}

--- a/scripts/run_to_tests.sh
+++ b/scripts/run_to_tests.sh
@@ -76,6 +76,24 @@ if [ -z "${LLI_BIN}" ]; then
     exit 2
 fi
 
+# --- Locate the shared Tocin runtime (for channels/goroutines/exceptions) ---
+# lli resolves libc symbols from its own process, but the __tocin_* runtime
+# lives in our own library; -load it so programs using those features run.
+find_runtime_so() {
+    if [ -n "${TOCIN_RUNTIME_SO:-}" ] && [ -f "${TOCIN_RUNTIME_SO}" ]; then
+        echo "${TOCIN_RUNTIME_SO}"; return 0
+    fi
+    local bindir; bindir="$(dirname "${TOCIN_BIN}")"
+    for cand in \
+        "${bindir}/libtocin_runtime.so" \
+        "${bindir}/libtocin_runtime.dylib" \
+        "${REPO_ROOT}/build/libtocin_runtime.so"; do
+        if [ -f "${cand}" ]; then echo "${cand}"; return 0; fi
+    done
+    return 1
+}
+RUNTIME_SO="$(find_runtime_so || true)"
+
 if [ ! -d "${CASES_DIR}" ]; then
     echo "ERROR: cases directory not found: ${CASES_DIR}" >&2
     exit 2
@@ -84,8 +102,15 @@ fi
 echo "Tocin .to test runner"
 echo "  tocin : ${TOCIN_BIN}"
 echo "  lli   : ${LLI_BIN}"
+echo "  rtlib : ${RUNTIME_SO:-<none found; runtime-dependent tests may fail>}"
 echo "  cases : ${CASES_DIR}"
 echo "========================================================"
+
+# lli flag to load the runtime shared library, when available.
+LLI_LOAD_ARGS=()
+if [ -n "${RUNTIME_SO}" ]; then
+    LLI_LOAD_ARGS=(-load "${RUNTIME_SO}")
+fi
 
 # --- Work directory for generated IR ------------------------------------
 WORK_DIR="$(mktemp -d "${TMPDIR:-/tmp}/tocin_to_tests.XXXXXX")"
@@ -165,7 +190,7 @@ for tofile in "${CASE_FILES[@]}"; do
     fi
 
     # Execute the IR. Capture stdout and exit code.
-    actual_output="$(timeout "${TIMEOUT}" "${LLI_BIN}" "${ll}" 2>"${base}.run.err")"
+    actual_output="$(timeout "${TIMEOUT}" "${LLI_BIN}" "${LLI_LOAD_ARGS[@]}" "${ll}" 2>"${base}.run.err")"
     actual_exit=$?
 
     if [ "${actual_exit}" -eq 124 ]; then

--- a/src/ast/ast.h
+++ b/src/ast/ast.h
@@ -69,6 +69,7 @@ namespace ast
     class GoStmt;
     class ArrayLiteralExpr;
     class IndexExpr;
+    class EnumStmt;
 
     // Define shared pointers for common types - Type is already defined in types.h
     using ExprPtr = std::shared_ptr<Expression>;
@@ -115,6 +116,7 @@ namespace ast
         virtual void visitGoStmt(GoStmt *stmt) = 0;
         virtual void visitArrayLiteralExpr(ArrayLiteralExpr *expr) = 0;
         virtual void visitIndexExpr(IndexExpr *expr) = 0;
+        virtual void visitEnumStmt(EnumStmt *stmt) = 0;
         virtual void visitTraitStmt(TraitStmt *stmt) = 0;
         virtual void visitImplStmt(ImplStmt *stmt) = 0;
 
@@ -899,6 +901,21 @@ namespace ast
         ExprPtr object;
         ExprPtr index;
         TypePtr getType() const override { return nullptr; }
+    };
+
+    /**
+     * @brief Enum declaration (e.g., enum Color { Red, Green, Blue }).
+     *        Members are integer constants with auto-incrementing values.
+     */
+    class EnumStmt : public Statement
+    {
+    public:
+        EnumStmt(const lexer::Token &token, const std::string &name,
+                 std::vector<std::pair<std::string, int64_t>> members)
+            : Statement(token), name(name), members(std::move(members)) {}
+        void accept(Visitor &visitor) override { visitor.visitEnumStmt(this); }
+        std::string name;
+        std::vector<std::pair<std::string, int64_t>> members;
     };
 
     /**

--- a/src/ast/ast.h
+++ b/src/ast/ast.h
@@ -70,6 +70,8 @@ namespace ast
     class ArrayLiteralExpr;
     class IndexExpr;
     class EnumStmt;
+    class TryStmt;
+    class ThrowStmt;
 
     // Define shared pointers for common types - Type is already defined in types.h
     using ExprPtr = std::shared_ptr<Expression>;
@@ -117,6 +119,8 @@ namespace ast
         virtual void visitArrayLiteralExpr(ArrayLiteralExpr *expr) = 0;
         virtual void visitIndexExpr(IndexExpr *expr) = 0;
         virtual void visitEnumStmt(EnumStmt *stmt) = 0;
+        virtual void visitTryStmt(TryStmt *stmt) = 0;
+        virtual void visitThrowStmt(ThrowStmt *stmt) = 0;
         virtual void visitTraitStmt(TraitStmt *stmt) = 0;
         virtual void visitImplStmt(ImplStmt *stmt) = 0;
 
@@ -916,6 +920,37 @@ namespace ast
         void accept(Visitor &visitor) override { visitor.visitEnumStmt(this); }
         std::string name;
         std::vector<std::pair<std::string, int64_t>> members;
+    };
+
+    /**
+     * @brief Try/catch/finally statement for error handling.
+     *        try { ... } catch (e) { ... } finally { ... }
+     *        catchBlock/finallyBlock may be null when absent.
+     */
+    class TryStmt : public Statement
+    {
+    public:
+        TryStmt(const lexer::Token &token, StmtPtr tryBlock,
+                const std::string &catchVar, StmtPtr catchBlock, StmtPtr finallyBlock)
+            : Statement(token), tryBlock(std::move(tryBlock)), catchVar(catchVar),
+              catchBlock(std::move(catchBlock)), finallyBlock(std::move(finallyBlock)) {}
+        void accept(Visitor &visitor) override { visitor.visitTryStmt(this); }
+        StmtPtr tryBlock;
+        std::string catchVar;   // name bound to the caught value (may be empty)
+        StmtPtr catchBlock;     // may be null
+        StmtPtr finallyBlock;   // may be null
+    };
+
+    /**
+     * @brief Throw statement: throw <expr>;
+     */
+    class ThrowStmt : public Statement
+    {
+    public:
+        ThrowStmt(const lexer::Token &token, ExprPtr value)
+            : Statement(token), value(std::move(value)) {}
+        void accept(Visitor &visitor) override { visitor.visitThrowStmt(this); }
+        ExprPtr value;
     };
 
     /**

--- a/src/codegen/ir_generator.cpp
+++ b/src/codegen/ir_generator.cpp
@@ -2400,6 +2400,18 @@ llvm::Function *IRGenerator::emitGenericInstance(ast::FunctionStmt *stmt,
     return function;
 }
 
+void IRGenerator::visitEnumStmt(ast::EnumStmt *stmt)
+{
+    // Enum members are integer constants, registered both bare (Red) and
+    // qualified (Color.Red) for use in expressions.
+    for (const auto &m : stmt->members)
+    {
+        enumConstants[m.first] = m.second;
+        enumConstants[stmt->name + "." + m.first] = m.second;
+    }
+    lastValue = nullptr;
+}
+
 void IRGenerator::generateMethod(const std::string &className, llvm::StructType *classType, ast::FunctionStmt *method)
 {
     llvm::Type *opaquePtr = llvm::PointerType::get(context, 0);
@@ -2522,6 +2534,17 @@ void IRGenerator::generateMethod(const std::string &className, llvm::StructType 
 
 void IRGenerator::visitGetExpr(ast::GetExpr *expr)
 {
+    // Qualified enum access: EnumName.Member -> integer constant.
+    if (auto v = std::dynamic_pointer_cast<ast::VariableExpr>(expr->object))
+    {
+        auto e = enumConstants.find(v->name + "." + expr->name);
+        if (e != enumConstants.end())
+        {
+            lastValue = llvm::ConstantInt::get(llvm::Type::getInt64Ty(context), e->second);
+            return;
+        }
+    }
+
     // Evaluate the object expression
     expr->object->accept(*this);
     if (!lastValue)
@@ -3117,10 +3140,15 @@ void IRGenerator::predeclareTopLevel(ast::StmtPtr ast)
     else
         stmts.push_back(ast);
 
-    // Register class types first (so signatures can reference them).
+    // Register class types and enum constants first (so they can be referenced
+    // regardless of declaration order).
     for (auto &s : stmts)
+    {
         if (auto cls = std::dynamic_pointer_cast<ast::ClassStmt>(s))
             registerClassType(cls.get());
+        else if (auto en = std::dynamic_pointer_cast<ast::EnumStmt>(s))
+            visitEnumStmt(en.get());
+    }
 
     // Then forward-declare free functions and method prototypes.
     for (auto &s : stmts)
@@ -3868,6 +3896,13 @@ void IRGenerator::visitGroupingExpr(ast::GroupingExpr *expr)
 
 void IRGenerator::visitVariableExpr(ast::VariableExpr *expr)
 {
+    // Enum members resolve to their integer constant.
+    auto e = enumConstants.find(expr->name);
+    if (e != enumConstants.end())
+    {
+        lastValue = llvm::ConstantInt::get(llvm::Type::getInt64Ty(context), e->second);
+        return;
+    }
     // Look up variable in current scope
     llvm::AllocaInst *alloca = lookupVariable(expr->name);
     if (alloca)

--- a/src/codegen/ir_generator.cpp
+++ b/src/codegen/ir_generator.cpp
@@ -2412,6 +2412,153 @@ void IRGenerator::visitEnumStmt(ast::EnumStmt *stmt)
     lastValue = nullptr;
 }
 
+void IRGenerator::visitThrowStmt(ast::ThrowStmt *stmt)
+{
+    llvm::Type *i64 = llvm::Type::getInt64Ty(context);
+    llvm::Type *voidTy = llvm::Type::getVoidTy(context);
+
+    llvm::Value *val = nullptr;
+    if (stmt->value)
+    {
+        stmt->value->accept(*this);
+        val = lastValue;
+    }
+    if (!val)
+        val = llvm::ConstantInt::get(i64, 0);
+
+    // Normalize the thrown value into a 64-bit slot (matching the channel ABI).
+    if (val->getType()->isPointerTy())
+        val = builder.CreatePtrToInt(val, i64, "throwv");
+    else if (val->getType()->isDoubleTy())
+        val = builder.CreateBitCast(val, i64, "throwv");
+    else if (val->getType()->isIntegerTy() && val->getType() != i64)
+        val = builder.CreateSExt(val, i64, "throwv");
+
+    llvm::Function *throwF = module->getFunction("__tocin_throw");
+    if (!throwF)
+        throwF = llvm::Function::Create(
+            llvm::FunctionType::get(voidTy, {i64}, false),
+            llvm::Function::ExternalLinkage, "__tocin_throw", *module);
+    builder.CreateCall(throwF, {val});
+    // __tocin_throw never returns (it longjmps); terminate the block.
+    builder.CreateUnreachable();
+    lastValue = nullptr;
+}
+
+void IRGenerator::visitTryStmt(ast::TryStmt *stmt)
+{
+    llvm::Function *function = builder.GetInsertBlock()->getParent();
+    llvm::Type *i8 = llvm::Type::getInt8Ty(context);
+    llvm::Type *i32 = llvm::Type::getInt32Ty(context);
+    llvm::Type *i64 = llvm::Type::getInt64Ty(context);
+    llvm::Type *ptr = llvm::PointerType::get(context, 0);
+    llvm::Type *voidTy = llvm::Type::getVoidTy(context);
+
+    // Runtime helpers.
+    auto getFn = [&](const char *name, llvm::FunctionType *ty) {
+        llvm::Function *f = module->getFunction(name);
+        if (!f)
+            f = llvm::Function::Create(ty, llvm::Function::ExternalLinkage, name, *module);
+        return f;
+    };
+    llvm::Function *regF = getFn("__tocin_try_register",
+                                 llvm::FunctionType::get(voidTy, {ptr}, false));
+    llvm::Function *popF = getFn("__tocin_try_pop",
+                                 llvm::FunctionType::get(voidTy, {}, false));
+    llvm::Function *excValF = getFn("__tocin_exc_value",
+                                    llvm::FunctionType::get(i64, {}, false));
+    llvm::Function *throwF = getFn("__tocin_throw",
+                                   llvm::FunctionType::get(voidTy, {i64}, false));
+    // libc setjmp; the call site must be marked returns_twice.
+    llvm::Function *setjmpF = module->getFunction("setjmp");
+    if (!setjmpF)
+    {
+        setjmpF = llvm::Function::Create(
+            llvm::FunctionType::get(i32, {ptr}, false),
+            llvm::Function::ExternalLinkage, "setjmp", *module);
+        setjmpF->addFnAttr(llvm::Attribute::ReturnsTwice);
+    }
+
+    // jmp_buf storage (256 bytes covers glibc's jmp_buf), in the entry block.
+    llvm::ArrayType *bufTy = llvm::ArrayType::get(i8, 256);
+    llvm::AllocaInst *buf = createEntryBlockAlloca(function, "try.jmpbuf", bufTy);
+
+    // Emits the finally block (if present) inline. Returns true if the current
+    // block is still open (not terminated) afterward.
+    auto emitFinally = [&]() -> bool {
+        if (stmt->finallyBlock)
+        {
+            createEnvironment();
+            stmt->finallyBlock->accept(*this);
+            restoreEnvironment();
+        }
+        return builder.GetInsertBlock()->getTerminator() == nullptr;
+    };
+
+    // Register the handler and arm setjmp.
+    builder.CreateCall(regF, {buf});
+    llvm::CallInst *sj = builder.CreateCall(setjmpF, {buf}, "sj");
+    sj->addFnAttr(llvm::Attribute::ReturnsTwice);
+    llvm::Value *isExc = builder.CreateICmpNE(sj, llvm::ConstantInt::get(i32, 0), "is.exc");
+
+    llvm::BasicBlock *tryBB = llvm::BasicBlock::Create(context, "try.body", function);
+    llvm::BasicBlock *excBB = llvm::BasicBlock::Create(context, "try.land", function);
+    llvm::BasicBlock *contBB = llvm::BasicBlock::Create(context, "try.cont", function);
+
+    builder.CreateCondBr(isExc, excBB, tryBB);
+
+    // --- try body (setjmp returned 0) ---
+    builder.SetInsertPoint(tryBB);
+    createEnvironment();
+    if (stmt->tryBlock)
+        stmt->tryBlock->accept(*this);
+    restoreEnvironment();
+    if (!builder.GetInsertBlock()->getTerminator())
+    {
+        builder.CreateCall(popF, {});       // handler consumed: normal completion
+        if (emitFinally())
+            builder.CreateBr(contBB);
+    }
+
+    // --- landing pad (setjmp returned non-zero: an exception unwound here) ---
+    // __tocin_throw has already popped this handler.
+    builder.SetInsertPoint(excBB);
+    if (stmt->catchBlock)
+    {
+        auto savedNamed = namedValues;
+        createEnvironment();
+        if (!stmt->catchVar.empty())
+        {
+            llvm::Value *exc = builder.CreateCall(excValF, {}, "exc.val");
+            llvm::AllocaInst *slot = builder.CreateAlloca(i64, nullptr, stmt->catchVar);
+            builder.CreateStore(exc, slot);
+            namedValues[stmt->catchVar] = slot;
+        }
+        stmt->catchBlock->accept(*this);
+        restoreEnvironment();
+        namedValues = savedNamed;
+        if (!builder.GetInsertBlock()->getTerminator())
+        {
+            if (emitFinally())
+                builder.CreateBr(contBB);
+        }
+    }
+    else
+    {
+        // No catch: run finally, then re-propagate to the enclosing handler.
+        if (emitFinally())
+        {
+            llvm::Value *exc = builder.CreateCall(excValF, {}, "exc.val");
+            builder.CreateCall(throwF, {exc});
+            builder.CreateUnreachable();
+        }
+    }
+
+    // --- continuation ---
+    builder.SetInsertPoint(contBB);
+    lastValue = nullptr;
+}
+
 void IRGenerator::generateMethod(const std::string &className, llvm::StructType *classType, ast::FunctionStmt *method)
 {
     llvm::Type *opaquePtr = llvm::PointerType::get(context, 0);
@@ -3925,7 +4072,17 @@ void IRGenerator::visitBlockStmt(ast::BlockStmt *stmt)
     enterScope();
     for (auto &statement : stmt->statements)
     {
-        if (statement) statement->accept(*this);
+        if (!statement)
+            continue;
+        // Stop at the first terminator within the current function: statements
+        // after a return/throw are unreachable, and emitting them would place
+        // instructions after a block terminator (invalid IR). The parent check
+        // avoids tripping at the top level, where the builder is left pointing
+        // at the previous function's (terminated) block between declarations.
+        if (auto *bb = builder.GetInsertBlock())
+            if (bb->getTerminator() && currentFunction && bb->getParent() == currentFunction)
+                break;
+        statement->accept(*this);
     }
     exitScope();
 }

--- a/src/codegen/ir_generator.h
+++ b/src/codegen/ir_generator.h
@@ -121,6 +121,8 @@ namespace codegen
         void visitArrayLiteralExpr(ast::ArrayLiteralExpr *expr) override;
         void visitIndexExpr(ast::IndexExpr *expr) override;
         void visitEnumStmt(ast::EnumStmt *stmt) override;
+        void visitTryStmt(ast::TryStmt *stmt) override;
+        void visitThrowStmt(ast::ThrowStmt *stmt) override;
         void visitMoveExpr(void *expr) override;
         void visitGoExpr(void *expr) override;
         void visitRuntimeChannelSendExpr(void *expr) override;

--- a/src/codegen/ir_generator.h
+++ b/src/codegen/ir_generator.h
@@ -120,6 +120,7 @@ namespace codegen
         void visitStringInterpolationExpr(ast::StringInterpolationExpr *expr) override;
         void visitArrayLiteralExpr(ast::ArrayLiteralExpr *expr) override;
         void visitIndexExpr(ast::IndexExpr *expr) override;
+        void visitEnumStmt(ast::EnumStmt *stmt) override;
         void visitMoveExpr(void *expr) override;
         void visitGoExpr(void *expr) override;
         void visitRuntimeChannelSendExpr(void *expr) override;
@@ -164,6 +165,7 @@ namespace codegen
         std::string lastExprClassName;                                             // Class name of the most recent expression value
         llvm::Type *lastExprArrayElem = nullptr;                                  // Element type of the most recent array expression
         std::map<std::string, ast::FunctionStmt *> genericFunctions;             // name -> generic function template
+        std::map<std::string, int64_t> enumConstants;                           // EnumName.Member and Member -> value
         std::map<std::string, llvm::Type *> typeBindings;                        // active type-parameter bindings during instantiation
         std::map<std::string, llvm::Function *> stdLibFunctions;                   // Standard library functions
         std::map<std::string, ClassInfo> classTypes;                               // Class type information

--- a/src/compiler/macro_system.cpp
+++ b/src/compiler/macro_system.cpp
@@ -91,6 +91,8 @@ ast::StmtPtr FunctionMacro::expand(const MacroContext& context, error::ErrorHand
         void visitArrayLiteralExpr(ast::ArrayLiteralExpr* expr) override {}
         void visitIndexExpr(ast::IndexExpr* expr) override {}
         void visitEnumStmt(ast::EnumStmt* stmt) override {}
+        void visitTryStmt(ast::TryStmt* stmt) override {}
+        void visitThrowStmt(ast::ThrowStmt* stmt) override {}
         void visitMoveExpr(void* expr) override {}
         void visitGoExpr(void* expr) override {}
         void visitRuntimeChannelSendExpr(void* expr) override {}
@@ -247,6 +249,8 @@ ast::StmtPtr MacroSystem::processMacros(ast::StmtPtr stmt, error::ErrorHandler& 
         void visitArrayLiteralExpr(ast::ArrayLiteralExpr* expr) override {}
         void visitIndexExpr(ast::IndexExpr* expr) override {}
         void visitEnumStmt(ast::EnumStmt* stmt) override {}
+        void visitTryStmt(ast::TryStmt* stmt) override {}
+        void visitThrowStmt(ast::ThrowStmt* stmt) override {}
         void visitMoveExpr(void* expr) override {}
         void visitGoExpr(void* expr) override {}
         void visitRuntimeChannelSendExpr(void* expr) override {}

--- a/src/compiler/macro_system.cpp
+++ b/src/compiler/macro_system.cpp
@@ -90,6 +90,7 @@ ast::StmtPtr FunctionMacro::expand(const MacroContext& context, error::ErrorHand
         void visitStringInterpolationExpr(ast::StringInterpolationExpr* expr) override {}
         void visitArrayLiteralExpr(ast::ArrayLiteralExpr* expr) override {}
         void visitIndexExpr(ast::IndexExpr* expr) override {}
+        void visitEnumStmt(ast::EnumStmt* stmt) override {}
         void visitMoveExpr(void* expr) override {}
         void visitGoExpr(void* expr) override {}
         void visitRuntimeChannelSendExpr(void* expr) override {}
@@ -245,6 +246,7 @@ ast::StmtPtr MacroSystem::processMacros(ast::StmtPtr stmt, error::ErrorHandler& 
         void visitStringInterpolationExpr(ast::StringInterpolationExpr* expr) override {}
         void visitArrayLiteralExpr(ast::ArrayLiteralExpr* expr) override {}
         void visitIndexExpr(ast::IndexExpr* expr) override {}
+        void visitEnumStmt(ast::EnumStmt* stmt) override {}
         void visitMoveExpr(void* expr) override {}
         void visitGoExpr(void* expr) override {}
         void visitRuntimeChannelSendExpr(void* expr) override {}

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -46,6 +46,10 @@ extern "C" {
     int64_t __tocin_chan_recv(void *);
     void __tocin_go(void (*)(void *), void *);
     void __tocin_join_all();
+    void __tocin_try_register(void *);
+    void __tocin_try_pop();
+    int64_t __tocin_exc_value();
+    void __tocin_throw(int64_t);
 }
 
 // Conditionally include Python
@@ -422,6 +426,10 @@ public:
             def("__tocin_chan_recv", reinterpret_cast<void *>(&__tocin_chan_recv));
             def("__tocin_go", reinterpret_cast<void *>(&__tocin_go));
             def("__tocin_join_all", reinterpret_cast<void *>(&__tocin_join_all));
+            def("__tocin_try_register", reinterpret_cast<void *>(&__tocin_try_register));
+            def("__tocin_try_pop", reinterpret_cast<void *>(&__tocin_try_pop));
+            def("__tocin_exc_value", reinterpret_cast<void *>(&__tocin_exc_value));
+            def("__tocin_throw", reinterpret_cast<void *>(&__tocin_throw));
             llvm::cantFail(jit->getMainJITDylib().define(llvm::orc::absoluteSymbols(std::move(rt))));
         }
 

--- a/src/parser/parser.cpp
+++ b/src/parser/parser.cpp
@@ -67,6 +67,10 @@ namespace parser
             {
                 return classDeclaration();
             }
+            if (match(lexer::TokenType::ENUM))
+            {
+                return enumDeclaration();
+            }
             if (match(lexer::TokenType::TRAIT))
             {
                 return traitDeclaration();
@@ -226,6 +230,31 @@ namespace parser
             return std::make_shared<ast::FunctionStmt>(name, name.value, typeParams,
                                                        parameters, returnType, body, isAsync);
         return std::make_shared<ast::FunctionStmt>(name, name.value, parameters, returnType, body, isAsync);
+    }
+
+    ast::StmtPtr Parser::enumDeclaration()
+    {
+        auto name = consume(lexer::TokenType::IDENTIFIER, "Expected enum name");
+        consume(lexer::TokenType::LEFT_BRACE, "Expected '{' before enum body");
+        std::vector<std::pair<std::string, int64_t>> members;
+        int64_t next = 0;
+        while (!check(lexer::TokenType::RIGHT_BRACE) && !isAtEnd())
+        {
+            auto member = consume(lexer::TokenType::IDENTIFIER, "Expected enum member name");
+            int64_t value = next;
+            if (match(lexer::TokenType::EQUAL))
+            {
+                bool neg = match(lexer::TokenType::MINUS);
+                auto v = consume(lexer::TokenType::INT, "Expected integer after '=' in enum");
+                value = std::stoll(v.value);
+                if (neg) value = -value;
+            }
+            members.emplace_back(member.value, value);
+            next = value + 1;
+            match(lexer::TokenType::COMMA); // optional separator
+        }
+        consume(lexer::TokenType::RIGHT_BRACE, "Expected '}' after enum body");
+        return std::make_shared<ast::EnumStmt>(name, name.value, members);
     }
 
     ast::StmtPtr Parser::traitDeclaration()

--- a/src/parser/parser.cpp
+++ b/src/parser/parser.cpp
@@ -324,7 +324,62 @@ namespace parser
             return goStmt();
         if (match(lexer::TokenType::SELECT))
             return selectStmt();
+        if (match(lexer::TokenType::TRY))
+            return tryStmt();
+        if (match(lexer::TokenType::THROW))
+            return throwStmt();
         return expressionStmt();
+    }
+
+    // try { ... } catch (e) { ... } finally { ... }
+    // The catch clause and finally clause are each optional, but at least one
+    // must be present. The catch variable is optional: `catch { ... }`.
+    ast::StmtPtr Parser::tryStmt()
+    {
+        lexer::Token keyword = previous();
+        consume(lexer::TokenType::LEFT_BRACE, "Expected '{' after 'try'");
+        ast::StmtPtr tryBlock = blockStmt();
+
+        std::string catchVar;
+        ast::StmtPtr catchBlock = nullptr;
+        if (match(lexer::TokenType::CATCH))
+        {
+            // Optional `(name)` or bare `name` binding for the caught value.
+            if (match(lexer::TokenType::LEFT_PAREN))
+            {
+                if (check(lexer::TokenType::IDENTIFIER))
+                    catchVar = advance().value;
+                consume(lexer::TokenType::RIGHT_PAREN, "Expected ')' after catch variable");
+            }
+            else if (check(lexer::TokenType::IDENTIFIER))
+            {
+                catchVar = advance().value;
+            }
+            consume(lexer::TokenType::LEFT_BRACE, "Expected '{' after catch");
+            catchBlock = blockStmt();
+        }
+
+        ast::StmtPtr finallyBlock = nullptr;
+        if (match(lexer::TokenType::FINALLY))
+        {
+            consume(lexer::TokenType::LEFT_BRACE, "Expected '{' after finally");
+            finallyBlock = blockStmt();
+        }
+
+        if (!catchBlock && !finallyBlock)
+            error(keyword, "'try' must be followed by 'catch' or 'finally'");
+
+        return std::make_shared<ast::TryStmt>(keyword, tryBlock, catchVar,
+                                              catchBlock, finallyBlock);
+    }
+
+    // throw <expr>;
+    ast::StmtPtr Parser::throwStmt()
+    {
+        lexer::Token keyword = previous();
+        ast::ExprPtr value = expression();
+        consume(lexer::TokenType::SEMI_COLON, "Expected ';' after thrown value");
+        return std::make_shared<ast::ThrowStmt>(keyword, value);
     }
 
     ast::StmtPtr Parser::expressionStmt()

--- a/src/parser/parser.h
+++ b/src/parser/parser.h
@@ -63,6 +63,7 @@ namespace parser
         ast::StmtPtr classDeclaration();
         ast::StmtPtr traitDeclaration();
         ast::StmtPtr implDeclaration();
+        ast::StmtPtr enumDeclaration();
         std::shared_ptr<ast::FunctionStmt> methodDeclaration(bool allowNoBody);
         ast::StmtPtr statement();
         ast::StmtPtr expressionStmt();

--- a/src/parser/parser.h
+++ b/src/parser/parser.h
@@ -76,6 +76,8 @@ namespace parser
         ast::StmtPtr matchStmt();
         ast::StmtPtr goStmt();
         ast::StmtPtr selectStmt();
+        ast::StmtPtr tryStmt();
+        ast::StmtPtr throwStmt();
         ast::ExprPtr expression();
         ast::ExprPtr assignment();
         ast::ExprPtr orExpr();

--- a/src/runtime/concurrency_runtime.cpp
+++ b/src/runtime/concurrency_runtime.cpp
@@ -1,4 +1,4 @@
-// Tocin concurrency runtime: goroutines (OS threads) and channels.
+// Tocin runtime: goroutines (OS threads), channels, and exception handling.
 //
 // These symbols are linked into the compiler/runtime and resolved by the JIT
 // from the running process, and linked into native executables via the normal
@@ -6,7 +6,9 @@
 // (ints, bit-cast floats, or pointers), matching the codegen ABI.
 #include <atomic>
 #include <condition_variable>
+#include <csetjmp>
 #include <cstdint>
+#include <cstdio>
 #include <cstdlib>
 #include <deque>
 #include <mutex>
@@ -86,5 +88,58 @@ extern "C"
         for (auto &t : threads)
             if (t.joinable())
                 t.join();
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Exception handling: setjmp/longjmp-based unwinding.
+//
+// Each `try` allocates a jmp_buf in its own frame, calls setjmp, and registers
+// the buffer with __tocin_try_register. `throw` records a 64-bit value and
+// longjmps back to the most recently registered handler. The handler stack is
+// thread-local so goroutines have independent exception state.
+// ---------------------------------------------------------------------------
+namespace
+{
+    thread_local std::vector<std::jmp_buf *> g_handlerStack;
+    thread_local int64_t g_excValue = 0;
+}
+
+extern "C"
+{
+    // Register a setjmp buffer as the innermost active exception handler.
+    void __tocin_try_register(void *buf)
+    {
+        g_handlerStack.push_back(static_cast<std::jmp_buf *>(buf));
+    }
+
+    // Remove the innermost handler (try body completed without throwing).
+    void __tocin_try_pop()
+    {
+        if (!g_handlerStack.empty())
+            g_handlerStack.pop_back();
+    }
+
+    // Return the value carried by the most recently thrown exception.
+    int64_t __tocin_exc_value()
+    {
+        return g_excValue;
+    }
+
+    // Throw: record the value and unwind to the nearest handler via longjmp.
+    // With no active handler the exception is fatal.
+    void __tocin_throw(int64_t value)
+    {
+        g_excValue = value;
+        if (g_handlerStack.empty())
+        {
+            std::fprintf(stderr,
+                         "Tocin: uncaught exception (value=%lld)\n",
+                         static_cast<long long>(value));
+            std::abort();
+        }
+        std::jmp_buf *buf = g_handlerStack.back();
+        g_handlerStack.pop_back();
+        std::longjmp(*buf, 1);
     }
 }

--- a/src/type/type_checker.cpp
+++ b/src/type/type_checker.cpp
@@ -234,6 +234,42 @@ namespace type_checker
         currentType_ = nullptr;
     }
 
+    void TypeChecker::visitTryStmt(ast::TryStmt *stmt)
+    {
+        // try block in its own scope.
+        if (stmt->tryBlock)
+        {
+            pushScope();
+            stmt->tryBlock->accept(*this);
+            popScope();
+        }
+        // catch block: the caught value is bound as an int (exceptions carry a
+        // 64-bit value).
+        if (stmt->catchBlock)
+        {
+            pushScope();
+            if (environment_ && !stmt->catchVar.empty())
+                environment_->define(stmt->catchVar, makeBasic(ast::TypeKind::INT), true);
+            stmt->catchBlock->accept(*this);
+            popScope();
+        }
+        // finally block.
+        if (stmt->finallyBlock)
+        {
+            pushScope();
+            stmt->finallyBlock->accept(*this);
+            popScope();
+        }
+        currentType_ = nullptr;
+    }
+
+    void TypeChecker::visitThrowStmt(ast::ThrowStmt *stmt)
+    {
+        if (stmt->value)
+            stmt->value->accept(*this);
+        currentType_ = nullptr;
+    }
+
     void TypeChecker::visitMoveExpr(void *expr)
     {
         // Not supported; no-op

--- a/src/type/type_checker.cpp
+++ b/src/type/type_checker.cpp
@@ -222,6 +222,18 @@ namespace type_checker
         currentType_ = std::make_shared<ast::BasicType>(ast::TypeKind::UNKNOWN);
     }
 
+    void TypeChecker::visitEnumStmt(ast::EnumStmt *stmt)
+    {
+        // Enum members are integer constants; make them visible by name.
+        auto intType = makeBasic(ast::TypeKind::INT);
+        for (const auto &m : stmt->members)
+        {
+            if (environment_) environment_->define(m.first, intType, true);
+            if (globalEnv_) globalEnv_->define(m.first, intType, true);
+        }
+        currentType_ = nullptr;
+    }
+
     void TypeChecker::visitMoveExpr(void *expr)
     {
         // Not supported; no-op

--- a/src/type/type_checker.h
+++ b/src/type/type_checker.h
@@ -97,6 +97,7 @@ namespace type_checker
         void visitMatchStmt(ast::MatchStmt *stmt) override;
         void visitArrayLiteralExpr(ast::ArrayLiteralExpr *expr) override;
         void visitIndexExpr(ast::IndexExpr *expr) override;
+        void visitEnumStmt(ast::EnumStmt *stmt) override;
         void visitMoveExpr(void *expr) override;
         void visitGoExpr(void *expr) override;
         void visitRuntimeChannelSendExpr(void *expr) override;

--- a/src/type/type_checker.h
+++ b/src/type/type_checker.h
@@ -98,6 +98,8 @@ namespace type_checker
         void visitArrayLiteralExpr(ast::ArrayLiteralExpr *expr) override;
         void visitIndexExpr(ast::IndexExpr *expr) override;
         void visitEnumStmt(ast::EnumStmt *stmt) override;
+        void visitTryStmt(ast::TryStmt *stmt) override;
+        void visitThrowStmt(ast::ThrowStmt *stmt) override;
         void visitMoveExpr(void *expr) override;
         void visitGoExpr(void *expr) override;
         void visitRuntimeChannelSendExpr(void *expr) override;

--- a/tests/cases/concurrency_channel.to
+++ b/tests/cases/concurrency_channel.to
@@ -1,0 +1,18 @@
+// expect: 55
+// Five goroutines (real OS threads) each send a square into a channel; the main
+// thread sums them. The total is order-independent, so the result is stable.
+def worker(ch: channel<int>, n: int) {
+    ch <- n * n;
+}
+
+def main() {
+    let ch = channel<int>();
+    for i in 1..6 {
+        go worker(ch, i);
+    }
+    let total = 0;
+    for i in 0..5 {
+        total = total + <-ch;
+    }
+    return total;
+}

--- a/tests/cases/enums.to
+++ b/tests/cases/enums.to
@@ -1,0 +1,7 @@
+// expect: 6
+enum Color { Red, Green, Blue }
+enum Code { A = 10, B = 20 }
+def main() {
+    // Red=0, Green=1, Blue=2 -> 0+1+2=3 ; plus Color.Blue=2 ; plus 1 = 6
+    return Red + Green + Blue + Color.Blue + 1;
+}

--- a/tests/cases/try_catch.to
+++ b/tests/cases/try_catch.to
@@ -1,0 +1,15 @@
+// expect: 42
+// A thrown value propagates out of a called function to the caller's handler.
+def boom() -> int {
+    throw 42;
+    return 0;
+}
+
+def main() {
+    try {
+        boom();
+    } catch (e) {
+        return e;
+    }
+    return 0;
+}

--- a/tests/cases/try_catch_value.to
+++ b/tests/cases/try_catch_value.to
@@ -1,0 +1,14 @@
+// expect: 7
+// The catch variable is bound to the thrown value and usable in the handler;
+// finally runs and does not change the result.
+def main() {
+    let x = 0;
+    try {
+        throw 7;
+    } catch (e) {
+        x = e;
+    } finally {
+        x = x + 0;
+    }
+    return x;
+}

--- a/tests/cases/try_finally_output.to
+++ b/tests/cases/try_finally_output.to
@@ -1,0 +1,12 @@
+// expect-output: cleanup
+// finally runs even when the try body throws and the exception is caught.
+def main() {
+    try {
+        throw 1;
+    } catch (e) {
+        print("");
+    } finally {
+        println("cleanup");
+    }
+    return 0;
+}

--- a/tests/cases/try_nested_rethrow.to
+++ b/tests/cases/try_nested_rethrow.to
@@ -1,0 +1,15 @@
+// expect: 99
+// An inner try with only a finally re-throws to the outer handler after the
+// finally block runs.
+def main() {
+    try {
+        try {
+            throw 99;
+        } finally {
+            print("");
+        }
+    } catch (e) {
+        return e;
+    }
+    return 0;
+}

--- a/tests/test_parser.cpp
+++ b/tests/test_parser.cpp
@@ -116,3 +116,25 @@ TEST(Parser, ParsesMultipleTopLevelDeclarations) {
     auto stmts = topLevel(root);
     ASSERT_TRUE(stmts.size() >= 2);
 }
+
+TEST(Parser, ParsesTryCatchFinally) {
+    auto root = parseProgram(
+        "def m() { try { throw 1; } catch (e) { return e; } finally { return 0; } }");
+    auto fn = std::dynamic_pointer_cast<ast::FunctionStmt>(topLevel(root)[0]);
+    auto body = std::dynamic_pointer_cast<ast::BlockStmt>(fn->body);
+    auto tryStmt = std::dynamic_pointer_cast<ast::TryStmt>(body->statements[0]);
+    ASSERT_TRUE(tryStmt != nullptr);
+    ASSERT_TRUE(tryStmt->tryBlock != nullptr);
+    ASSERT_EQ(std::string("e"), tryStmt->catchVar);
+    ASSERT_TRUE(tryStmt->catchBlock != nullptr);
+    ASSERT_TRUE(tryStmt->finallyBlock != nullptr);
+}
+
+TEST(Parser, ParsesThrowStatement) {
+    auto root = parseProgram("def m() { throw 42; }");
+    auto fn = std::dynamic_pointer_cast<ast::FunctionStmt>(topLevel(root)[0]);
+    auto body = std::dynamic_pointer_cast<ast::BlockStmt>(fn->body);
+    auto thr = std::dynamic_pointer_cast<ast::ThrowStmt>(body->statements[0]);
+    ASSERT_TRUE(thr != nullptr);
+    ASSERT_TRUE(thr->value != nullptr);
+}


### PR DESCRIPTION
## Summary

Adds two language features end-to-end, verified through both the JIT (`--run`) and native-AOT (`-o`) paths:

- **Enums** — `enum Color { Red, Green, Blue }` with auto-incrementing integer constants, usable bare (`Red`) or qualified (`Color.Red`).
- **Error handling** — `throw`, `try { } catch (e) { } finally { }`, with exceptions that unwind across function calls.

## How error handling works

Lowered to a `setjmp`/`longjmp` model:

- Each `try` allocates a `jmp_buf`, registers it on a thread-local handler stack, and arms `setjmp` (call marked `returns_twice`).
- `throw v` records a 64-bit value and `longjmp`s to the nearest handler; an uncaught throw prints a diagnostic and aborts.
- `finally` is emitted inline on the normal, caught, and no-catch re-throw paths, so it always runs. A `try` with only a `finally` re-propagates to the enclosing handler after the finally block runs.
- The runtime lives in the LLVM-free `tocin_runtime` library, so it links into native binaries; the JIT registers the new `__tocin_*` symbols and `setjmp`/`longjmp` resolve from libc.

```tocin
def divide(a: int, b: int) -> int {
    if b == 0 { throw 1; }
    return a / b;
}

def main() {
    try {
        let r = divide(10, 0);
    } catch (e) {
        println("error code {}", e);   // error code 1
    } finally {
        println("done");               // always runs
    }
    return 0;
}
```

## Codegen robustness

`visitBlockStmt` now stops emitting statements after a terminator **within the current function**, so dead code after `throw`/`return` (e.g. `throw x; return 0;`) no longer produces invalid IR. The parent-function check prevents this from tripping at the top level, where the builder is left pointing at the previous function's terminated block between declarations.

## Testing

- New `tocin_runtime_shared` library so the `lli`-based `.to` runner can resolve the `__tocin_*` runtime symbols; the runner now `-load`s it. This also unlocks running concurrency programs under the suite.
- New `.to` cases: `try_catch`, `try_catch_value`, `try_finally_output`, `try_nested_rethrow`, `concurrency_channel` — **40 cases total, all passing**.
- Parser unit tests for `try`/`catch`/`finally` and `throw` (all 5 C++ unit-test suites pass).
- `examples/errors.to`; README documents error handling + enums; CI builds the shared runtime on Linux and macOS.

## Scope notes (honest limitations)

- Thrown values carry an integer code today; throwing/binding arbitrary typed payloads is future work.
- `finally` is guaranteed on the normal, caught, and no-catch-rethrow paths; an exception thrown *inside* a `catch`, or an early `return` inside `try`, currently bypasses `finally`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Fih5HHhUzVNkusdaXHoSdu

---
_Generated by [Claude Code](https://claude.ai/code/session_01Fih5HHhUzVNkusdaXHoSdu)_