### PR TITLE
Generic classes (class C&lt;T&gt;) via monomorphization

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,9 @@ clear what is implemented versus planned.
   mutation, and method calls.
 - **Traits & impl** — `trait` interfaces and `impl [Trait for] Type` blocks with
   per-type method dispatch.
-- **Generics** — `def f<T>(...)` monomorphized per concrete type at the call site.
+- **Generics** — `def f<T>(...)` functions and `class C<T>` classes, both
+  monomorphized per concrete type (type arguments inferred at the call/constructor
+  site).
 - **Arrays** — array literals, indexing (read/write), `len`, iteration, and arrays
   as reference-typed function parameters.
 - **Concurrency** — `go f(args)` goroutines (real OS threads) and typed `channel<T>`
@@ -163,6 +165,24 @@ def main() {
 }
 ```
 
+Generic classes (`class C<T>`), monomorphized per type argument:
+
+```tocin
+class Box<T> {
+    value: T;
+    def get(self) -> T { return self.value; }
+    def set(self, v: T) { self.value = v; }
+}
+
+def main() {
+    let bi = Box(42);                     // Box<int>
+    bi.set(100);
+    let bf = Box(1.5);                    // Box<float> — a separate instantiation
+    println("{} {}", bi.get(), bf.get()); // 100 1.5
+    return bi.get();
+}
+```
+
 Goroutines and channels:
 
 ```tocin
@@ -261,8 +281,9 @@ bash scripts/run_to_tests.sh                      # .to integration programs
 These features are planned or partially scaffolded but **not yet fully working
 end-to-end**. They are listed honestly so expectations match reality:
 
-- **Generic classes** — generic *functions* are monomorphized today; generic
-  `class C<T>` instantiation is still pending (generic free functions work).
+- **Explicit generic type arguments** — generic functions and classes infer their
+  type arguments from the call/constructor today; turbofish-style annotations
+  (`Box<int>(...)`) and generic types in parameter/field signatures are pending.
 - **LINQ-style collections** — `where` / `select` / `aggregate` over collections.
 - **Pattern matching destructuring** — `match` works on values today; binding
   sub-patterns (e.g. `case Some(x)`) is pending.

--- a/examples/generics_class.to
+++ b/examples/generics_class.to
@@ -1,0 +1,30 @@
+// Generic classes: class C<T> is monomorphized per concrete type argument,
+// inferred from the constructor call.
+//   tocin examples/generics_class.to --run
+
+class Box<T> {
+    value: T;
+    def get(self) -> T { return self.value; }
+    def set(self, v: T) { self.value = v; }
+}
+
+class Pair<A, B> {
+    first: A;
+    second: B;
+    def sum(self) -> A { return self.first + self.second; }
+}
+
+def main() {
+    let bi = Box(42);                          // Box<int>
+    println("box(int)   = {}", bi.get());      // 42
+    bi.set(100);
+    println("after set  = {}", bi.get());      // 100
+
+    let bf = Box(1.5);                          // Box<float> — separate instance
+    println("box(float) = {}", bf.get());      // 1.5
+
+    let p = Pair(20, 22);
+    println("pair sum   = {}", p.sum());        // 42
+
+    return p.sum();
+}

--- a/src/codegen/ir_generator.cpp
+++ b/src/codegen/ir_generator.cpp
@@ -995,6 +995,75 @@ void IRGenerator::visitCallExpr(ast::CallExpr *expr)
         }
     }
 
+    // Generic constructor call: Box(args) infers the type arguments from the
+    // argument types, monomorphizes the class, and constructs an instance.
+    if (auto ctorName = std::dynamic_pointer_cast<ast::VariableExpr>(expr->callee))
+    {
+        auto git = genericClasses.find(ctorName->name);
+        if (git != genericClasses.end())
+        {
+            ast::ClassStmt *tmpl = git->second;
+
+            std::vector<llvm::Value *> argVals;
+            for (const auto &a : expr->arguments)
+            {
+                a->accept(*this);
+                if (!lastValue) return;
+                argVals.push_back(lastValue);
+            }
+
+            // Infer bindings by matching each field's declared type-parameter
+            // name against the corresponding argument's concrete type.
+            std::set<std::string> tparams;
+            for (const auto &tp : tmpl->typeParameters)
+                tparams.insert(tp.getName());
+            std::map<std::string, llvm::Type *> bindings;
+            size_t fi = 0;
+            for (const auto &fieldStmt : tmpl->fields)
+            {
+                auto var = std::dynamic_pointer_cast<ast::VariableStmt>(fieldStmt);
+                if (!var) continue;
+                std::string ftName = var->type ? var->type->toString() : "";
+                if (tparams.count(ftName) && fi < argVals.size() && !bindings.count(ftName))
+                    bindings[ftName] = argVals[fi]->getType();
+                ++fi;
+            }
+            for (const auto &tp : tmpl->typeParameters)
+                if (!bindings.count(tp.getName()))
+                    bindings[tp.getName()] = llvm::Type::getInt64Ty(context);
+
+            std::string mangled = instantiateGenericClass(tmpl, bindings);
+            const ClassInfo &ci = classTypes[mangled];
+            llvm::StructType *st = ci.classType;
+
+            llvm::Function *mallocFn = stdLibFunctions["malloc"];
+            llvm::Value *size = llvm::ConstantExpr::getSizeOf(st);
+            llvm::Value *obj = builder.CreateCall(mallocFn->getFunctionType(), mallocFn,
+                                                  {size}, ctorName->name + ".obj");
+            for (size_t i = 0; i < argVals.size() && i < ci.memberNames.size(); ++i)
+            {
+                llvm::Value *fieldVal = argVals[i];
+                llvm::Type *fieldTy = st->getStructElementType(i);
+                if (fieldVal->getType() != fieldTy)
+                {
+                    if (fieldVal->getType()->isIntegerTy() && fieldTy->isIntegerTy())
+                        fieldVal = builder.CreateIntCast(fieldVal, fieldTy, true, "fcast");
+                    else if (fieldVal->getType()->isFloatingPointTy() && fieldTy->isFloatingPointTy())
+                        fieldVal = builder.CreateFPCast(fieldVal, fieldTy, "fcast");
+                }
+                std::vector<llvm::Value *> idx = {
+                    llvm::ConstantInt::get(llvm::Type::getInt32Ty(context), 0),
+                    llvm::ConstantInt::get(llvm::Type::getInt32Ty(context), (unsigned)i)};
+                llvm::Value *fp = builder.CreateGEP(st, obj, idx, "init." + ci.memberNames[i]);
+                builder.CreateStore(fieldVal, fp);
+            }
+            lastValue = obj;
+            lastExprClassName = mangled;
+            genericCtorClass[expr] = mangled;
+            return;
+        }
+    }
+
     // Method call: receiver.method(args) -> ClassName_method(receiver, args).
     if (auto methodCallee = std::dynamic_pointer_cast<ast::GetExpr>(expr->callee))
     {
@@ -2230,6 +2299,10 @@ std::string IRGenerator::getExprClassName(const ast::ExprPtr &expr)
     }
     if (auto call = std::dynamic_pointer_cast<ast::CallExpr>(expr))
     {
+        // Generic constructor call resolved earlier to a mangled class name.
+        auto gc = genericCtorClass.find(call.get());
+        if (gc != genericCtorClass.end())
+            return gc->second;
         // Constructor call: ClassName(...)
         if (auto callee = std::dynamic_pointer_cast<ast::VariableExpr>(call->callee))
             if (classTypes.count(callee->name))
@@ -2398,6 +2471,58 @@ llvm::Function *IRGenerator::emitGenericInstance(ast::FunctionStmt *stmt,
     if (savedBlock)
         builder.SetInsertPoint(savedBlock);
     return function;
+}
+
+std::string IRGenerator::instantiateGenericClass(ast::ClassStmt *stmt,
+                                                 const std::map<std::string, llvm::Type *> &bindings)
+{
+    // Mangle the concrete class name from its type arguments (e.g. Box$i64).
+    std::string mangled = stmt->name;
+    for (const auto &tp : stmt->typeParameters)
+    {
+        auto it = bindings.find(tp.getName());
+        mangled += "$" + (it != bindings.end() ? llvmTypeName(it->second) : "t");
+    }
+    if (classTypes.count(mangled))
+        return mangled; // already instantiated
+
+    // Bind type parameters while we build the struct and method signatures.
+    auto savedBindings = typeBindings;
+    typeBindings = bindings;
+
+    // Build the concrete struct from the fields (type params now resolved).
+    ClassInfo info;
+    std::vector<llvm::Type *> fieldTypes;
+    for (const auto &fieldStmt : stmt->fields)
+    {
+        auto var = std::dynamic_pointer_cast<ast::VariableStmt>(fieldStmt);
+        if (!var)
+            continue;
+        llvm::Type *ft = var->type ? getLLVMType(var->type) : llvm::Type::getInt64Ty(context);
+        info.memberNames.push_back(var->name);
+        info.memberTypes[var->name] = ft;
+        fieldTypes.push_back(ft);
+    }
+    llvm::StructType *structType = llvm::StructType::getTypeByName(context, mangled);
+    if (!structType)
+        structType = llvm::StructType::create(context, fieldTypes, mangled);
+    else
+        structType->setBody(fieldTypes);
+    info.classType = structType;
+    info.baseClass = nullptr;
+    classTypes[mangled] = info; // register before methods so they can reference it
+
+    // Declare all method prototypes first (so methods can call each other),
+    // then generate their bodies — all under the mangled class name.
+    for (const auto &methodStmt : stmt->methods)
+        if (auto method = std::dynamic_pointer_cast<ast::FunctionStmt>(methodStmt))
+            declareMethodProto(mangled, structType, method.get());
+    for (const auto &methodStmt : stmt->methods)
+        if (auto method = std::dynamic_pointer_cast<ast::FunctionStmt>(methodStmt))
+            generateMethod(mangled, structType, method.get());
+
+    typeBindings = savedBindings;
+    return mangled;
 }
 
 void IRGenerator::visitEnumStmt(ast::EnumStmt *stmt)
@@ -3292,7 +3417,12 @@ void IRGenerator::predeclareTopLevel(ast::StmtPtr ast)
     for (auto &s : stmts)
     {
         if (auto cls = std::dynamic_pointer_cast<ast::ClassStmt>(s))
-            registerClassType(cls.get());
+        {
+            if (cls->isGeneric())
+                genericClasses[cls->name] = cls.get(); // instantiated lazily per type argument
+            else
+                registerClassType(cls.get());
+        }
         else if (auto en = std::dynamic_pointer_cast<ast::EnumStmt>(s))
             visitEnumStmt(en.get());
     }

--- a/src/codegen/ir_generator.h
+++ b/src/codegen/ir_generator.h
@@ -167,6 +167,8 @@ namespace codegen
         std::string lastExprClassName;                                             // Class name of the most recent expression value
         llvm::Type *lastExprArrayElem = nullptr;                                  // Element type of the most recent array expression
         std::map<std::string, ast::FunctionStmt *> genericFunctions;             // name -> generic function template
+        std::map<std::string, ast::ClassStmt *> genericClasses;                  // name -> generic class template
+        std::map<const ast::CallExpr *, std::string> genericCtorClass;           // generic constructor call -> mangled class name
         std::map<std::string, int64_t> enumConstants;                           // EnumName.Member and Member -> value
         std::map<std::string, llvm::Type *> typeBindings;                        // active type-parameter bindings during instantiation
         std::map<std::string, llvm::Function *> stdLibFunctions;                   // Standard library functions
@@ -267,6 +269,10 @@ namespace codegen
         // Monomorphize a generic function for a concrete set of type bindings.
         llvm::Function *emitGenericInstance(ast::FunctionStmt *stmt,
                                             const std::map<std::string, llvm::Type *> &bindings);
+        // Monomorphize a generic class: build the concrete struct + methods for a
+        // set of type bindings and register it. Returns the mangled class name.
+        std::string instantiateGenericClass(ast::ClassStmt *stmt,
+                                             const std::map<std::string, llvm::Type *> &bindings);
         std::string llvmTypeName(llvm::Type *t);
     };
 

--- a/src/type/type_checker.cpp
+++ b/src/type/type_checker.cpp
@@ -875,6 +875,9 @@ namespace type_checker
         std::unordered_set<std::string> typeParamNames;
         for (const auto &tp : stmt->typeParameters)
             typeParamNames.insert(tp.getName());
+        // Type parameters of the enclosing generic class are abstract here too.
+        for (const auto &name : classTypeParams_)
+            typeParamNames.insert(name);
         auto resolveParamType = [&](const ast::TypePtr &t) -> ast::TypePtr {
             if (t)
             {
@@ -897,8 +900,13 @@ namespace type_checker
         currentReturnTypes_ = &returnTypes;
         inAsyncContext_ = stmt->isAsync;
 
-        // Generic functions return an abstract type parameter; check permissively.
-        const bool unannotated = isUnannotatedReturn(stmt->returnType) || stmt->isGeneric();
+        // Generic functions (and methods whose return type is a type parameter)
+        // return an abstract type; check permissively.
+        bool returnIsTypeParam = false;
+        if (auto s = std::dynamic_pointer_cast<ast::SimpleType>(stmt->returnType))
+            returnIsTypeParam = typeParamNames.count(s->toString()) > 0;
+        const bool unannotated =
+            isUnannotatedReturn(stmt->returnType) || stmt->isGeneric() || returnIsTypeParam;
         if (!unannotated)
         {
             expectedReturnType_ = canonicalize(stmt->returnType);
@@ -1029,7 +1037,14 @@ namespace type_checker
                                  std::make_shared<ast::ClassType>(stmt->token, stmt->name), true);
         }
 
-        // Check field declarations and methods within a class scope.
+        // Check field declarations and methods within a class scope. For a
+        // generic class, expose its type parameters so methods that mention them
+        // (fields of type T, `-> T` returns) are checked permissively.
+        auto savedClassTypeParams = classTypeParams_;
+        classTypeParams_.clear();
+        for (const auto &tp : stmt->typeParameters)
+            classTypeParams_.insert(tp.getName());
+
         pushScope();
         for (auto &field : stmt->fields)
         {
@@ -1043,6 +1058,7 @@ namespace type_checker
         }
         popScope();
 
+        classTypeParams_ = savedClassTypeParams;
         currentType_ = nullptr;
     }
 

--- a/src/type/type_checker.h
+++ b/src/type/type_checker.h
@@ -173,6 +173,9 @@ namespace type_checker
         // True only while visiting the program-root block/module so its direct
         // children share the global environment (top-level scope).
         bool atProgramRoot_ = false;
+        // Type-parameter names of the enclosing generic class (if any); methods
+        // treat these as abstract types and check permissively.
+        std::unordered_set<std::string> classTypeParams_;
 
         // Module related methods
         bool loadModule(const std::string &moduleName);

--- a/tests/cases/generic_class_box.to
+++ b/tests/cases/generic_class_box.to
@@ -1,0 +1,14 @@
+// expect: 100
+// A generic class is monomorphized per concrete type argument inferred from
+// the constructor. Box(42) instantiates Box<int>.
+class Box<T> {
+    value: T;
+    def get(self) -> T { return self.value; }
+    def set(self, v: T) { self.value = v; }
+}
+
+def main() {
+    let b = Box(42);
+    b.set(100);
+    return b.get();
+}

--- a/tests/cases/generic_class_pair.to
+++ b/tests/cases/generic_class_pair.to
@@ -1,0 +1,13 @@
+// expect: 30
+// A generic class with multiple type parameters; each is inferred from the
+// matching constructor argument.
+class Pair<A, B> {
+    first: A;
+    second: B;
+    def total(self) -> A { return self.first + self.second; }
+}
+
+def main() {
+    let p = Pair(10, 20);
+    return p.total();
+}

--- a/tests/cases/generic_class_two_inst.to
+++ b/tests/cases/generic_class_two_inst.to
@@ -1,0 +1,14 @@
+// expect: 7
+// Two instantiations of the same generic class coexist with independent struct
+// layouts: Box<int> (i64) and Box<float> (f64).
+class Box<T> {
+    value: T;
+    def get(self) -> T { return self.value; }
+}
+
+def main() {
+    let bi = Box(7);        // Box<int>
+    let bf = Box(2.5);      // Box<float> — distinct layout + methods
+    let f = bf.get();       // exercises the float instantiation
+    return bi.get();        // 7
+}

--- a/tests/test_parser.cpp
+++ b/tests/test_parser.cpp
@@ -138,3 +138,22 @@ TEST(Parser, ParsesThrowStatement) {
     ASSERT_TRUE(thr != nullptr);
     ASSERT_TRUE(thr->value != nullptr);
 }
+
+TEST(Parser, ParsesGenericClassWithTypeParameters) {
+    auto root = parseProgram(
+        "class Box<T> { value: T; def get(self) -> T { return self.value; } }");
+    auto cls = std::dynamic_pointer_cast<ast::ClassStmt>(topLevel(root)[0]);
+    ASSERT_TRUE(cls != nullptr);
+    ASSERT_EQ(std::string("Box"), cls->name);
+    ASSERT_TRUE(cls->isGeneric());
+    ASSERT_EQ(size_t(1), cls->typeParameters.size());
+    ASSERT_EQ(std::string("T"), cls->typeParameters[0].getName());
+}
+
+TEST(Parser, ParsesGenericClassWithMultipleTypeParameters) {
+    auto root = parseProgram("class Pair<A, B> { first: A; second: B; }");
+    auto cls = std::dynamic_pointer_cast<ast::ClassStmt>(topLevel(root)[0]);
+    ASSERT_TRUE(cls != nullptr);
+    ASSERT_TRUE(cls->isGeneric());
+    ASSERT_EQ(size_t(2), cls->typeParameters.size());
+}


### PR DESCRIPTION
## Summary

Extends the existing monomorphization machinery (already used for generic functions) to **generic classes**. A `class C<T>` is a template: each distinct set of type arguments produces its own concrete struct layout and method set.

```tocin
class Box<T> {
    value: T;
    def get(self) -> T { return self.value; }
    def set(self, v: T) { self.value = v; }
}

def main() {
    let bi = Box(42);                     // Box<int>
    bi.set(100);
    let bf = Box(1.5);                    // Box<float> — a separate instantiation
    println("{} {}", bi.get(), bf.get()); // 100 1.5
    return bi.get();
}
```

## How it works

- **Templates** — `predeclareTopLevel` records generic class declarations in `genericClasses` instead of building a concrete struct.
- **Instantiation** — `instantiateGenericClass()` builds a mangled concrete class (e.g. `Box$i64`): it resolves field types under the active type bindings, creates the LLVM struct, declares all method prototypes, then generates their bodies — reusing the existing `generateMethod` path with `typeBindings` set.
- **Inference** — a constructor call infers type arguments by matching the argument types against the template's field types (`Box(42)` → `Box<int>`, `Box(1.5)` → `Box<float>`), instantiates on demand, and constructs the instance.
- **Dispatch** — `getExprClassName` resolves a generic constructor call to its mangled class via a per-call map, so variable typing, field access, and method dispatch all target the right instantiation.
- **Type checker** — methods of a generic class treat the class's type parameters as abstract (UNKNOWN): parameters typed by a type parameter and `-> T` returns are checked permissively, mirroring generic functions. Real mismatches are still reported.

## Testing

- `.to` integration cases — `generic_class_box`, `generic_class_pair`, `generic_class_two_inst`. **46 cases total, all passing** in both JIT and native.
- Parser unit tests — single and multi type-parameter classes (**6/6 unit suites pass**).
- `examples/generics_class.to`; README documents generic classes in Highlights, the language tour, and the roadmap.

## Scope notes (honest limitations)

- Type arguments are **inferred** from the constructor call. Turbofish-style explicit annotations (`Box<int>(...)`) and using a generic type in parameter/field signatures (`def f(b: Box<int>)`) are noted as future work in the roadmap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Fih5HHhUzVNkusdaXHoSdu

---
_Generated by [Claude Code](https://claude.ai/code/session_01Fih5HHhUzVNkusdaXHoSdu)_