### PR TITLE
Null-safety, Option/Result, select, LINQ, FFI tests — and a codegen bug fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,10 @@ clear what is implemented versus planned.
   `match` / `case` / `default`.
 - **Error handling** — `throw`, `try` / `catch (e)` / `finally`; exceptions unwind
   across function calls (setjmp/longjmp runtime) in both JIT and native builds.
+- **Null safety** — safe navigation `a?.b`, elvis/coalescing `a ?: b`, and
+  force-unwrap `a!!` over nullable references.
+- **Option / Result** — `Some`/`None`/`Ok`/`Err` with destructuring `match`
+  patterns (`case Some(x)`, `case Err(e)`).
 - **Enums** — `enum Color { Red, Green, Blue }` with auto-incrementing integer
   constants, usable bare or qualified (`Color.Red`).
 - **Classes / structs** — fields, methods with `self`, construction, field read and
@@ -35,10 +39,11 @@ clear what is implemented versus planned.
   site).
 - **Arrays** — array literals, indexing (read/write), `len`, iteration, and arrays
   as reference-typed function parameters.
-- **Concurrency** — `go f(args)` goroutines (real OS threads) and typed `channel<T>`
-  send/receive, in both JIT and native builds.
+- **Concurrency** — `go f(args)` goroutines (real OS threads), typed `channel<T>`
+  send/receive, and `select` over multiple channels, in both JIT and native builds.
 - **Modules** — `import a.b.c` / `import "path"` resolves and merges other `.to`
-  files; a small standard library ships in `stdlib/std/` (math, list).
+  files; a small standard library ships in `stdlib/std/` (math, list, LINQ-style
+  collection ops).
 - **Macros** — function-like `macro name(params) { body }` expanded at the token
   level before parsing; invoked as `name!(args)` with precedence-safe, composable
   expansion.
@@ -285,14 +290,16 @@ end-to-end**. They are listed honestly so expectations match reality:
 - **Explicit generic type arguments** — generic functions and classes infer their
   type arguments from the call/constructor today; turbofish-style annotations
   (`Box<int>(...)`) and generic types in parameter/field signatures are pending.
-- **LINQ-style collections** — `where` / `select` / `aggregate` over collections.
-- **Pattern matching destructuring** — `match` works on values today; binding
-  sub-patterns (e.g. `case Some(x)`) is pending.
-- **Null safety** — `?.`, `?:`, `!!` operators and nullable-type flow analysis.
-- **`Option` / `Result`** — types are defined; exhaustiveness checking and `?`
-  propagation pending.
-- **`async` / `await`** — goroutines and channels work; structured async is pending.
-- **`select`** over multiple channels.
+- **Higher-order LINQ** — `where`/`select`/`aggregate` ship today as stdlib
+  functions over int lists (`import std.linq`); arbitrary lambda predicates/maps
+  need first-class function values (pending).
+- **Nullable-type flow analysis** — the `?.`/`?:`/`!!` operators work today;
+  static tracking of which references are nullable is pending.
+- **`Option` / `Result` ergonomics** — `Some`/`None`/`Ok`/`Err` and `case`
+  destructuring work today; exhaustiveness checking, `?` propagation and typed
+  payloads (the bound value is an int slot) are pending.
+- **`async` / `await`** — goroutines, channels and `select` work; structured
+  async is pending.
 - **Typed exceptions** — `throw` / `catch` carry an integer code today; throwing and
   binding arbitrary typed payloads (e.g. error objects) is pending.
 - **Python / JavaScript FFI** — C FFI works via `extern`; deep CPython and V8

--- a/README.md
+++ b/README.md
@@ -42,7 +42,8 @@ clear what is implemented versus planned.
 - **Macros** — function-like `macro name(params) { body }` expanded at the token
   level before parsing; invoked as `name!(args)` with precedence-safe, composable
   expansion.
-- **C FFI** — call C library functions via `extern def name(...) -> T;`.
+- **C FFI** — call C library functions via `extern def name(...) -> T;`, resolved
+  by the JIT and the native linker ([docs/ffi.md](docs/ffi.md)).
 - **Strings** — string literals and concatenation with `+`.
 - **Math builtins** — `sqrt`, `pow`, `abs`, `min`, `max`, `floor`, trig, and more.
 - **Formatted output** — `print` / `println`, including `println("x = {}", x)`.

--- a/docs/ffi.md
+++ b/docs/ffi.md
@@ -1,0 +1,64 @@
+# Foreign Function Interface (FFI)
+
+Tocin can call C functions directly. Python and JavaScript FFI are scaffolded
+but **not yet functional** — see [Status](#status) below.
+
+## C FFI (working)
+
+Declare an external C function with `extern def` (a function with no body), then
+call it like any Tocin function:
+
+```tocin
+extern def labs(x: int) -> int;
+extern def atoi(s: string) -> int;
+
+def main() {
+    println("{}", labs(-42));     // 42
+    return atoi("7");             // 7
+}
+```
+
+- **JIT (`--run`)**: the symbol is resolved from the running process, which is
+  linked against libc/libm, so the C standard library is available out of the
+  box.
+- **Native (`-o out`)**: the external symbol is linked by the C toolchain like
+  any other.
+
+### Type mapping
+
+| Tocin            | C / LLVM            |
+|------------------|---------------------|
+| `int`            | 64-bit integer (`i64`) |
+| `i32` `i16` `i8` | sized integers      |
+| `float`          | `double`            |
+| `f32`            | `float`             |
+| `bool`           | `i1`                |
+| `string`         | `char*`             |
+| `void` (no `-> T`)| `void`             |
+
+### Gotchas
+
+- **Reserved builtin names shadow externs.** A set of names is intercepted by
+  the compiler as builtins and will *not* reach the FFI path even if you declare
+  them `extern`: `sqrt`, `sin`, `cos`, `tan`, `asin`, `acos`, `atan`, `exp`,
+  `log`, `log2`, `log10`, `floor`, `ceil`, `round`, `fabs`, `pow`, `abs`, `min`,
+  `max`, `len`, `print`, `println`. To exercise the real FFI path use other
+  symbols (e.g. `labs`, `atoi`, `getenv`, `putchar`, `hypot`, `toupper`).
+- **`int` is 64-bit.** Declaring a C `int`-returning function (e.g. `atoi`) as
+  `-> int` (i64) works on the x86-64 SysV ABI; use `-> i32` if you need an exact
+  C `int`.
+- **Only declared functions resolve.** Calling an undeclared C function is a
+  compile error; you must `extern def` it first.
+
+See `examples/ffi.to` and `tests/cases/ffi_*.to` for runnable examples.
+
+## Status
+
+| FFI         | Status                                                            |
+|-------------|------------------------------------------------------------------|
+| **C**       | Working (JIT + native), as documented above.                     |
+| **Python**  | Experimental scaffold behind `WITH_PYTHON`; no `import`-from-Python syntax is wired into the pipeline yet. |
+| **JavaScript / V8** | Disabled. V8 is not available from standard package managers, so builds use `-DWITH_V8=OFF`. |
+
+Contributions toward real Python/JS integration are welcome; the C path is the
+supported FFI today.

--- a/examples/ffi.to
+++ b/examples/ffi.to
@@ -1,0 +1,20 @@
+// C FFI: call C library functions directly via `extern def`.
+//   tocin examples/ffi.to --run
+//
+// An `extern def` declares a function with no body; the JIT resolves it from
+// the running process (libc/libm here), and native builds link it normally.
+
+extern def labs(x: int) -> int;          // C long abs
+extern def atoi(s: string) -> int;       // parse an int from a string
+extern def putchar(c: int) -> int;       // write one byte to stdout
+extern def hypot(x: float, y: float) -> float;  // libm
+
+def main() {
+    println("labs(-42)   = {}", labs(-42));      // 42
+    println("atoi(\"123\") = {}", atoi("123"));   // 123
+    println("hypot(3,4)  = {}", hypot(3.0, 4.0)); // 5
+
+    putchar(72); putchar(105); putchar(10);       // "Hi\n"
+
+    return labs(-7);                               // exit 7
+}

--- a/examples/linq.to
+++ b/examples/linq.to
@@ -1,0 +1,27 @@
+// LINQ-style collection operations from the standard library.
+//   tocin examples/linq.to --run
+//
+// Reductions return a scalar; `*Into` transforms write into a destination list.
+
+import std.linq;
+
+def main() {
+    let xs = [3, 1, 4, 1, 5, 9, 2, 6];
+
+    println("sum      = {}", reduceSum(xs));          // 31
+    println("product  = {}", reduceProduct([1,2,3,4])); // 24
+    println("max      = {}", aggregate(xs, xs[0], 2)); // 9
+    println("> 3 count= {}", countGreater(xs, 3));     // 4 (4,5,9,6)
+
+    // map: double each element into a destination list.
+    let doubled = [0, 0, 0, 0, 0, 0, 0, 0];
+    mapScaleInto(doubled, xs, 2);
+    println("doubled sum = {}", reduceSum(doubled));   // 62
+
+    // filter: keep elements > 3 into a destination, using the returned count.
+    let big = [0, 0, 0, 0, 0, 0, 0, 0];
+    let n = filterGreaterInto(big, xs, 3);
+    println("kept {} elements", n);                    // kept 4 elements
+
+    return reduceSum(xs);                               // 31
+}

--- a/examples/null_safety.to
+++ b/examples/null_safety.to
@@ -1,0 +1,29 @@
+// Null-safety operators: safe navigation (?.), elvis / null-coalescing (?:),
+// and force-unwrap (!!).
+//   tocin examples/null_safety.to --run
+//
+// References (class instances) can be null (`None`). These operators make
+// working with possibly-null references concise and safe.
+
+class Box {
+    v: int;
+    def get(self) -> int { return self.v; }
+}
+
+def main() {
+    let present: Box = Box(42);
+    let missing: Box = None;
+
+    // ?: supplies a fallback when the left side is null.
+    let a = present ?: Box(0);     // present is non-null -> present
+    let b = missing ?: Box(7);     // missing is null     -> Box(7)
+    println("elvis: {} {}", a.get(), b.get());     // 42 7
+
+    // ?. reads a field only when the base is non-null, else yields 0/null.
+    println("safe:  {} {}", present?.v, missing?.v); // 42 0
+
+    // !! asserts non-null (would abort if it were null).
+    println("force: {}", present!!.get());          // 42
+
+    return present!!.get();                          // 42
+}

--- a/examples/option_result.to
+++ b/examples/option_result.to
@@ -1,0 +1,39 @@
+// Option and Result types with destructuring pattern matching.
+//   tocin examples/option_result.to --run
+//
+// Some(x) / Ok(v) / Err(e) wrap a value; None is the empty case. `match` with
+// constructor patterns checks the case and binds the inner payload.
+
+def safeDiv(a: int, b: int) -> Result {
+    if b == 0 {
+        return Err(1);      // error code 1
+    }
+    return Ok(a / b);
+}
+
+def describe(n: int) -> int {
+    match safeDiv(100, n) {
+        case Ok(v): {
+            println("ok: {}", v);
+            return v;
+        }
+        case Err(e): {
+            println("error code {}", e);
+            return -1;
+        }
+    }
+    return 0;
+}
+
+def main() {
+    // Option
+    match Some(42) {
+        case Some(x): { println("got {}", x); }   // got 42
+        case None: { println("nothing"); }
+    }
+
+    describe(4);     // ok: 25
+    describe(0);     // error code 1
+
+    return describe(5);   // ok: 20  -> exit 20
+}

--- a/examples/select.to
+++ b/examples/select.to
@@ -1,0 +1,30 @@
+// select waits on multiple channels and runs the case that becomes ready.
+//   tocin examples/select.to --run
+
+def worker(ch: channel<int>, n: int) {
+    ch <- n;
+}
+
+def main() {
+    let fast = channel<int>();
+    let slow = channel<int>();
+
+    go worker(fast, 10);
+
+    // Blocking select: waits until one of the channels has a value. Only `fast`
+    // gets one here, so we receive 10.
+    let got = 0;
+    select {
+        case v = <-fast: { got = v; }
+        case v = <-slow: { got = v; }
+    }
+    println("received {}", got);     // received 10
+
+    // Non-blocking select: nothing is ready, so the default runs.
+    select {
+        case v = <-slow: { println("unexpected {}", v); }
+        default: { println("nothing ready"); }
+    }
+
+    return got;
+}

--- a/src/ast/ast.h
+++ b/src/ast/ast.h
@@ -737,6 +737,11 @@ namespace ast
         void accept(Visitor &visitor) override;
         ExprPtr value;
         std::vector<std::pair<ExprPtr, StmtPtr>> cases;
+        // Per-case constructor-pattern metadata, index-aligned with `cases`.
+        // caseCtor: "Some"/"None"/"Ok"/"Err" for a constructor pattern, else "".
+        // caseBind: payload variable bound by the pattern (e.g. "x"), else "".
+        std::vector<std::string> caseCtor;
+        std::vector<std::string> caseBind;
         StmtPtr defaultCase;
     };
 

--- a/src/ast/ast.h
+++ b/src/ast/ast.h
@@ -855,12 +855,14 @@ namespace ast
     public:
         struct Case
         {
-            ExprPtr channel;
+            ExprPtr channel;      // channel expression for `<-channel` (null for default)
+            std::string bindName; // receive bind variable, e.g. `v` in `case v = <-ch:` ("" = none)
             StmtPtr body;
             bool isDefault;
 
-            Case(ExprPtr ch, StmtPtr b, bool def = false)
-                : channel(std::move(ch)), body(std::move(b)), isDefault(def) {}
+            Case(ExprPtr ch, std::string bind, StmtPtr b, bool def = false)
+                : channel(std::move(ch)), bindName(std::move(bind)),
+                  body(std::move(b)), isDefault(def) {}
         };
 
         SelectStmt(const lexer::Token &token, std::vector<Case> cases)

--- a/src/ast/ast.h
+++ b/src/ast/ast.h
@@ -413,11 +413,12 @@ namespace ast
     class GetExpr : public Expression
     {
     public:
-        GetExpr(const lexer::Token &token, ExprPtr object, const std::string &name)
-            : Expression(token), object(std::move(object)), name(name) {}
+        GetExpr(const lexer::Token &token, ExprPtr object, const std::string &name, bool isSafe = false)
+            : Expression(token), object(std::move(object)), name(name), isSafe(isSafe) {}
         void accept(Visitor &visitor) override;
         ExprPtr object;
         std::string name;
+        bool isSafe = false; // true when parsed from `?.` (safe navigation)
         TypePtr getType() const override { return object ? object->getType() : nullptr; }
     };
 

--- a/src/codegen/ir_generator.cpp
+++ b/src/codegen/ir_generator.cpp
@@ -1086,6 +1086,23 @@ void IRGenerator::visitCallExpr(ast::CallExpr *expr)
     {
         std::string funcName = varExpr->name;
 
+        // Option/Result constructors. Some(x)/Ok(v) are tag 1; Err(e) is tag 0.
+        // None is the nil literal (a null pointer), handled in visitLiteralExpr.
+        if ((funcName == "Some" || funcName == "Ok") && expr->arguments.size() == 1)
+        {
+            expr->arguments[0]->accept(*this);
+            if (!lastValue) return;
+            lastValue = makeOptRes(1, lastValue);
+            return;
+        }
+        if (funcName == "Err" && expr->arguments.size() == 1)
+        {
+            expr->arguments[0]->accept(*this);
+            if (!lastValue) return;
+            lastValue = makeOptRes(0, lastValue);
+            return;
+        }
+
         // len(arr) reads the length stored in the array header (offset 0).
         if (funcName == "len" && expr->arguments.size() == 1)
         {
@@ -2349,6 +2366,46 @@ std::string IRGenerator::getExprClassName(const ast::ExprPtr &expr)
             return getExprClassName(un->right);
     }
     return "";
+}
+
+llvm::StructType *IRGenerator::getOptResType()
+{
+    if (!optResTy)
+    {
+        llvm::Type *i64 = llvm::Type::getInt64Ty(context);
+        optResTy = llvm::StructType::create(context, {i64, i64}, "tocin.optres");
+    }
+    return optResTy;
+}
+
+llvm::Value *IRGenerator::normalizeToSlot(llvm::Value *v)
+{
+    llvm::Type *i64 = llvm::Type::getInt64Ty(context);
+    if (v->getType()->isPointerTy())
+        return builder.CreatePtrToInt(v, i64, "slot");
+    if (v->getType()->isDoubleTy())
+        return builder.CreateBitCast(v, i64, "slot");
+    if (v->getType()->isIntegerTy() && v->getType() != i64)
+        return builder.CreateSExt(v, i64, "slot");
+    return v;
+}
+
+// Allocate a { tag, payload } Option/Result object on the heap.
+llvm::Value *IRGenerator::makeOptRes(int64_t tag, llvm::Value *payload)
+{
+    llvm::StructType *st = getOptResType();
+    llvm::Type *i32 = llvm::Type::getInt32Ty(context);
+    llvm::Type *i64 = llvm::Type::getInt64Ty(context);
+    llvm::Function *mallocFn = stdLibFunctions["malloc"];
+    llvm::Value *size = llvm::ConstantExpr::getSizeOf(st);
+    llvm::Value *obj = builder.CreateCall(mallocFn->getFunctionType(), mallocFn, {size}, "optres");
+    llvm::Value *tagP = builder.CreateGEP(st, obj,
+        {llvm::ConstantInt::get(i32, 0), llvm::ConstantInt::get(i32, 0)}, "tagp");
+    builder.CreateStore(llvm::ConstantInt::get(i64, tag), tagP);
+    llvm::Value *payP = builder.CreateGEP(st, obj,
+        {llvm::ConstantInt::get(i32, 0), llvm::ConstantInt::get(i32, 1)}, "payp");
+    builder.CreateStore(payload ? normalizeToSlot(payload) : llvm::ConstantInt::get(i64, 0), payP);
+    return obj;
 }
 
 void IRGenerator::recordArrayParam(const std::string &name, const ast::TypePtr &type)
@@ -4333,7 +4390,69 @@ void IRGenerator::visitMatchStmt(ast::MatchStmt *stmt)
 
     for (size_t i = 0; i < stmt->cases.size(); ++i)
     {
-        // Evaluate this case's pattern and compare for equality with the value.
+        std::string ctor = i < stmt->caseCtor.size() ? stmt->caseCtor[i] : "";
+
+        // ---- Option/Result constructor pattern (Some/Ok/Err/None) ----
+        if (!ctor.empty())
+        {
+            llvm::StructType *st = getOptResType();
+            llvm::Type *i32 = llvm::Type::getInt32Ty(context);
+            llvm::Type *ptrTy = llvm::PointerType::get(context, 0);
+            llvm::Value *mvPtr = matchVal->getType()->isPointerTy()
+                                     ? matchVal
+                                     : builder.CreateIntToPtr(matchVal, ptrTy, "mv.ptr");
+            llvm::Value *nullp = llvm::ConstantPointerNull::get(llvm::cast<llvm::PointerType>(mvPtr->getType()));
+
+            llvm::BasicBlock *caseBlock = llvm::BasicBlock::Create(context, "case", function);
+            llvm::BasicBlock *nextBlock = llvm::BasicBlock::Create(context, "casenext", function);
+
+            if (ctor == "None")
+            {
+                // None is the null pointer.
+                builder.CreateCondBr(builder.CreateICmpEQ(mvPtr, nullp, "is.none"),
+                                     caseBlock, nextBlock);
+            }
+            else
+            {
+                // Some/Ok/Err are non-null; distinguish by tag (Some/Ok=1, Err=0).
+                int64_t wantTag = (ctor == "Some" || ctor == "Ok") ? 1 : 0;
+                llvm::BasicBlock *tagBlock = llvm::BasicBlock::Create(context, "casetag", function);
+                builder.CreateCondBr(builder.CreateICmpNE(mvPtr, nullp, "nonnull"),
+                                     tagBlock, nextBlock);
+                builder.SetInsertPoint(tagBlock);
+                llvm::Value *tagP = builder.CreateGEP(st, mvPtr,
+                    {llvm::ConstantInt::get(i32, 0), llvm::ConstantInt::get(i32, 0)}, "tagp");
+                llvm::Value *tag = builder.CreateLoad(i64, tagP, "tag");
+                builder.CreateCondBr(
+                    builder.CreateICmpEQ(tag, llvm::ConstantInt::get(i64, wantTag), "tagcmp"),
+                    caseBlock, nextBlock);
+            }
+
+            builder.SetInsertPoint(caseBlock);
+            auto savedNamed = namedValues;
+            createEnvironment();
+            std::string bind = i < stmt->caseBind.size() ? stmt->caseBind[i] : "";
+            if (!bind.empty() && ctor != "None")
+            {
+                llvm::Value *payP = builder.CreateGEP(st, mvPtr,
+                    {llvm::ConstantInt::get(i32, 0), llvm::ConstantInt::get(i32, 1)}, "payp");
+                llvm::Value *pay = builder.CreateLoad(i64, payP, bind);
+                llvm::AllocaInst *slot = builder.CreateAlloca(i64, nullptr, bind);
+                builder.CreateStore(pay, slot);
+                namedValues[bind] = slot;
+            }
+            if (stmt->cases[i].second)
+                stmt->cases[i].second->accept(*this);
+            restoreEnvironment();
+            namedValues = savedNamed;
+            if (!builder.GetInsertBlock()->getTerminator())
+                builder.CreateBr(mergeBlock);
+
+            builder.SetInsertPoint(nextBlock);
+            continue;
+        }
+
+        // ---- Value-equality pattern (case 5:, case "x":) ----
         stmt->cases[i].first->accept(*this);
         llvm::Value *pat = lastValue;
         if (!pat)

--- a/src/codegen/ir_generator.cpp
+++ b/src/codegen/ir_generator.cpp
@@ -4666,87 +4666,100 @@ void codegen::IRGenerator::visitChannelReceiveExpr(ast::ChannelReceiveExpr* expr
 }
 
 void codegen::IRGenerator::visitSelectStmt(ast::SelectStmt* stmt) {
-    // Generate IR for select statement
-    
-    // Create a function to handle the select logic
-    std::string selectFuncName = "select_handler_" + std::to_string(getNextId());
-    llvm::Function* selectFunc = llvm::Function::Create(
-        llvm::FunctionType::get(llvm::Type::getInt32Ty(context), false), // Returns case index
-        llvm::Function::InternalLinkage,
-        selectFuncName,
-        module.get()
-    );
-    
-    // Create the select function body
-    llvm::BasicBlock* entryBlock = llvm::BasicBlock::Create(context, "entry", selectFunc);
-    builder.SetInsertPoint(entryBlock);
-    
-    // Get the runtime select function
-    llvm::Function* runtimeSelectFunc = module->getFunction("runtime_select");
-    if (!runtimeSelectFunc) {
-        // Create the runtime function declaration if it doesn't exist
-        llvm::FunctionType* selectType = llvm::FunctionType::get(
-            llvm::Type::getInt32Ty(context), // Returns selected case index
-            {llvm::Type::getInt32Ty(context)}, // Number of cases
-            false
-        );
-        runtimeSelectFunc = llvm::Function::Create(
-            selectType,
-            llvm::Function::ExternalLinkage,
-            "runtime_select",
-            module.get()
-        );
+    // `select` waits on multiple channel receives. Lowered to a poll loop over
+    // the cases using the non-blocking __tocin_chan_try_recv: try each channel;
+    // run the first ready case's body; with a `default`, run it when none are
+    // ready; otherwise park briefly and retry (blocking).
+    llvm::Function *function = builder.GetInsertBlock()->getParent();
+    llvm::Type *i8 = llvm::Type::getInt8Ty(context);
+    llvm::Type *i64 = llvm::Type::getInt64Ty(context);
+    llvm::Type *ptr = llvm::PointerType::get(context, 0);
+
+    llvm::Function *tryF = module->getFunction("__tocin_chan_try_recv");
+    if (!tryF)
+        tryF = llvm::Function::Create(
+            llvm::FunctionType::get(i8, {ptr, ptr}, false),
+            llvm::Function::ExternalLinkage, "__tocin_chan_try_recv", *module);
+    llvm::Function *parkF = module->getFunction("__tocin_chan_park");
+    if (!parkF)
+        parkF = llvm::Function::Create(
+            llvm::FunctionType::get(llvm::Type::getVoidTy(context), {}, false),
+            llvm::Function::ExternalLinkage, "__tocin_chan_park", *module);
+
+    // Split receive cases from an optional default.
+    std::vector<const ast::SelectStmt::Case *> recvCases;
+    const ast::SelectStmt::Case *defCase = nullptr;
+    for (const auto &c : stmt->cases) {
+        if (c.isDefault) defCase = &c;
+        else recvCases.push_back(&c);
     }
-    
-    // Call the runtime select function with the number of cases
-    std::vector<llvm::Value*> args = {
-        llvm::ConstantInt::get(llvm::Type::getInt32Ty(context), stmt->cases.size())
-    };
-    llvm::Value* selectedCase = builder.CreateCall(runtimeSelectFunc, args);
-    
-    // Return the selected case index
-    builder.CreateRet(selectedCase);
-    
-    // Now create the main select logic in the current function
-    llvm::BasicBlock* currentBlock = builder.GetInsertBlock();
-    llvm::Function* currentFunction = currentBlock->getParent();
-    
-    // Call the select handler
-    std::vector<llvm::Value*> callArgs;
-    llvm::Value* caseIndex = builder.CreateCall(selectFunc, callArgs);
-    
-    // Create a switch statement to handle each case
-    llvm::SwitchInst* switchInst = builder.CreateSwitch(caseIndex, nullptr, stmt->cases.size());
-    
-    // Add cases for each select case
-    for (size_t i = 0; i < stmt->cases.size(); ++i) {
-        const auto& selectCase = stmt->cases[i];
-        
-        // Create a basic block for this case
-        llvm::BasicBlock* caseBlock = llvm::BasicBlock::Create(context, 
-            "select_case_" + std::to_string(i), currentFunction);
-        
-        // Add the case to the switch
-        switchInst->addCase(llvm::ConstantInt::get(llvm::Type::getInt32Ty(context), i), caseBlock);
-        
-        // Set the insert point to the case block
-        builder.SetInsertPoint(caseBlock);
-        
-        // Execute the case body
-        if (selectCase.body) {
-            selectCase.body->accept(*this);
+
+    // Evaluate channel handles once; one received-value slot per case.
+    std::vector<llvm::Value *> handles, slots;
+    for (auto *c : recvCases) {
+        c->channel->accept(*this);
+        llvm::Value *h = lastValue;
+        if (!h) { lastValue = nullptr; return; }
+        if (!h->getType()->isPointerTy())
+            h = builder.CreateIntToPtr(h, ptr, "ch.ptr");
+        handles.push_back(h);
+        slots.push_back(createEntryBlockAlloca(function, "sel.slot", i64));
+    }
+
+    llvm::BasicBlock *pollBlock = llvm::BasicBlock::Create(context, "select.poll", function);
+    llvm::BasicBlock *noMatch = llvm::BasicBlock::Create(context, "select.nomatch", function);
+    llvm::BasicBlock *contBlock = llvm::BasicBlock::Create(context, "select.cont", function);
+    std::vector<llvm::BasicBlock *> tryBlocks, bodyBlocks;
+    for (size_t i = 0; i < recvCases.size(); ++i) {
+        tryBlocks.push_back(llvm::BasicBlock::Create(context, "select.try", function));
+        bodyBlocks.push_back(llvm::BasicBlock::Create(context, "select.body", function));
+    }
+
+    builder.CreateBr(pollBlock);
+    builder.SetInsertPoint(pollBlock);
+    builder.CreateBr(recvCases.empty() ? noMatch : tryBlocks[0]);
+
+    // Per-case readiness checks, chained.
+    for (size_t i = 0; i < recvCases.size(); ++i) {
+        builder.SetInsertPoint(tryBlocks[i]);
+        llvm::Value *got = builder.CreateCall(tryF, {handles[i], slots[i]}, "got");
+        llvm::Value *ready = builder.CreateICmpNE(got, llvm::ConstantInt::get(i8, 0), "ready");
+        llvm::BasicBlock *nextTry = (i + 1 < recvCases.size()) ? tryBlocks[i + 1] : noMatch;
+        builder.CreateCondBr(ready, bodyBlocks[i], nextTry);
+    }
+
+    // No case ready: run default, or park and retry (blocking).
+    builder.SetInsertPoint(noMatch);
+    if (defCase) {
+        createEnvironment();
+        if (defCase->body) defCase->body->accept(*this);
+        restoreEnvironment();
+        if (!builder.GetInsertBlock()->getTerminator())
+            builder.CreateBr(contBlock);
+    } else {
+        builder.CreateCall(parkF, {});
+        builder.CreateBr(pollBlock);
+    }
+
+    // Case bodies: bind the received value (if named), then run the body.
+    for (size_t i = 0; i < recvCases.size(); ++i) {
+        builder.SetInsertPoint(bodyBlocks[i]);
+        auto savedNamed = namedValues;
+        createEnvironment();
+        if (!recvCases[i]->bindName.empty()) {
+            llvm::AllocaInst *bindSlot = createEntryBlockAlloca(function, recvCases[i]->bindName, i64);
+            builder.CreateStore(builder.CreateLoad(i64, slots[i], "recv"), bindSlot);
+            namedValues[recvCases[i]->bindName] = bindSlot;
         }
-        
-        // Branch to the end of the select
-        llvm::BasicBlock* endBlock = llvm::BasicBlock::Create(context, "select_end", currentFunction);
-        builder.CreateBr(endBlock);
-        
-        // Set the insert point to the end block
-        builder.SetInsertPoint(endBlock);
+        if (recvCases[i]->body) recvCases[i]->body->accept(*this);
+        restoreEnvironment();
+        namedValues = savedNamed;
+        if (!builder.GetInsertBlock()->getTerminator())
+            builder.CreateBr(contBlock);
     }
-    
-    // Set the current value to void
-    lastValue = llvm::Constant::getNullValue(llvm::Type::getVoidTy(context));
+
+    builder.SetInsertPoint(contBlock);
+    lastValue = nullptr;
 }
 
 int IRGenerator::getNextId() {

--- a/src/codegen/ir_generator.cpp
+++ b/src/codegen/ir_generator.cpp
@@ -558,26 +558,25 @@ void IRGenerator::visitLiteralExpr(ast::LiteralExpr *expr)
 
 void IRGenerator::visitVariableStmt(ast::VariableStmt *stmt)
 {
-    // Get the variable type
-    llvm::Type *varType = nullptr;
+    llvm::Type *varType = stmt->type ? getLLVMType(stmt->type) : nullptr;
 
-    if (stmt->type)
+    // Evaluate the initializer exactly once, here. Never reuse a stale
+    // `lastValue` left over from a previous statement (it may even belong to a
+    // different function, which produced "does not dominate all uses"). For an
+    // inferred type, the evaluated value also determines the variable's type.
+    llvm::Value *initVal = nullptr;
+    if (stmt->initializer)
     {
-        // If type is explicitly specified
-        varType = getLLVMType(stmt->type);
-    }
-    else if (stmt->initializer)
-    {
-        // If type is inferred from initializer
+        lastValue = nullptr;
         stmt->initializer->accept(*this);
         if (!lastValue)
             return;
-
-        varType = lastValue->getType();
+        initVal = lastValue;
+        if (!varType)
+            varType = initVal->getType();
     }
-    else
+    else if (!stmt->type)
     {
-        // No type and no initializer - error
         errorHandler.reportError(error::ErrorCode::T032_CANNOT_INFER_TYPE,
                                  "Cannot infer type for variable '" + stmt->name + "' without initializer",
                                  "", 0, 0, error::ErrorSeverity::ERROR);
@@ -598,7 +597,9 @@ void IRGenerator::visitVariableStmt(ast::VariableStmt *stmt)
     // Store the variable in the symbol table
     namedValues[stmt->name] = alloca;
 
-    // Track the variable's class (for field/method resolution).
+    // Track the variable's class (for field/method resolution). Done after the
+    // initializer is evaluated so generic-constructor calls have already been
+    // resolved to a concrete mangled class name.
     std::string vcls = getExprClassName(stmt->initializer);
     if (vcls.empty() && stmt->type && classTypes.count(stmt->type->toString()))
         vcls = stmt->type->toString();
@@ -620,30 +621,16 @@ void IRGenerator::visitVariableStmt(ast::VariableStmt *stmt)
             varArrayElem[stmt->name] = it->second;
     }
 
-    // If there's an initializer, store its value
-    if (stmt->initializer)
+    // Store the initializer value (already evaluated above).
+    if (initVal)
     {
-        if (!lastValue)
+        if (initVal->getType() != varType)
         {
-            // If we don't have a value yet, compute the initializer
-            stmt->initializer->accept(*this);
-            if (!lastValue)
-                return;
-        }
-
-        // Validate that initializer type matches variable type
-        if (lastValue->getType() != varType)
-        {
-            // Simple cast for numeric values
-            if (lastValue->getType()->isIntegerTy() && varType->isIntegerTy())
-            {
-                lastValue = builder.CreateIntCast(lastValue, varType, true, "cast");
-            }
-            else if ((lastValue->getType()->isFloatTy() || lastValue->getType()->isDoubleTy()) &&
+            if (initVal->getType()->isIntegerTy() && varType->isIntegerTy())
+                initVal = builder.CreateIntCast(initVal, varType, true, "cast");
+            else if ((initVal->getType()->isFloatTy() || initVal->getType()->isDoubleTy()) &&
                      (varType->isFloatTy() || varType->isDoubleTy()))
-            {
-                lastValue = builder.CreateFPCast(lastValue, varType, "cast");
-            }
+                initVal = builder.CreateFPCast(initVal, varType, "cast");
             else
             {
                 errorHandler.reportError(error::ErrorCode::T001_TYPE_MISMATCH,
@@ -652,9 +639,7 @@ void IRGenerator::visitVariableStmt(ast::VariableStmt *stmt)
                 return;
             }
         }
-
-        // Store the initial value
-        builder.CreateStore(lastValue, alloca);
+        builder.CreateStore(initVal, alloca);
     }
 }
 

--- a/src/codegen/ir_generator.cpp
+++ b/src/codegen/ir_generator.cpp
@@ -1749,6 +1749,35 @@ void IRGenerator::visitUnaryExpr(ast::UnaryExpr *expr)
         }
         break;
 
+    case lexer::TokenType::BANG_BANG:
+    {
+        // Force-unwrap: abort if the operand is null, otherwise yield it.
+        if (!operand->getType()->isPointerTy()) {
+            // Non-pointer values can never be null; identity.
+            lastValue = operand;
+            break;
+        }
+        llvm::Function *fn = builder.GetInsertBlock()->getParent();
+        llvm::Value *isNull = builder.CreateICmpEQ(
+            operand,
+            llvm::ConstantPointerNull::get(llvm::cast<llvm::PointerType>(operand->getType())),
+            "uw.isnull");
+        llvm::BasicBlock *nullBB = llvm::BasicBlock::Create(context, "unwrap.null", fn);
+        llvm::BasicBlock *okBB = llvm::BasicBlock::Create(context, "unwrap.ok", fn);
+        builder.CreateCondBr(isNull, nullBB, okBB);
+        builder.SetInsertPoint(nullBB);
+        llvm::Function *abortFn = module->getFunction("abort");
+        if (!abortFn)
+            abortFn = llvm::Function::Create(
+                llvm::FunctionType::get(llvm::Type::getVoidTy(context), {}, false),
+                llvm::Function::ExternalLinkage, "abort", *module);
+        builder.CreateCall(abortFn, {});
+        builder.CreateUnreachable();
+        builder.SetInsertPoint(okBB);
+        lastValue = operand;
+        break;
+    }
+
     case lexer::TokenType::BITWISE_NOT:
         if (operand->getType()->isIntegerTy()) {
             lastValue = builder.CreateNot(operand, "bitnot");
@@ -2304,6 +2333,21 @@ std::string IRGenerator::getExprClassName(const ast::ExprPtr &expr)
             (void)cit;
         }
     }
+    // Null-safety operators preserve the operand's class: `a ?: b` and `a!!`.
+    if (auto bin = std::dynamic_pointer_cast<ast::BinaryExpr>(expr))
+    {
+        if (bin->op.type == lexer::TokenType::ELVIS ||
+            bin->op.type == lexer::TokenType::NULL_COALESCE)
+        {
+            std::string c = getExprClassName(bin->left);
+            return !c.empty() ? c : getExprClassName(bin->right);
+        }
+    }
+    if (auto un = std::dynamic_pointer_cast<ast::UnaryExpr>(expr))
+    {
+        if (un->op.type == lexer::TokenType::BANG_BANG)
+            return getExprClassName(un->right);
+    }
     return "";
 }
 
@@ -2840,17 +2884,42 @@ void IRGenerator::visitGetExpr(ast::GetExpr *expr)
 
         if (fieldIndex != -1)
         {
-            // Create a GEP instruction to access the field
             std::vector<llvm::Value *> indices = {
                 llvm::ConstantInt::get(llvm::Type::getInt32Ty(context), 0),
                 llvm::ConstantInt::get(llvm::Type::getInt32Ty(context), fieldIndex)};
+            llvm::Type *fieldType = structType->getStructElementType(fieldIndex);
+
+            // Safe navigation `a?.b`: when the base is null, yield a null/zero
+            // value of the field type instead of dereferencing.
+            if (expr->isSafe && object->getType()->isPointerTy())
+            {
+                llvm::Function *fn = builder.GetInsertBlock()->getParent();
+                llvm::Value *isNull = builder.CreateICmpEQ(
+                    object,
+                    llvm::ConstantPointerNull::get(llvm::cast<llvm::PointerType>(object->getType())),
+                    "safe.isnull");
+                llvm::BasicBlock *nullBB = builder.GetInsertBlock();
+                llvm::BasicBlock *loadBB = llvm::BasicBlock::Create(context, "safe.load", fn);
+                llvm::BasicBlock *mergeBB = llvm::BasicBlock::Create(context, "safe.merge", fn);
+                builder.CreateCondBr(isNull, mergeBB, loadBB);
+
+                builder.SetInsertPoint(loadBB);
+                llvm::Value *fieldPtr = builder.CreateGEP(structType, object, indices, "field." + expr->name);
+                llvm::Value *loaded = builder.CreateLoad(fieldType, fieldPtr);
+                llvm::BasicBlock *loadEnd = builder.GetInsertBlock();
+                builder.CreateBr(mergeBB);
+
+                builder.SetInsertPoint(mergeBB);
+                llvm::PHINode *phi = builder.CreatePHI(fieldType, 2, "safe");
+                phi->addIncoming(llvm::Constant::getNullValue(fieldType), nullBB);
+                phi->addIncoming(loaded, loadEnd);
+                lastValue = phi;
+                return;
+            }
 
             // Get a pointer to the field (using the known struct type)
             llvm::Value *fieldPtr = builder.CreateGEP(
                 structType, object, indices, "field." + expr->name);
-
-            // Load the field value (use the field type from class info)
-            llvm::Type *fieldType = structType->getStructElementType(fieldIndex);
             lastValue = builder.CreateLoad(fieldType, fieldPtr);
             return;
         }
@@ -3860,6 +3929,48 @@ void IRGenerator::visitBinaryExpr(ast::BinaryExpr *expr)
                                  "Binary expression missing operands",
                                  "", 0, 0, error::ErrorSeverity::ERROR);
         lastValue = nullptr;
+        return;
+    }
+
+    // Elvis / null-coalescing: `a ?: b` / `a ?? b`. Short-circuit — only
+    // evaluate `b` when `a` is null. Handled before the eager both-operands
+    // evaluation below.
+    if (expr->op.type == lexer::TokenType::ELVIS ||
+        expr->op.type == lexer::TokenType::NULL_COALESCE)
+    {
+        expr->left->accept(*this);
+        llvm::Value *lhs = lastValue;
+        if (!lhs) { lastValue = nullptr; return; }
+
+        if (!lhs->getType()->isPointerTy()) {
+            // A non-pointer left operand is never null; result is the left.
+            lastValue = lhs;
+            return;
+        }
+
+        llvm::Function *fn = builder.GetInsertBlock()->getParent();
+        llvm::Value *isNull = builder.CreateICmpEQ(
+            lhs, llvm::ConstantPointerNull::get(llvm::cast<llvm::PointerType>(lhs->getType())),
+            "elvis.isnull");
+        llvm::BasicBlock *lhsBB = builder.GetInsertBlock();
+        llvm::BasicBlock *rhsBB = llvm::BasicBlock::Create(context, "elvis.rhs", fn);
+        llvm::BasicBlock *mergeBB = llvm::BasicBlock::Create(context, "elvis.merge", fn);
+        builder.CreateCondBr(isNull, rhsBB, mergeBB);
+
+        builder.SetInsertPoint(rhsBB);
+        expr->right->accept(*this);
+        llvm::Value *rhs = lastValue;
+        if (!rhs) { lastValue = nullptr; return; }
+        if (rhs->getType() != lhs->getType() && rhs->getType()->isPointerTy())
+            rhs = builder.CreateBitCast(rhs, lhs->getType(), "elvis.cast");
+        llvm::BasicBlock *rhsEnd = builder.GetInsertBlock();
+        builder.CreateBr(mergeBB);
+
+        builder.SetInsertPoint(mergeBB);
+        llvm::PHINode *phi = builder.CreatePHI(lhs->getType(), 2, "elvis");
+        phi->addIncoming(lhs, lhsBB);
+        phi->addIncoming(rhs, rhsEnd);
+        lastValue = phi;
         return;
     }
 

--- a/src/codegen/ir_generator.h
+++ b/src/codegen/ir_generator.h
@@ -266,6 +266,13 @@ namespace codegen
         // so indexing the parameter inside the function uses the right type.
         void recordArrayParam(const std::string &name, const ast::TypePtr &type);
 
+        // Option/Result lowering: a heap { i64 tag, i64 payload } object.
+        // tag 1 = Some/Ok, tag 0 = Err; None is a null pointer.
+        llvm::StructType *optResTy = nullptr;
+        llvm::StructType *getOptResType();
+        llvm::Value *normalizeToSlot(llvm::Value *v);
+        llvm::Value *makeOptRes(int64_t tag, llvm::Value *payload);
+
         // Monomorphize a generic function for a concrete set of type bindings.
         llvm::Function *emitGenericInstance(ast::FunctionStmt *stmt,
                                             const std::map<std::string, llvm::Type *> &bindings);

--- a/src/lexer/lexer.cpp
+++ b/src/lexer/lexer.cpp
@@ -829,6 +829,10 @@ namespace lexer
                     tokens.emplace_back(TokenType::BANG_EQUAL, "!=", filename, line, column - 2);
                 }
             }
+            else if (match('!'))
+            {
+                tokens.emplace_back(TokenType::BANG_BANG, "!!", filename, line, column - 2);
+            }
             else
             {
                 tokens.emplace_back(TokenType::BANG, "!", filename, line, column - 1);
@@ -923,6 +927,10 @@ namespace lexer
             else if (match('?'))
             {
                 tokens.emplace_back(TokenType::NULL_COALESCE, "??", filename, line, column - 2);
+            }
+            else if (match(':'))
+            {
+                tokens.emplace_back(TokenType::ELVIS, "?:", filename, line, column - 2);
             }
             else
             {

--- a/src/lexer/token.h
+++ b/src/lexer/token.h
@@ -42,6 +42,7 @@ namespace lexer
         EQUAL_EQUAL,
         BANG,
         BANG_EQUAL,
+        BANG_BANG,
         NOT_EQUAL,
         LESS,
         LESS_EQUAL,

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -46,6 +46,8 @@ extern "C" {
     int64_t __tocin_chan_recv(void *);
     void __tocin_go(void (*)(void *), void *);
     void __tocin_join_all();
+    int8_t __tocin_chan_try_recv(void *, int64_t *);
+    void __tocin_chan_park();
     void __tocin_try_register(void *);
     void __tocin_try_pop();
     int64_t __tocin_exc_value();
@@ -429,6 +431,8 @@ public:
             def("__tocin_chan_recv", reinterpret_cast<void *>(&__tocin_chan_recv));
             def("__tocin_go", reinterpret_cast<void *>(&__tocin_go));
             def("__tocin_join_all", reinterpret_cast<void *>(&__tocin_join_all));
+            def("__tocin_chan_try_recv", reinterpret_cast<void *>(&__tocin_chan_try_recv));
+            def("__tocin_chan_park", reinterpret_cast<void *>(&__tocin_chan_park));
             def("__tocin_try_register", reinterpret_cast<void *>(&__tocin_try_register));
             def("__tocin_try_pop", reinterpret_cast<void *>(&__tocin_try_pop));
             def("__tocin_exc_value", reinterpret_cast<void *>(&__tocin_exc_value));

--- a/src/parser/parser.cpp
+++ b/src/parser/parser.cpp
@@ -995,6 +995,13 @@ namespace parser
         return peek().type == type;
     }
 
+    bool Parser::checkNext(lexer::TokenType type) const
+    {
+        if (current + 1 >= tokens.size())
+            return false;
+        return tokens[current + 1].type == type;
+    }
+
     lexer::Token Parser::advance()
     {
         if (!isAtEnd())
@@ -1242,55 +1249,37 @@ namespace parser
         consume(lexer::TokenType::LEFT_BRACE, "Expected '{' after 'select'");
         
         std::vector<ast::SelectStmt::Case> cases;
-        
+
         while (!check(lexer::TokenType::RIGHT_BRACE) && !isAtEnd())
         {
             if (match(lexer::TokenType::CASE))
             {
-                // Parse channel send or receive case
-                ast::ExprPtr channel = nullptr;
-                ast::ExprPtr value = nullptr;
-                bool isSend = false;
-                
-                // Check if this is a send case (channel <- value)
-                auto firstExpr = expression();
-                
-                if (match(lexer::TokenType::CHANNEL_SEND))
+                // Optional receive bind: `case v = <-ch:`.
+                std::string bindName;
+                if (check(lexer::TokenType::IDENTIFIER) && checkNext(lexer::TokenType::EQUAL))
                 {
-                    // This is a send case: channel <- value
-                    channel = firstExpr;
-                    value = expression();
-                    isSend = true;
+                    bindName = advance().value; // bind variable
+                    advance();                  // '='
                 }
-                else
-                {
-                    // This is a receive case: <-channel or value := <-channel
-                    if (firstExpr->token.type == lexer::TokenType::CHANNEL_RECEIVE)
-                    {
-                        // Simple receive: <-channel
-                        channel = expression();
-                    }
-                    else
-                    {
-                        // Assignment receive: value := <-channel
-                        value = firstExpr;
-                        consume(lexer::TokenType::CHANNEL_RECEIVE, "Expected '<-' for channel receive");
-                        channel = expression();
-                    }
-                }
-                
-                consume(lexer::TokenType::COLON, "Expected ':' after case");
+
+                // The receive operation: `<-ch` (lexes as a prefix CHANNEL_SEND
+                // or CHANNEL_RECEIVE, producing a ChannelReceiveExpr).
+                ast::ExprPtr recv = unary();
+                ast::ExprPtr channel = recv;
+                if (auto cr = std::dynamic_pointer_cast<ast::ChannelReceiveExpr>(recv))
+                    channel = cr->channel;
+
+                consume(lexer::TokenType::COLON, "Expected ':' after select case");
+                consume(lexer::TokenType::LEFT_BRACE, "Expected '{' for case body");
                 auto body = blockStmt();
-                
-                cases.emplace_back(channel, body, false);
+                cases.emplace_back(channel, bindName, body, false);
             }
             else if (match(lexer::TokenType::DEFAULT))
             {
                 consume(lexer::TokenType::COLON, "Expected ':' after default");
+                consume(lexer::TokenType::LEFT_BRACE, "Expected '{' for default body");
                 auto body = blockStmt();
-                
-                // Create a default case with null channel
-                cases.emplace_back(nullptr, body, true);
+                cases.emplace_back(nullptr, std::string(), body, true);
             }
             else
             {
@@ -1298,7 +1287,7 @@ namespace parser
                 advance();
             }
         }
-        
+
         consume(lexer::TokenType::RIGHT_BRACE, "Expected '}' after select statement");
         return std::make_shared<ast::SelectStmt>(keyword, cases);
     }

--- a/src/parser/parser.cpp
+++ b/src/parser/parser.cpp
@@ -496,6 +496,8 @@ namespace parser
         auto value = expression();
         consume(lexer::TokenType::LEFT_BRACE, "Expected '{' after match value");
         std::vector<std::pair<ast::ExprPtr, ast::StmtPtr>> cases;
+        std::vector<std::string> ctors;
+        std::vector<std::string> binds;
         ast::StmtPtr defaultCase = nullptr;
         while (!check(lexer::TokenType::RIGHT_BRACE) && !isAtEnd())
         {
@@ -505,7 +507,33 @@ namespace parser
                 consume(lexer::TokenType::COLON, "Expected ':' after case pattern");
                 consume(lexer::TokenType::LEFT_BRACE, "Expected '{' after case pattern");
                 auto body = blockStmt();
+
+                // Classify Option/Result constructor patterns so codegen can do
+                // a tag check + payload binding instead of value equality.
+                std::string ctor, bind;
+                if (auto lit = std::dynamic_pointer_cast<ast::LiteralExpr>(pattern))
+                {
+                    if (lit->literalType == ast::LiteralExpr::LiteralType::NIL)
+                        ctor = "None"; // `None` lexes as the nil literal
+                }
+                else if (auto call = std::dynamic_pointer_cast<ast::CallExpr>(pattern))
+                {
+                    if (auto callee = std::dynamic_pointer_cast<ast::VariableExpr>(call->callee))
+                    {
+                        const std::string &n = callee->name;
+                        if (n == "Some" || n == "Ok" || n == "Err")
+                        {
+                            ctor = n;
+                            if (call->arguments.size() == 1)
+                                if (auto v = std::dynamic_pointer_cast<ast::VariableExpr>(call->arguments[0]))
+                                    bind = v->name;
+                        }
+                    }
+                }
+
                 cases.emplace_back(pattern, body);
+                ctors.push_back(ctor);
+                binds.push_back(bind);
             }
             else if (match(lexer::TokenType::DEFAULT))
             {
@@ -520,7 +548,10 @@ namespace parser
             }
         }
         consume(lexer::TokenType::RIGHT_BRACE, "Expected '}' after match");
-        return std::make_shared<ast::MatchStmt>(value->token, value, cases, defaultCase);
+        auto stmt = std::make_shared<ast::MatchStmt>(value->token, value, cases, defaultCase);
+        stmt->caseCtor = std::move(ctors);
+        stmt->caseBind = std::move(binds);
+        return stmt;
     }
 
     ast::ExprPtr Parser::expression()

--- a/src/parser/parser.cpp
+++ b/src/parser/parser.cpp
@@ -528,9 +528,23 @@ namespace parser
         return assignment();
     }
 
+    ast::ExprPtr Parser::elvis()
+    {
+        // a ?: b / a ?? b : yield a when non-null, else b. Binds looser than
+        // logical-or and tighter than assignment.
+        auto expr = orExpr();
+        while (match(lexer::TokenType::ELVIS) || match(lexer::TokenType::NULL_COALESCE))
+        {
+            auto op = previous();
+            auto right = orExpr();
+            expr = std::make_shared<ast::BinaryExpr>(op, expr, op, right);
+        }
+        return expr;
+    }
+
     ast::ExprPtr Parser::assignment()
     {
-        ast::ExprPtr expr = orExpr();
+        ast::ExprPtr expr = elvis();
 
         if (match(lexer::TokenType::EQUAL))
         {
@@ -687,6 +701,18 @@ namespace parser
             {
                 auto name = consume(lexer::TokenType::IDENTIFIER, "Expected property name after '.'");
                 expr = std::make_shared<ast::GetExpr>(name, expr, name.value);
+            }
+            else if (match(lexer::TokenType::SAFE_ACCESS))
+            {
+                // a?.b : safe navigation (null base yields null).
+                auto name = consume(lexer::TokenType::IDENTIFIER, "Expected property name after '?.'");
+                expr = std::make_shared<ast::GetExpr>(name, expr, name.value, /*isSafe=*/true);
+            }
+            else if (match(lexer::TokenType::BANG_BANG))
+            {
+                // a!! : force-unwrap (trap if null).
+                lexer::Token op = previous();
+                expr = std::make_shared<ast::UnaryExpr>(op, op, expr);
             }
             else if (match(lexer::TokenType::LEFT_BRACKET))
             {

--- a/src/parser/parser.h
+++ b/src/parser/parser.h
@@ -80,6 +80,7 @@ namespace parser
         ast::StmtPtr throwStmt();
         ast::ExprPtr expression();
         ast::ExprPtr assignment();
+        ast::ExprPtr elvis();
         ast::ExprPtr orExpr();
         ast::ExprPtr andExpr();
         ast::ExprPtr equality();

--- a/src/parser/parser.h
+++ b/src/parser/parser.h
@@ -101,6 +101,7 @@ namespace parser
 
         bool match(lexer::TokenType type);
         bool check(lexer::TokenType type) const;
+        bool checkNext(lexer::TokenType type) const;
         lexer::Token advance();
         lexer::Token peek() const;
         lexer::Token previous() const;

--- a/src/runtime/concurrency_runtime.cpp
+++ b/src/runtime/concurrency_runtime.cpp
@@ -5,6 +5,7 @@
 // C toolchain. Values flowing through channels are passed as 64-bit slots
 // (ints, bit-cast floats, or pointers), matching the codegen ABI.
 #include <atomic>
+#include <chrono>
 #include <condition_variable>
 #include <csetjmp>
 #include <cstdint>
@@ -61,6 +62,27 @@ extern "C"
         int64_t value = ch->q.front();
         ch->q.pop_front();
         return value;
+    }
+
+    // Non-blocking receive: if a value is available, dequeue it into *out and
+    // return 1; otherwise return 0 without blocking. Used to implement `select`.
+    int8_t __tocin_chan_try_recv(void *handle, int64_t *out)
+    {
+        if (!handle || !out)
+            return 0;
+        auto *ch = static_cast<Channel *>(handle);
+        std::lock_guard<std::mutex> lock(ch->m);
+        if (ch->q.empty())
+            return 0;
+        *out = ch->q.front();
+        ch->q.pop_front();
+        return 1;
+    }
+
+    // Briefly sleep to avoid a hot busy-wait in a blocking `select` poll loop.
+    void __tocin_chan_park()
+    {
+        std::this_thread::sleep_for(std::chrono::milliseconds(1));
     }
 
     void __tocin_join_all();

--- a/src/type/type_checker.cpp
+++ b/src/type/type_checker.cpp
@@ -397,8 +397,19 @@ namespace type_checker
 
     void TypeChecker::visitSelectStmt(ast::SelectStmt *stmt)
     {
-        // Type check select statement (concurrency)
-        // In practice, check all cases and ensure they are valid channel operations
+        // Check each case's channel expression and body. The received value is
+        // bound as an int (the 64-bit channel slot) in the case body's scope.
+        for (auto &c : stmt->cases)
+        {
+            pushScope();
+            if (!c.isDefault && c.channel)
+                c.channel->accept(*this);
+            if (environment_ && !c.bindName.empty())
+                environment_->define(c.bindName, makeBasic(ast::TypeKind::INT), false);
+            if (c.body)
+                c.body->accept(*this);
+            popScope();
+        }
         currentType_ = nullptr;
     }
 

--- a/stdlib/std/linq.to
+++ b/stdlib/std/linq.to
@@ -1,0 +1,85 @@
+// Tocin standard library: LINQ-style collection operations over int lists.
+//
+// Tocin does not yet have first-class lambdas, so transforms come in two forms:
+//   * reductions/aggregations that return a scalar, and
+//   * `*Into` transforms that write into a caller-allocated destination list.
+// Booleans are represented as int (0/1), matching std.list / std.math.
+
+// ---- Reductions / aggregations ----
+
+def reduceSum(xs: list<int>) -> int {
+    let acc = 0;
+    for i in 0..len(xs) { acc = acc + xs[i]; }
+    return acc;
+}
+
+def reduceProduct(xs: list<int>) -> int {
+    let acc = 1;
+    for i in 0..len(xs) { acc = acc * xs[i]; }
+    return acc;
+}
+
+// Fold with an explicit seed and an operation code:
+//   op 0 = add, 1 = multiply, 2 = max, 3 = min.
+def aggregate(xs: list<int>, seed: int, op: int) -> int {
+    let acc = seed;
+    for i in 0..len(xs) {
+        let v = xs[i];
+        if op == 0 { acc = acc + v; }
+        if op == 1 { acc = acc * v; }
+        if op == 2 { if v > acc { acc = v; } }
+        if op == 3 { if v < acc { acc = v; } }
+    }
+    return acc;
+}
+
+def count(xs: list<int>) -> int { return len(xs); }
+
+// where(x > threshold).count()
+def countGreater(xs: list<int>, threshold: int) -> int {
+    let c = 0;
+    for i in 0..len(xs) { if xs[i] > threshold { c = c + 1; } }
+    return c;
+}
+
+def indexOf(xs: list<int>, target: int) -> int {
+    for i in 0..len(xs) { if xs[i] == target { return i; } }
+    return -1;
+}
+
+// all(x > threshold)
+def allGreater(xs: list<int>, threshold: int) -> int {
+    for i in 0..len(xs) { if xs[i] <= threshold { return 0; } }
+    return 1;
+}
+
+// any(x > threshold)
+def anyGreater(xs: list<int>, threshold: int) -> int {
+    for i in 0..len(xs) { if xs[i] > threshold { return 1; } }
+    return 0;
+}
+
+// ---- select / map into a caller-allocated destination (dst length >= src) ----
+
+def mapScaleInto(dst: list<int>, src: list<int>, k: int) -> int {
+    for i in 0..len(src) { dst[i] = src[i] * k; }
+    return len(src);
+}
+
+def mapAddInto(dst: list<int>, src: list<int>, k: int) -> int {
+    for i in 0..len(src) { dst[i] = src[i] + k; }
+    return len(src);
+}
+
+// ---- where / filter into a destination; returns the number written ----
+
+def filterGreaterInto(dst: list<int>, src: list<int>, threshold: int) -> int {
+    let n = 0;
+    for i in 0..len(src) {
+        if src[i] > threshold {
+            dst[n] = src[i];
+            n = n + 1;
+        }
+    }
+    return n;
+}

--- a/tests/cases/ffi_atoi.to
+++ b/tests/cases/ffi_atoi.to
@@ -1,0 +1,3 @@
+// expect: 32
+extern def atoi(s: string) -> int;
+def main() -> int { return atoi("32"); }

--- a/tests/cases/ffi_labs.to
+++ b/tests/cases/ffi_labs.to
@@ -1,0 +1,4 @@
+// expect: 42
+// C FFI: call libc labs via an extern declaration.
+extern def labs(x: int) -> int;
+def main() -> int { return labs(-42); }

--- a/tests/cases/ffi_multi.to
+++ b/tests/cases/ffi_multi.to
@@ -1,0 +1,9 @@
+// expect: 42
+// Two extern calls in two typed locals (regression for the initializer fix).
+extern def labs(x: int) -> int;
+extern def atoi(s: string) -> int;
+def main() -> int {
+    let a: int = labs(-10);
+    let b: int = atoi("32");
+    return a + b;
+}

--- a/tests/cases/ffi_putchar.to
+++ b/tests/cases/ffi_putchar.to
@@ -1,0 +1,3 @@
+// expect-output: A
+extern def putchar(c: int) -> int;
+def main() -> int { putchar(65); return 0; }

--- a/tests/cases/let_typed_two_calls.to
+++ b/tests/cases/let_typed_two_calls.to
@@ -1,0 +1,12 @@
+// expect: 42
+// Regression: two explicitly-typed locals each initialized by a call must each
+// evaluate their own initializer (previously the second reused a stale value,
+// producing invalid IR / a wrong result).
+def f(x: int) -> int { return x; }
+def g(x: int) -> int { return x; }
+
+def main() {
+    let a: int = f(10);
+    let b: int = g(32);
+    return a + b;
+}

--- a/tests/cases/linq_aggregate.to
+++ b/tests/cases/linq_aggregate.to
@@ -1,0 +1,6 @@
+// expect: 19
+import std.linq;
+def main() -> int {
+    let a = [3, 1, 4, 1, 5];
+    return aggregate(a, 5, 0);   // 5 + 14 = 19
+}

--- a/tests/cases/linq_filter_count.to
+++ b/tests/cases/linq_filter_count.to
@@ -1,0 +1,6 @@
+// expect: 3
+import std.linq;
+def main() -> int {
+    let a = [5, 1, 8, 2, 9, 0];
+    return countGreater(a, 3);   // 5,8,9 -> 3
+}

--- a/tests/cases/linq_filter_into.to
+++ b/tests/cases/linq_filter_into.to
@@ -1,0 +1,10 @@
+// expect: 22
+import std.linq;
+def main() -> int {
+    let src = [5, 1, 8, 2, 9];
+    let dst = [0, 0, 0, 0, 0];
+    let n = filterGreaterInto(dst, src, 3);   // [5,8,9], n=3
+    let acc = 0;
+    for i in 0..n { acc = acc + dst[i]; }
+    return acc;                  // 22
+}

--- a/tests/cases/linq_map_into.to
+++ b/tests/cases/linq_map_into.to
@@ -1,0 +1,8 @@
+// expect: 20
+import std.linq;
+def main() -> int {
+    let src = [1, 2, 3, 4];
+    let dst = [0, 0, 0, 0];
+    mapScaleInto(dst, src, 2);   // [2,4,6,8]
+    return reduceSum(dst);       // 20
+}

--- a/tests/cases/linq_reduce.to
+++ b/tests/cases/linq_reduce.to
@@ -1,0 +1,6 @@
+// expect: 24
+import std.linq;
+def main() -> int {
+    let a = [1, 2, 3, 4];
+    return reduceProduct(a);   // 24
+}

--- a/tests/cases/null_safety_elvis.to
+++ b/tests/cases/null_safety_elvis.to
@@ -1,0 +1,10 @@
+// expect: 12
+// Elvis/null-coalescing: `a ?: b` is `a` when non-null, else `b`.
+class Box { v: int; def get(self) -> int { return self.v; } }
+def main() {
+    let b: Box = Box(5);
+    let c = b ?: Box(99);     // b non-null -> 5
+    let n: Box = None;
+    let d = n ?: Box(7);      // n null -> 7
+    return c.get() + d.get(); // 12
+}

--- a/tests/cases/null_safety_force_unwrap.to
+++ b/tests/cases/null_safety_force_unwrap.to
@@ -1,0 +1,7 @@
+// expect: 11
+// Force-unwrap `a!!` yields a when non-null (it aborts when null).
+class Box { v: int; def get(self) -> int { return self.v; } }
+def main() {
+    let b: Box = Box(11);
+    return b!!.get();
+}

--- a/tests/cases/null_safety_safe_access.to
+++ b/tests/cases/null_safety_safe_access.to
@@ -1,0 +1,11 @@
+// expect: 9
+// Safe navigation `a?.b`: a null base yields a zero/null result instead of
+// dereferencing.
+class Box { v: int; }
+def main() {
+    let b: Box = Box(9);
+    let x = b?.v;        // 9
+    let nb: Box = None;
+    let y = nb?.v;       // null base -> 0
+    return x + y;        // 9
+}

--- a/tests/cases/option_none.to
+++ b/tests/cases/option_none.to
@@ -1,0 +1,9 @@
+// expect: 7
+// None matches the None arm (None is the nil literal / null).
+def main() {
+    match None {
+        case Some(x): { return x; }
+        case None: { return 7; }
+    }
+    return 99;
+}

--- a/tests/cases/option_print.to
+++ b/tests/cases/option_print.to
@@ -1,0 +1,8 @@
+// expect-output: 30
+def main() {
+    match Some(10) {
+        case Some(x): { println(x + 20); }
+        case None: { println(0); }
+    }
+    return 0;
+}

--- a/tests/cases/option_some.to
+++ b/tests/cases/option_some.to
@@ -1,0 +1,9 @@
+// expect: 5
+// case Some(x) binds the payload.
+def main() {
+    match Some(5) {
+        case Some(x): { return x; }
+        case None: { return 0; }
+    }
+    return 99;
+}

--- a/tests/cases/result_err.to
+++ b/tests/cases/result_err.to
@@ -1,0 +1,9 @@
+// expect: 13
+// Ok and Err are distinguished by tag; Err binds its payload.
+def main() {
+    match Err(13) {
+        case Ok(v): { return v; }
+        case Err(e): { return e; }
+    }
+    return 99;
+}

--- a/tests/cases/result_ok.to
+++ b/tests/cases/result_ok.to
@@ -1,0 +1,8 @@
+// expect: 42
+def main() {
+    match Ok(42) {
+        case Ok(v): { return v; }
+        case Err(e): { return 0; }
+    }
+    return 99;
+}

--- a/tests/cases/select_default.to
+++ b/tests/cases/select_default.to
@@ -1,0 +1,11 @@
+// expect: 7
+// With nothing ready and a default present, select is non-blocking.
+def main() {
+    let ch = channel<int>();
+    let result = 0;
+    select {
+        case v = <-ch: { result = v; }
+        default: { result = 7; }
+    }
+    return result;
+}

--- a/tests/cases/select_recv.to
+++ b/tests/cases/select_recv.to
@@ -1,0 +1,12 @@
+// expect: 42
+// select receives a value sent by a goroutine (blocking, no default).
+def producer(ch: channel<int>) { ch <- 42; }
+def main() {
+    let ch = channel<int>();
+    go producer(ch);
+    let result = 0;
+    select {
+        case v = <-ch: { result = v; }
+    }
+    return result;
+}

--- a/tests/cases/select_two.to
+++ b/tests/cases/select_two.to
@@ -1,0 +1,14 @@
+// expect: 99
+// select picks the ready channel among several.
+def producer(ch: channel<int>) { ch <- 99; }
+def main() {
+    let a = channel<int>();
+    let b = channel<int>();
+    go producer(b);
+    let result = 0;
+    select {
+        case v = <-a: { result = v; }
+        case v = <-b: { result = v; }
+    }
+    return result;
+}


### PR DESCRIPTION
## Summary

Implements the remaining roadmap language features in one batch, designed with parallel subagents and integrated sequentially to keep the build green at every step. Also fixes a **general miscompilation** found during the work.

Each feature reuses existing AST nodes where possible, so there are **no Visitor-interface or macro-system changes** — keeping the blast radius small.

## Foundational fix (affects all code)

**Stale variable initializer** — `visitVariableStmt` didn't evaluate the initializer for an explicitly-typed local (`let a: int = f();`), reusing whatever `lastValue` was left over (even from another function), producing wrong results and invalid IR (`instruction does not dominate all uses`). Now the initializer is evaluated exactly once. Regression test added.

## Features

- **Null-safety operators** — safe navigation `a?.b` (null base → null/zero), elvis/coalescing `a ?: b` (short-circuits), force-unwrap `a!!` (aborts on null). `None` is a null pointer.
- **Option / Result + pattern binding** — `Some(x)`/`Ok(v)` (`{tag=1,payload}`), `Err(e)` (`{tag=0}`), `None` (null); `match` gains `case Some(x)` / `case None` / `case Ok(v)` / `case Err(e)` with payload binding. Value-equality cases still work in the same `match`. Functions can return `-> Result`.
- **`select` over channels** — waits on multiple receives; `case v = <-ch:` and optional `default`. New non-blocking `__tocin_chan_try_recv` runtime primitive (+ `__tocin_chan_park`); the old parser couldn't even parse the bind form. JIT-registered and linked into native/shared runtimes.
- **LINQ-style collections** — `stdlib/std/linq.to` (pure Tocin, no compiler changes): `reduceSum`/`reduceProduct`/`aggregate`/`countGreater`/`indexOf`/`all`/`any` and `*Into` map/filter transforms. (Arbitrary-lambda LINQ needs first-class functions — noted as pending.)
- **C FFI** — already worked via `extern def`; this adds a test suite, `examples/ffi.to`, and `docs/ffi.md` documenting the type mapping, builtin-name shadowing, and an honest status table (Python = experimental scaffold; JS/V8 = disabled, not installable here).

## Testing

- **67 `.to` integration cases** (was 46), all passing in JIT and native — covering null-safety, Option/Result, select, LINQ, FFI, plus the initializer regression.
- **6/6 C++ unit suites** pass.
- README updated: completed features moved to Highlights; Roadmap trimmed to the genuinely-pending work.

## Honest limitations (documented)

- Option/Result payloads and `select`/match binds are 64-bit int slots (typed payloads pending).
- `?.` chaining through class-typed fields, turbofish generics, higher-order LINQ, and Python/JS FFI remain future work.
- `finally` is bypassed by a `throw` inside `catch` or an early `return` in `try` (pre-existing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Fih5HHhUzVNkusdaXHoSdu

---
_Generated by [Claude Code](https://claude.ai/code/session_01Fih5HHhUzVNkusdaXHoSdu)_