### PR TITLE
Function-like macros wired into the compile pipeline

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -516,6 +516,7 @@ if(ENABLE_TESTING)
         tests/test_type_checker.cpp
         tests/test_codegen.cpp
         tests/test_optimizer.cpp
+        tests/test_macros.cpp
     )
     
     target_include_directories(tocin_tests PRIVATE
@@ -533,6 +534,7 @@ if(ENABLE_TESTING)
     add_test(NAME TypeCheckerTests COMMAND tocin_tests --filter=TypeChecker)
     add_test(NAME CodeGenTests COMMAND tocin_tests --filter=CodeGen)
     add_test(NAME OptimizerTests COMMAND tocin_tests --filter=Optimizer)
+    add_test(NAME MacroTests COMMAND tocin_tests --filter=Macro)
     
     message(STATUS "Testing enabled - use 'ctest' to run tests")
 endif()

--- a/README.md
+++ b/README.md
@@ -37,6 +37,9 @@ clear what is implemented versus planned.
   send/receive, in both JIT and native builds.
 - **Modules** — `import a.b.c` / `import "path"` resolves and merges other `.to`
   files; a small standard library ships in `stdlib/std/` (math, list).
+- **Macros** — function-like `macro name(params) { body }` expanded at the token
+  level before parsing; invoked as `name!(args)` with precedence-safe, composable
+  expansion.
 - **C FFI** — call C library functions via `extern def name(...) -> T;`.
 - **Strings** — string literals and concatenation with `+`.
 - **Math builtins** — `sqrt`, `pow`, `abs`, `min`, `max`, `floor`, trig, and more.
@@ -175,6 +178,18 @@ def main() {
 }
 ```
 
+Function-like macros (`name!(args)`), expanded before parsing:
+
+```tocin
+macro square(x) { x * x }
+macro hypot2(a, b) { square!(a) + square!(b) }   // macros can use macros
+
+def main() {
+    println("{}", square!(2 + 3));   // 25 — arguments are auto-parenthesized
+    return hypot2!(3, 4);            // 25
+}
+```
+
 Error handling with `throw` / `try` / `catch` / `finally`:
 
 ```tocin
@@ -261,7 +276,9 @@ end-to-end**. They are listed honestly so expectations match reality:
 - **Python / JavaScript FFI** — C FFI works via `extern`; deep CPython and V8
   integration is gated behind build flags (V8 is not bundled — it is not
   installable from standard package managers, so CI builds with `-DWITH_V8=OFF`).
-- **Macros** — a macro engine exists but is not yet invoked by the pipeline.
+- **Hygienic / AST macros** — function-like token macros work today (`name!(...)`);
+  hygiene (auto-renaming macro-introduced bindings) and statement/item macros that
+  expand to multiple declarations are future work.
 - **WebAssembly target**, **package manager**, and an **interactive debugger**
   (behind their respective CMake flags).
 - **Advanced optimization** — the standard LLVM `-O0..-O3` pipelines are wired and

--- a/examples/macros.to
+++ b/examples/macros.to
@@ -1,0 +1,17 @@
+// Function-like macros, expanded at the token level before parsing.
+//   tocin examples/macros.to --run
+//
+// A `macro name(params) { body }` definition is invoked as `name!(args)`. Each
+// argument is substituted into the body and auto-parenthesized, and the whole
+// expansion is parenthesized too, so macros compose like expressions and
+// respect operator precedence. Macros may use other macros.
+
+macro square(x) { x * x }
+macro hypot2(a, b) { square!(a) + square!(b) }
+
+def main() {
+    println("square(5)      = {}", square!(5));        // 25
+    println("square(2 + 3)  = {}", square!(2 + 3));    // 25 (precedence safe)
+    println("hypot2(3, 4)   = {}", hypot2!(3, 4));     // 25 (nested macros)
+    return hypot2!(3, 4);
+}

--- a/src/compiler/macro_system.cpp
+++ b/src/compiler/macro_system.cpp
@@ -649,4 +649,230 @@ ast::StmtPtr profileMacro(const MacroContext& context, error::ErrorHandler& erro
 
 } // namespace builtin_macros
 
+// ---------------------------------------------------------------------------
+// Token-level macro expansion (runs between lexing and parsing).
+// ---------------------------------------------------------------------------
+namespace {
+
+struct TokenMacro {
+    std::vector<std::string> params;
+    std::vector<lexer::Token> body;
+    lexer::Token site; // for diagnostics
+};
+
+// Build a synthetic token that borrows position info from a nearby token.
+lexer::Token synth(lexer::TokenType type, const char *value, const lexer::Token &at) {
+    return lexer::Token(type, value, at.filename, at.line, at.column);
+}
+
+bool isOpenBracket(lexer::TokenType t) {
+    return t == lexer::TokenType::LEFT_PAREN ||
+           t == lexer::TokenType::LEFT_BRACKET ||
+           t == lexer::TokenType::LEFT_BRACE;
+}
+bool isCloseBracket(lexer::TokenType t) {
+    return t == lexer::TokenType::RIGHT_PAREN ||
+           t == lexer::TokenType::RIGHT_BRACKET ||
+           t == lexer::TokenType::RIGHT_BRACE;
+}
+
+} // namespace
+
+std::vector<lexer::Token> expandMacroTokens(const std::vector<lexer::Token> &input,
+                                            error::ErrorHandler &errorHandler) {
+    using lexer::Token;
+    using lexer::TokenType;
+
+    const size_t n = input.size();
+
+    // --- Pass 1: collect `macro name(params) { body }` definitions, removing
+    //     them from the token stream. ---
+    std::unordered_map<std::string, TokenMacro> macros;
+    std::vector<Token> stripped;
+    stripped.reserve(n);
+
+    size_t i = 0;
+    while (i < n) {
+        const Token &t = input[i];
+        const bool isDef = t.type == TokenType::IDENTIFIER && t.value == "macro" &&
+                           i + 2 < n &&
+                           input[i + 1].type == TokenType::IDENTIFIER &&
+                           input[i + 2].type == TokenType::LEFT_PAREN;
+        if (!isDef) {
+            stripped.push_back(t);
+            ++i;
+            continue;
+        }
+
+        TokenMacro m;
+        m.site = t;
+        const std::string name = input[i + 1].value;
+        size_t j = i + 3; // first token after '('
+
+        // Parameter list: comma-separated identifiers up to ')'.
+        bool paramsOk = true;
+        while (j < n && input[j].type != TokenType::RIGHT_PAREN) {
+            if (input[j].type == TokenType::IDENTIFIER) {
+                m.params.push_back(input[j].value);
+            } else if (input[j].type != TokenType::COMMA) {
+                errorHandler.reportError(error::ErrorCode::S006_INVALID_FUNCTION_DECLARATION,
+                                         "Invalid parameter in macro '" + name + "'",
+                                         input[j], error::ErrorSeverity::FATAL);
+                paramsOk = false;
+                break;
+            }
+            ++j;
+        }
+        if (!paramsOk) break;
+        if (j >= n) {
+            errorHandler.reportError(error::ErrorCode::S006_INVALID_FUNCTION_DECLARATION,
+                                     "Unterminated parameter list in macro '" + name + "'",
+                                     t, error::ErrorSeverity::FATAL);
+            break;
+        }
+        ++j; // skip ')'
+        if (j >= n || input[j].type != TokenType::LEFT_BRACE) {
+            errorHandler.reportError(error::ErrorCode::S006_INVALID_FUNCTION_DECLARATION,
+                                     "Expected '{' to open body of macro '" + name + "'",
+                                     t, error::ErrorSeverity::FATAL);
+            break;
+        }
+        ++j; // skip '{'
+
+        // Body: tokens up to the matching '}'.
+        int depth = 1;
+        bool bodyOk = false;
+        while (j < n) {
+            if (input[j].type == TokenType::LEFT_BRACE) {
+                ++depth;
+            } else if (input[j].type == TokenType::RIGHT_BRACE) {
+                --depth;
+                if (depth == 0) { bodyOk = true; break; }
+            }
+            m.body.push_back(input[j]);
+            ++j;
+        }
+        if (!bodyOk) {
+            errorHandler.reportError(error::ErrorCode::S006_INVALID_FUNCTION_DECLARATION,
+                                     "Unterminated body in macro '" + name + "'",
+                                     t, error::ErrorSeverity::FATAL);
+            break;
+        }
+        ++j; // skip closing '}'
+
+        macros[name] = std::move(m);
+        i = j;
+    }
+
+    if (errorHandler.hasFatalErrors())
+        return input;
+    if (macros.empty())
+        return input; // fast path: nothing to expand
+
+    // --- Pass 2: replace `name!(args)` invocations with substituted bodies,
+    //     iterating to a fixed point so macros can invoke other macros. ---
+    const int kMaxRounds = 128;
+    std::vector<Token> cur = std::move(stripped);
+    for (int round = 0; round < kMaxRounds; ++round) {
+        std::vector<Token> next;
+        next.reserve(cur.size());
+        bool expandedAny = false;
+
+        size_t k = 0;
+        const size_t cn = cur.size();
+        while (k < cn) {
+            const bool isCall = cur[k].type == TokenType::IDENTIFIER &&
+                                macros.count(cur[k].value) && k + 2 < cn &&
+                                cur[k + 1].type == TokenType::BANG &&
+                                cur[k + 2].type == TokenType::LEFT_PAREN;
+            if (!isCall) {
+                next.push_back(cur[k]);
+                ++k;
+                continue;
+            }
+
+            const Token callTok = cur[k];
+            const TokenMacro &def = macros[callTok.value];
+
+            // Split arguments on top-level commas until the matching ')'.
+            std::vector<std::vector<Token>> args;
+            std::vector<Token> arg;
+            int depth = 1;
+            size_t a = k + 3;
+            bool closed = false;
+            for (; a < cn; ++a) {
+                const TokenType tt = cur[a].type;
+                if (tt == TokenType::LEFT_PAREN || tt == TokenType::LEFT_BRACKET ||
+                    tt == TokenType::LEFT_BRACE) {
+                    ++depth;
+                } else if (tt == TokenType::RIGHT_PAREN || tt == TokenType::RIGHT_BRACKET ||
+                           tt == TokenType::RIGHT_BRACE) {
+                    --depth;
+                    if (depth == 0) {
+                        if (!arg.empty() || !args.empty())
+                            args.push_back(arg);
+                        closed = true;
+                        ++a;
+                        break;
+                    }
+                } else if (tt == TokenType::COMMA && depth == 1) {
+                    args.push_back(arg);
+                    arg.clear();
+                    continue;
+                }
+                arg.push_back(cur[a]);
+            }
+
+            if (!closed) {
+                errorHandler.reportError(error::ErrorCode::S001_UNEXPECTED_TOKEN,
+                                         "Unterminated invocation of macro '" + callTok.value + "'",
+                                         callTok, error::ErrorSeverity::FATAL);
+                return input;
+            }
+            if (args.size() != def.params.size()) {
+                errorHandler.reportError(error::ErrorCode::S001_UNEXPECTED_TOKEN,
+                                         "Macro '" + callTok.value + "' expects " +
+                                             std::to_string(def.params.size()) + " argument(s), got " +
+                                             std::to_string(args.size()),
+                                         callTok, error::ErrorSeverity::FATAL);
+                return input;
+            }
+
+            std::unordered_map<std::string, const std::vector<Token> *> argOf;
+            for (size_t p = 0; p < def.params.size(); ++p)
+                argOf[def.params[p]] = &args[p];
+
+            // Emit `( body-with-substitutions )`.
+            next.push_back(synth(TokenType::LEFT_PAREN, "(", callTok));
+            for (const Token &bt : def.body) {
+                auto it = bt.type == TokenType::IDENTIFIER ? argOf.find(bt.value) : argOf.end();
+                if (it != argOf.end()) {
+                    next.push_back(synth(TokenType::LEFT_PAREN, "(", bt));
+                    for (const Token &at : *it->second)
+                        next.push_back(at);
+                    next.push_back(synth(TokenType::RIGHT_PAREN, ")", bt));
+                } else {
+                    next.push_back(bt);
+                }
+            }
+            next.push_back(synth(TokenType::RIGHT_PAREN, ")", callTok));
+
+            expandedAny = true;
+            k = a; // resume after the invocation
+        }
+
+        cur = std::move(next);
+        if (!expandedAny)
+            break;
+        if (round == kMaxRounds - 1) {
+            errorHandler.reportError(error::ErrorCode::C001_UNIMPLEMENTED_FEATURE,
+                                     "Macro expansion did not terminate (recursive macro?)",
+                                     error::ErrorSeverity::FATAL);
+            return input;
+        }
+    }
+
+    return cur;
+}
+
 } // namespace compiler 

--- a/src/compiler/macro_system.h
+++ b/src/compiler/macro_system.h
@@ -155,6 +155,22 @@ private:
 };
 
 /**
+ * @brief Expand function-like macros at the token level, before parsing.
+ *
+ * Definitions use `macro name(p1, p2) { body-tokens }` and invocations use
+ * `name!(arg-tokens, ...)`. Each invocation is replaced by the macro body with
+ * parameters textually substituted by the (parenthesized) argument tokens; the
+ * whole expansion is parenthesized so it composes safely as an expression.
+ * Expansion iterates to a fixed point so macros may use other macros. The
+ * returned token stream has all definitions removed and invocations expanded.
+ *
+ * This is intentionally unhygienic (C-style): identifiers introduced by a macro
+ * body are not renamed. Macros are expression-shaped and file-local.
+ */
+std::vector<lexer::Token> expandMacroTokens(const std::vector<lexer::Token> &tokens,
+                                            error::ErrorHandler &errorHandler);
+
+/**
  * @brief Built-in macros
  */
 namespace builtin_macros {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -166,20 +166,23 @@ public:
     bool compile(const std::string &source, const std::string &filename,
                  const CompilationOptions &options = CompilationOptions())
     {
-        std::string processedSource = source;
-        
-        // Process macros if enabled
-        if (options.enableMacros) {
-            processedSource = processMacros(source, filename);
-        }
-
         // Lexical analysis
-        lexer::Lexer lexer(processedSource, filename, 4);
+        lexer::Lexer lexer(source, filename, 4);
         std::vector<lexer::Token> tokens = lexer.tokenize();
 
         if (errorHandler.hasFatalErrors())
         {
             return false;
+        }
+
+        // Expand function-like macros at the token level, before parsing.
+        if (options.enableMacros)
+        {
+            tokens = compiler::expandMacroTokens(tokens, errorHandler);
+            if (errorHandler.hasFatalErrors())
+            {
+                return false;
+            }
         }
 
         // Parsing

--- a/tests/cases/macros_expr.to
+++ b/tests/cases/macros_expr.to
@@ -1,0 +1,9 @@
+// expect: 25
+// A function-like macro is expanded at the token level before parsing.
+// Arguments are auto-parenthesized, so precedence is preserved:
+// square!(2 + 3) -> ((2 + 3) * (2 + 3)) = 25, not 2 + 3*2 + 3.
+macro square(x) { x * x }
+
+def main() {
+    return square!(2 + 3);
+}

--- a/tests/cases/macros_nested.to
+++ b/tests/cases/macros_nested.to
@@ -1,0 +1,8 @@
+// expect: 25
+// Macros may invoke other macros; expansion iterates to a fixed point.
+macro square(x) { x * x }
+macro sumsq(a, b) { square!(a) + square!(b) }
+
+def main() {
+    return sumsq!(3, 4);   // 9 + 16
+}

--- a/tests/cases/macros_stmt.to
+++ b/tests/cases/macros_stmt.to
@@ -1,0 +1,8 @@
+// expect-output: hi Tocin
+// A macro can wrap a call so it reads as a statement at the use site.
+macro greet(name) { println("hi {}", name) }
+
+def main() {
+    greet!("Tocin");
+    return 0;
+}

--- a/tests/test_macros.cpp
+++ b/tests/test_macros.cpp
@@ -1,0 +1,69 @@
+#include "test_framework.h"
+#include "../src/lexer/lexer.h"
+#include "../src/compiler/macro_system.h"
+#include "../src/error/error_handler.h"
+
+using namespace lexer;
+
+// Lex source, run the token-level macro expander, and return the token values
+// (excluding EOF) joined by spaces — a compact form to assert against.
+static std::string expandToString(const std::string &src, bool &hadError) {
+    Lexer lex(src, "test.to");
+    auto toks = lex.tokenize();
+    error::ErrorHandler eh("test.to");
+    auto out = compiler::expandMacroTokens(toks, eh);
+    hadError = eh.hasErrors();
+    std::string s;
+    for (const auto &t : out) {
+        if (t.type == TokenType::EOF_TOKEN) continue;
+        if (!s.empty()) s += ' ';
+        s += t.value;
+    }
+    return s;
+}
+
+TEST_SUITE(Macro)
+
+TEST(Macro, DefinitionIsRemoved) {
+    bool err = false;
+    auto s = expandToString("macro id(x) { x }\nlet y = 1;", err);
+    ASSERT_TRUE(!err);
+    // The definition tokens must not survive into the output.
+    ASSERT_TRUE(s.find("macro") == std::string::npos);
+    ASSERT_TRUE(s.find("let y = 1 ;") != std::string::npos);
+}
+
+TEST(Macro, InvocationIsExpandedWithParens) {
+    bool err = false;
+    auto s = expandToString("macro square(x) { x * x }\nlet y = square!(2 + 3);", err);
+    ASSERT_TRUE(!err);
+    // Argument is parenthesized and the whole body wrapped: ((2 + 3) * (2 + 3)).
+    ASSERT_TRUE(s.find("( ( 2 + 3 ) * ( 2 + 3 ) )") != std::string::npos);
+    // No bang/invocation tokens remain.
+    ASSERT_TRUE(s.find("!") == std::string::npos);
+}
+
+TEST(Macro, NestedMacrosExpandToFixedPoint) {
+    bool err = false;
+    auto s = expandToString(
+        "macro square(x) { x * x }\n"
+        "macro sumsq(a, b) { square!(a) + square!(b) }\n"
+        "let z = sumsq!(3, 4);",
+        err);
+    ASSERT_TRUE(!err);
+    ASSERT_TRUE(s.find("square") == std::string::npos); // fully expanded
+    ASSERT_TRUE(s.find("!") == std::string::npos);
+}
+
+TEST(Macro, ArgumentCountMismatchIsAnError) {
+    bool err = false;
+    expandToString("macro add(a, b) { a + b }\nlet q = add!(1);", err);
+    ASSERT_TRUE(err);
+}
+
+TEST(Macro, SourceWithoutMacrosIsUnchanged) {
+    bool err = false;
+    auto s = expandToString("def main() { return 1 + 2; }", err);
+    ASSERT_TRUE(!err);
+    ASSERT_TRUE(s.find("def main ( ) { return 1 + 2 ; }") != std::string::npos);
+}


### PR DESCRIPTION
## Summary

Implements **function-like macros** as a token-level transformation that runs between lexing and parsing. The previous `processMacros` hook in the driver was a no-op placeholder; this makes macros real and end-to-end.

Because `macro` already lexes as an identifier and `!` as `BANG`, this needed **zero** changes to the lexer, parser, AST, or any visitor — it's a self-contained pass over the token stream, fully decoupled from the rest of the compiler.

```tocin
macro square(x) { x * x }
macro hypot2(a, b) { square!(a) + square!(b) }   // macros can use macros

def main() {
    println("{}", square!(2 + 3));   // 25 — arguments are auto-parenthesized
    return hypot2!(3, 4);            // 25
}
```

## How it works

- **Definitions** — `macro name(p1, p2) { body-tokens }` are collected and stripped from the stream (order-independent).
- **Invocations** — `name!(args)` are replaced by the macro body with parameters substituted by the argument token sequences.
- **Precedence-safe** — each argument and the whole expansion are parenthesized, so `square!(2 + 3)` expands to `((2 + 3) * (2 + 3))` = 25, not 11.
- **Composable** — expansion iterates to a fixed point, so macros may invoke other macros; a round cap guards against infinite recursion.
- **Diagnostics** — fatal, located errors for arg-count mismatch and malformed definitions; honors `--no-macros`.

## Testing

- C++ unit tests — new `tests/test_macros.cpp` (MacroTests suite): definition removal, parenthesized expansion, nesting to a fixed point, arg-count error, and the no-macro passthrough. **6/6 unit suites pass.**
- `.to` integration cases — `macros_expr`, `macros_nested`, `macros_stmt`. **43 cases total, all passing** in both JIT and native.
- `examples/macros.to`; README documents macros in Highlights, the language tour, and the roadmap.

## Scope notes (honest limitations)

- Macros are **unhygienic** (C-style): identifiers introduced by a macro body are not auto-renamed.
- Macros are **expression-shaped** and **file-local**: they expand in place and don't (yet) produce multiple top-level declarations or cross files. Hygiene and item/statement macros are noted as future work in the roadmap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Fih5HHhUzVNkusdaXHoSdu

---
_Generated by [Claude Code](https://claude.ai/code/session_01Fih5HHhUzVNkusdaXHoSdu)_