### PR TITLE
Language features: by-ref closures, &/&mut borrows, generators, async/await + turnkey Windows installer

### DIFF
--- a/docs/async-scheduler-design.md
+++ b/docs/async-scheduler-design.md
@@ -1,0 +1,101 @@
+# Async M:N scheduler — design
+
+This document scopes the one concurrency item Tocin does **not** yet ship: a
+cooperative **M:N** scheduler that multiplexes many `async` tasks onto a small
+pool of OS worker threads, suspending a task at `await` when its result is not
+ready and running other tasks meanwhile.
+
+It is written so the work can be picked up as a focused, de-risked project. The
+language surface (`async def`, `await`) already works today with **eager**
+semantics (an async body runs on the calling path; `await f()` is f()'s result).
+This design replaces the eager lowering with a suspend/resume one **without
+changing observable single-result semantics** — only adding concurrency.
+
+## What already exists
+
+- **`async`/`await` front end** — parsed, type-checked, and lowered (currently
+  as ordinary synchronous calls; `await` is identity over a ready value).
+- **Goroutines + channels** — `go f(args)` packs args into a heap struct and
+  spawns a real OS thread (`__tocin_go`, `src/runtime/concurrency_runtime.cpp`);
+  `channel<T>`, `<-`, and `select` work in JIT and native builds.
+- **A fiber substrate** — `src/runtime/lightweight_scheduler.{h,cpp}`: a `Fiber`
+  with a `ucontext`-based stack (POSIX `makecontext`/`swapcontext`; Windows
+  fibers), a `WorkStealingQueue`, `Worker` threads, and a `LightweightScheduler`
+  with work-stealing and NUMA hooks. It compiles into the **compiler** today but
+  is **not linked into the program runtime** (`tocin_runtime`) and is not driven
+  by generated code.
+
+The gap is therefore *integration*, not invention: wire the existing fiber
+scheduler into the runtime and lower `async`/`await` onto it.
+
+## Target model
+
+Stackful coroutines on a fixed worker pool (the Go model), because the fiber
+substrate is already stackful:
+
+- A **task** is a `Fiber` running one `async` call's body on its own ~16–64 KB
+  stack. `go`/spawning an async function enqueues a task.
+- `P` **workers** (default `min(nproc, ...)`) each run a loop pulling ready tasks
+  from their queue, stealing from peers when idle.
+- `await fut`:
+  - fast path — if `fut` is already resolved, take the value and continue (no
+    switch), preserving today's eager behavior for ready results;
+  - slow path — register the current fiber as `fut`'s waiter and
+    `swapcontext` back to the worker scheduler loop. When `fut` resolves, its
+    completer marks the waiter Ready and pushes it to a worker queue; the worker
+    later `swapcontext`s back in, and `await` returns the value.
+- A **Future** is `{ state, value, waiters, mutex }`; an async task's return
+  resolves its own future and wakes waiters.
+
+## Work items (in dependency order)
+
+1. **Link the scheduler into the runtime.** Add `lightweight_scheduler.cpp` (and
+   a new `async_runtime.cpp`) to the `tocin_runtime` / `tocin_runtime_shared`
+   targets in `CMakeLists.txt`. Today only `concurrency_runtime.cpp` is linked
+   into programs.
+2. **C ABI bridge** (`extern "C"`, the established `__tocin_*` pattern — define
+   in the runtime, dispatch by name in `visitCallExpr`, register in `main.cpp`):
+   - `__tocin_sched_start()/_shutdown()` — boot/drain the worker pool.
+   - `void* __tocin_future_new()`, `__tocin_future_resolve(f, i64)`,
+     `i64 __tocin_future_await(f)` — await parks the current fiber if pending.
+   - `__tocin_spawn(fnptr, argpack)` — enqueue an async body as a task (reuse the
+     `go` arg-packing thunk in `visitGoStmt`).
+3. **Lower `async`/`await` onto the bridge.**
+   - An `async def` compiles to a body function returning into a future plus a
+     thin entry that `__tocin_spawn`s it and returns the future handle.
+   - `await e` → `__tocin_future_await(e)` (replacing today's identity lowering
+     in `visitAwaitExpr`). Keep the eager fast path inside the runtime so
+     single-await programs behave identically.
+4. **GC × fibers (correctness-critical).** Boehm GC must scan every fiber stack
+   as roots, or live values get collected mid-suspend. Register each fiber stack
+   with `GC_register_my_thread` / a `GC_stack_base`, or allocate fiber stacks
+   from GC memory and push them as explicit roots. This is the subtlest item and
+   needs its own stress test (allocate-heavy tasks across many suspends).
+5. **Blocking-call offload.** A task that makes a blocking syscall (file/socket)
+   would stall its worker. Minimum: document it. Better: a small blocking-IO
+   thread pool, or hand off to non-blocking epoll/kqueue (ties into the
+   higher-level-networking item).
+6. **Cancellation + structured concurrency** (optional v2): a `select`/timeout
+   that cancels a pending await; scope-bound task groups.
+
+## Testing
+
+- **Semantics unchanged**: every existing async test (`tests/cases/async_*.to`)
+  must still pass under the new lowering.
+- **Real interleaving**: two async tasks that `await` on each other's futures
+  must complete (would deadlock under a 1:1 model with fewer workers than
+  tasks) — proves M:N suspend/resume.
+- **Scale**: spawn 100k tasks that each await once; assert completion and a
+  worker count ≪ task count (proves M:N, not 1:1).
+- **GC stress**: allocation-heavy tasks across many suspensions, run under GC,
+  assert no use-after-free and bounded memory.
+
+## Why it is deferred (honesty)
+
+Items 1–4 are individually tractable but collectively a subsystem, and item 4
+(GC interacting with hand-switched stacks) is genuinely subtle — a wrong cut
+there yields rare, hard-to-debug corruption. Shipping a half-working scheduler
+would regress the currently-green concurrency story, so it is staged here as
+scoped, testable work rather than rushed in. The eager `async`/`await` that
+ships today is correct for the common single-result case; this design is the
+path to making it *concurrent*.

--- a/docs/capability-report.md
+++ b/docs/capability-report.md
@@ -4,9 +4,9 @@ An honest assessment of what Tocin can and cannot build today, written against
 the real in-tree compiler (every claim below is backed by a program that
 compiles and runs — see `tests/cases/` and `examples/`).
 
-Last updated: this build. Test suite: 139/139 `.to` programs passing, plus
-opt-in borrow-check (5/5), match-exhaustiveness (3/3), and safety —
-const + bounds + trait-bound (3/3) — harnesses.
+Last updated: this build. Test suite: 141/141 `.to` programs passing, plus
+opt-in borrow-check — move + `&`/`&mut` borrows (12/12), match-exhaustiveness
+(3/3), and safety — const + bounds + trait-bound (3/3) — harnesses.
 
 ---
 
@@ -96,14 +96,21 @@ These are the remaining items a Rust/C++-class language would want; none are
 blocked by a fundamental design flaw, but they are real work and are *not*
 implemented today:
 
-- `&`/`&mut` reference borrows and lifetimes (the borrow checker is move-only)
-  and generators (`yield`). **By-reference closure capture now works**: a
-  closure that *writes* a captured local shares the cell, so the mutation is
-  visible in the enclosing scope (read-only captures stay by-value snapshots).
-  The one nuance is escaping by-ref closures (a written-capture closure that
-  outlives its defining frame) — not reachable today because the type checker
-  does not yet permit calling a stored function-typed value; heap-promotion of
-  the cell is the upgrade for when it does.
+- Generators (`yield`) are not yet built. **By-reference closure capture now
+  works**: a closure that *writes* a captured local shares the cell, so the
+  mutation is visible in the enclosing scope (read-only captures stay by-value
+  snapshots). The one nuance is escaping by-ref closures (a written-capture
+  closure that outlives its defining frame) — not reachable today because the
+  type checker does not yet permit calling a stored function-typed value;
+  heap-promotion of the cell is the upgrade for when it does.
+- **`&`/`&mut` reference borrows now work** under `--borrow-check`: `&x` takes a
+  shared borrow and `&mut x` an exclusive one, with the standard rule (many
+  shared XOR one mutable) and lexical borrow lifetimes (a borrow ends when its
+  binding leaves scope). Conflicts — a second `&mut`, a `&mut` over a live `&`,
+  using/moving/mutating a value while it is borrowed — are fatal `B002`. What
+  remains is non-lexical (flow-sensitive) lifetimes and borrows through struct
+  fields / across function boundaries; the move analysis and these statement-
+  scoped borrows are the foundation those build on.
 - **Async runtime / M:N scheduler.** `async`/`await` parse and goroutines run on
   1:1 OS threads; a cooperative scheduler that suspends/resumes `await` on a
   worker pool is not yet built.
@@ -136,11 +143,13 @@ implemented today:
 4. **Generators, the power operator `**`, and `++`/`--` are not implemented.**
    Memory safety has two layers: GC by default (always safe — no use-after-free
    regardless), plus an **opt-in borrow checker** (`--borrow-check`) that adds
-   Rust-like compile-time move / use-after-move enforcement on owned values.
-   `defer` + RAII destructors (`__del__`) give deterministic cleanup. The borrow
-   checker is move-only for now — `&`/`&mut` reference borrows and lifetimes are
-   the remaining Rust-parity items (the move analysis is the foundation they
-   build on).
+   Rust-like compile-time enforcement on owned values: move / use-after-move
+   (`B001`) *and* `&`/`&mut` reference borrows with the shared-XOR-mutable rule
+   and lexical borrow lifetimes (`B002`). `defer` + RAII destructors (`__del__`)
+   give deterministic cleanup. What remains for full Rust parity is non-lexical
+   (flow-sensitive) lifetimes and borrows through struct fields / across
+   function boundaries — refinements on the statement-scoped borrows that work
+   today.
 5. **TCP networking is built in** (`tcpListen`/`tcpAccept`/`tcpConnect`/
    `tcpSend`/`tcpRecv`/`tcpClose`, POSIX sockets) — enough to write a concurrent
    server (pair with `go`) or a client, plus `time`/`hashing`/`random`/`env`

--- a/docs/capability-report.md
+++ b/docs/capability-report.md
@@ -4,7 +4,7 @@ An honest assessment of what Tocin can and cannot build today, written against
 the real in-tree compiler (every claim below is backed by a program that
 compiles and runs — see `tests/cases/` and `examples/`).
 
-Last updated: this build. Test suite: 144/144 `.to` programs passing, plus
+Last updated: this build. Test suite: 146/146 `.to` programs passing, plus
 opt-in borrow-check — move + `&`/`&mut` borrows (12/12), match-exhaustiveness
 (3/3), and safety — const + bounds + trait-bound (3/3) — harnesses.
 
@@ -125,9 +125,16 @@ implemented today:
   remains is non-lexical (flow-sensitive) lifetimes and borrows through struct
   fields / across function boundaries; the move analysis and these statement-
   scoped borrows are the foundation those build on.
-- **Async runtime / M:N scheduler.** `async`/`await` parse and goroutines run on
-  1:1 OS threads; a cooperative scheduler that suspends/resumes `await` on a
-  worker pool is not yet built.
+- **Async/await works; the M:N scheduler is the remaining layer.** `async def`
+  and `await` now compile and run with correct eager semantics: an async body
+  runs on the calling path and `await f()` evaluates to f()'s result (composes
+  in expressions and across async calls — `examples/async_await.to`). Goroutines
+  (`go`) run on real 1:1 OS threads with channels. What is *not* built is the
+  cooperative **M:N** scheduler that suspends a pending `await` and runs other
+  tasks on a worker pool — the fiber substrate exists
+  (`src/runtime/lightweight_scheduler.*`, ucontext-based) but is not yet wired
+  into the program runtime; the design is written up in
+  `docs/async-scheduler-design.md`.
 - **Higher-level networking** (HTTP, TLS) and async/epoll I/O; build on the raw
   socket primitives or C FFI.
 - **Tooling**: a formatter and an LSP are not provided; a hosted package

--- a/docs/capability-report.md
+++ b/docs/capability-report.md
@@ -4,7 +4,7 @@ An honest assessment of what Tocin can and cannot build today, written against
 the real in-tree compiler (every claim below is backed by a program that
 compiles and runs — see `tests/cases/` and `examples/`).
 
-Last updated: this build. Test suite: 141/141 `.to` programs passing, plus
+Last updated: this build. Test suite: 144/144 `.to` programs passing, plus
 opt-in borrow-check — move + `&`/`&mut` borrows (12/12), match-exhaustiveness
 (3/3), and safety — const + bounds + trait-bound (3/3) — harnesses.
 
@@ -89,6 +89,15 @@ systems — each backed by a passing `.to` test and, where noted, an example:
 - **Generic trait bounds** — `def f<T: Bound>` rejects a type argument that does
   not implement `Bound` (fatal `T016`), and trait-method calls on the bounded
   parameter resolve to the concrete type.
+- **Generators** — a function with `yield` produces a sequence; calling it
+  materializes the yielded values into an array that `for x in gen(...)` walks
+  or indexes. Eager (finite-sequence) collection. (`examples/generators.to`)
+- **By-reference closures** — a closure that writes a captured local shares the
+  cell (the write is visible outside); read-only captures stay by-value.
+  (`examples/byref_closures.to`)
+- **`&`/`&mut` reference borrows** — under `--borrow-check`, shared-XOR-mutable
+  borrows with lexical lifetimes (conflicts are fatal `B002`).
+  (`examples/borrow_check.to`)
 
 ## Not yet built (honest)
 
@@ -96,13 +105,18 @@ These are the remaining items a Rust/C++-class language would want; none are
 blocked by a fundamental design flaw, but they are real work and are *not*
 implemented today:
 
-- Generators (`yield`) are not yet built. **By-reference closure capture now
-  works**: a closure that *writes* a captured local shares the cell, so the
-  mutation is visible in the enclosing scope (read-only captures stay by-value
-  snapshots). The one nuance is escaping by-ref closures (a written-capture
-  closure that outlives its defining frame) — not reachable today because the
-  type checker does not yet permit calling a stored function-typed value;
-  heap-promotion of the cell is the upgrade for when it does.
+- **By-reference closure capture now works**: a closure that *writes* a
+  captured local shares the cell, so the mutation is visible in the enclosing
+  scope (read-only captures stay by-value snapshots). The one nuance is escaping
+  by-ref closures (a written-capture closure that outlives its defining frame) —
+  not reachable today because the type checker does not yet permit calling a
+  stored function-typed value; heap-promotion of the cell is the upgrade for
+  when it does.
+- **Generators (`yield`) now work** for finite sequences: a function containing
+  `yield` becomes a generator whose call materializes the yielded values as an
+  array that `for x in gen(...)` iterates (or you can index it). Collection is
+  eager (collect-then-iterate), so infinite/lazy generators — which need a
+  coroutine substrate (see the async item) — are the remaining piece.
 - **`&`/`&mut` reference borrows now work** under `--borrow-check`: `&x` takes a
   shared borrow and `&mut x` an exclusive one, with the standard rule (many
   shared XOR one mutable) and lexical borrow lifetimes (a borrow ends when its
@@ -140,7 +154,8 @@ implemented today:
    are designed for `int`. Pointers/strings round-trip as raw addresses but
    there is no element-type tracking, so storing strings in a `vector` is
    fragile. Use `mapPutStr`/`mapGetStr` for string-keyed data.
-4. **Generators, the power operator `**`, and `++`/`--` are not implemented.**
+4. **The power operator `**` and `++`/`--` are not implemented** (generators
+   now work for finite sequences via `yield`; truly lazy ones are future work).
    Memory safety has two layers: GC by default (always safe — no use-after-free
    regardless), plus an **opt-in borrow checker** (`--borrow-check`) that adds
    Rust-like compile-time enforcement on owned values: move / use-after-move

--- a/docs/capability-report.md
+++ b/docs/capability-report.md
@@ -96,9 +96,14 @@ These are the remaining items a Rust/C++-class language would want; none are
 blocked by a fundamental design flaw, but they are real work and are *not*
 implemented today:
 
-- **By-reference closure capture** (capture is by value), `&`/`&mut` reference
-  borrows and lifetimes (the borrow checker is move-only), and generators
-  (`yield`).
+- `&`/`&mut` reference borrows and lifetimes (the borrow checker is move-only)
+  and generators (`yield`). **By-reference closure capture now works**: a
+  closure that *writes* a captured local shares the cell, so the mutation is
+  visible in the enclosing scope (read-only captures stay by-value snapshots).
+  The one nuance is escaping by-ref closures (a written-capture closure that
+  outlives its defining frame) — not reachable today because the type checker
+  does not yet permit calling a stored function-typed value; heap-promotion of
+  the cell is the upgrade for when it does.
 - **Async runtime / M:N scheduler.** `async`/`await` parse and goroutines run on
   1:1 OS threads; a cooperative scheduler that suspends/resumes `await` on a
   worker pool is not yet built.
@@ -116,12 +121,14 @@ implemented today:
    `vecFree`/`mapFree`; and the GC is conservative (an int that happens to hold
    a heap address keeps that block alive). For request-scoped servers this is a
    non-issue in practice.
-2. **Capture is by value, not by reference.** Closures snapshot captured
-   locals; mutating the original afterward doesn't change the copy. (`const`
-   bindings are enforced — reassigning one is a compile error; array indexing is
-   bounds-checked by default, panicking on an out-of-range access, with
-   `--freestanding` omitting the check for systems code; and `break`/`continue`
-   support outer-loop labels.)
+2. **Closure capture is by value for reads, by reference for writes.** A
+   closure that only reads a captured local snapshots it (mutating the original
+   afterward doesn't change the snapshot); a closure that *assigns* a captured
+   local shares the underlying cell, so the write is visible outside the closure
+   (`examples/byref_closures.to`). (`const` bindings are enforced — reassigning
+   one is a compile error; array indexing is bounds-checked by default, panicking
+   on an out-of-range access, with `--freestanding` omitting the check for systems
+   code; and `break`/`continue` support outer-loop labels.)
 3. **Collection elements are 64-bit slots.** `vector`/`map`/channel payloads
    are designed for `int`. Pointers/strings round-trip as raw addresses but
    there is no element-type tracking, so storing strings in a `vector` is

--- a/examples/README.md
+++ b/examples/README.md
@@ -22,10 +22,12 @@ These programs compile and run with the current compiler. Run any of them with:
 | `json_parser.to` | A JSON parser written in Tocin (ADTs + recursion + vectors) |
 | `tuples.to` | **Tuples** and multiple return values; destructuring |
 | `iterators.to` | The **iterator protocol** (`next(self) -> Option`) |
+| `generators.to` | **Generators** (`yield`) — finite sequences driven by `for x in gen()` |
+| `byref_closures.to` | **By-reference closures** — a closure mutates a captured local |
 | `tcp_echo.to` | **TCP networking** + `go` goroutines (a loopback server/client) |
 | `operator_overload.to` | Operator overloading via dunder methods |
 | `raii_destructor.to` | Deterministic cleanup with `__del__` + `defer` |
-| `borrow_check.to` | The opt-in `--borrow-check` move analysis |
+| `borrow_check.to` | The opt-in `--borrow-check` move + `&`/`&mut` borrow analysis |
 | `freestanding_kernel.to` | `--freestanding` systems code (no libc/GC/runtime) |
 | `defer_cleanup.to` | `defer` (LIFO cleanup at function return) |
 | `concurrency.to` | `go` goroutines, typed channels, `select` |

--- a/examples/README.md
+++ b/examples/README.md
@@ -24,6 +24,7 @@ These programs compile and run with the current compiler. Run any of them with:
 | `iterators.to` | The **iterator protocol** (`next(self) -> Option`) |
 | `generators.to` | **Generators** (`yield`) — finite sequences driven by `for x in gen()` |
 | `byref_closures.to` | **By-reference closures** — a closure mutates a captured local |
+| `async_await.to` | **async/await** — async functions and awaiting their results |
 | `tcp_echo.to` | **TCP networking** + `go` goroutines (a loopback server/client) |
 | `operator_overload.to` | Operator overloading via dunder methods |
 | `raii_destructor.to` | Deterministic cleanup with `__del__` + `defer` |

--- a/examples/async_await.to
+++ b/examples/async_await.to
@@ -1,0 +1,28 @@
+// async / await
+// -------------
+// `async def` marks a function asynchronous and `await` retrieves an async
+// result. Today async bodies run eagerly (on the calling path) and `await f()`
+// evaluates to f()'s result — correct async/await *semantics*. The cooperative
+// M:N scheduler that would run pending awaits concurrently on a worker pool is
+// designed in docs/async-scheduler-design.md (goroutines via `go` already run
+// on real OS threads).
+
+async def square(x: int) -> int {
+    return x * x;
+}
+
+async def sumOfSquares(n: int) -> int {
+    let total = 0;
+    let i = 1;
+    while i <= n {
+        total = total + await square(i);   // await composes in expressions
+        i = i + 1;
+    }
+    return total;
+}
+
+def main() -> int {
+    let r = await sumOfSquares(5);   // 1+4+9+16+25 = 55
+    println("sum of squares 1..5 = {}", r);
+    return r;
+}

--- a/examples/borrow_check.to
+++ b/examples/borrow_check.to
@@ -1,14 +1,21 @@
-// Opt-in ownership / move checking.  Compile with:
+// Opt-in ownership / move + borrow checking.  Compile with:
 //   tocin --borrow-check examples/borrow_check.to -o app
 //
 // By DEFAULT (no flag) Tocin is GC-based and class instances alias freely.
 // With --borrow-check, owned values (class/struct instances) follow Rust-like
-// move semantics: binding/passing/returning a value MOVES it, and using a moved
-// value is a compile error (B001). Reassignment revives. Copy types
-// (int/float/bool) are never moved.
+// rules:
 //
-// This file is written to PASS the checker. To see an error, add `return a.v;`
-// after `let b = a;` — `a` was moved into `b`.
+//   Moves   — binding/passing/returning a value MOVES it; using a moved value
+//             is a compile error (B001). Reassignment revives. Copy types
+//             (int/float/bool) are never moved.
+//   Borrows — `&x` is a shared borrow and `&mut x` an exclusive one. Many
+//             shared borrows may coexist, but a `&mut` is exclusive: while one
+//             is live you cannot use, move, mutate, or re-borrow `x` (B002).
+//             Borrows end when the borrowing binding leaves scope.
+//
+// This file is written to PASS the checker. To see errors, try:
+//   - add `return a.size;` right after `let b = a;`   (use after move,  B001)
+//   - add `let m2 = &mut a;` after `let m = &mut a;`  (double &mut,     B002)
 
 class Buffer { size: int; }
 
@@ -24,7 +31,17 @@ def main() -> int {
     a = Buffer(8);             // revive `a` with a fresh value
     let n = a.size + c.size;   // both live
 
+    // Shared borrows: any number may be live at once.
+    let r = &c;
+    let s = &c;
+    let shared = r.size + s.size;   // 16 + 16 = 32
+
+    // Exclusive borrow in its own scope; released at the closing brace.
+    let ex = 0;
+    { let m = &mut a; ex = m.size; }   // 8
+
     let i = 10;
     let j = i;                 // int is a copy type: `i` still usable
-    return total + n + i + j;  // 64 + (8+16) + 10 + 10 = 108
+    // 64 + (8+16) + 32 + 8 + 10 + 10 = 148
+    return total + n + shared + ex + i + j;
 }

--- a/examples/byref_closures.to
+++ b/examples/byref_closures.to
@@ -1,0 +1,29 @@
+// By-reference closure capture
+// ----------------------------
+// A closure that READS a captured local takes a by-value snapshot; a closure
+// that WRITES (assigns) a captured local shares the underlying cell, so the
+// mutation is visible in the enclosing scope after the closure runs.
+
+def main() -> int {
+    // --- by-value read: the snapshot is frozen at capture time ---
+    let base = 10;
+    let readonly = lambda (x: int) -> int x + base;
+    base = 999;                 // does not affect the snapshot
+    let a = readonly(5);        // 5 + 10 = 15
+
+    // --- by-reference write: the closure mutates the enclosing local ---
+    let count = 0;
+    let inc = lambda () -> int count = count + 1;
+    inc();
+    inc();
+    inc();                      // count is now 3
+
+    // --- by-reference accumulation ---
+    let total = 0;
+    let add = lambda (x: int) -> int total = total + x;
+    add(100);
+    add(40);                    // total is now 140
+
+    // a(15) + count(3) + total(140) = 158
+    return a + count + total;
+}

--- a/examples/generators.to
+++ b/examples/generators.to
@@ -1,0 +1,56 @@
+// Generators (`yield`)
+// --------------------
+// A function that contains `yield` is a generator: each `yield x` contributes
+// the next value of a sequence, and calling the generator produces that whole
+// sequence, which `for x in gen(...)` walks (or you can index it directly).
+//
+// The sequence is materialized eagerly (collect-then-iterate), so generators
+// model finite sequences — the natural, common case. (Truly lazy / infinite
+// generators would need a coroutine substrate, which is future work.)
+
+// Yield the first `n` square numbers.
+def squares(n: int) -> int {
+    let i = 1;
+    while i <= n {
+        yield i * i;
+        i = i + 1;
+    }
+}
+
+// Yield only the even numbers in [0, n) — generators can yield conditionally.
+def evens(n: int) -> int {
+    for i in 0..n {
+        if i % 2 == 0 {
+            yield i;
+        }
+    }
+}
+
+// The classic: the first `n` Fibonacci numbers.
+def fibs(n: int) -> int {
+    let a = 0;
+    let b = 1;
+    for i in 0..n {
+        yield a;
+        let t = a + b;
+        a = b;
+        b = t;
+    }
+}
+
+def main() -> int {
+    let sumSq = 0;
+    for s in squares(5) { sumSq = sumSq + s; }   // 1+4+9+16+25 = 55
+
+    let sumEven = 0;
+    for e in evens(10) { sumEven = sumEven + e; } // 0+2+4+6+8 = 20
+
+    let f = fibs(10);                             // 0 1 1 2 3 5 8 13 21 34
+    let fib9 = f[9];                              // 34
+
+    println("sum of squares 1..5 = {}", sumSq);
+    println("sum of evens   < 10 = {}", sumEven);
+    println("10th fibonacci      = {}", fib9);
+
+    return sumSq + sumEven + fib9;                // 55 + 20 + 34 = 109
+}

--- a/installer/README.md
+++ b/installer/README.md
@@ -8,8 +8,9 @@ producing and publishing the release packages.
 
 | File | Role |
 |---|---|
+| `windows/Build-TocinInstaller.ps1` | **Turnkey Windows builder** — bootstraps the toolchain, builds, and packages in one run (see below). |
 | `package.sh` | Build a Linux/macOS tarball (`dist/tocin-<ver>-<os>-<arch>.tar.gz`). |
-| `package.ps1` | Build a Windows zip (`dist/tocin-<ver>-windows-x86_64.zip`). |
+| `package.ps1` | Build a Windows zip when the toolchain is *already* installed. |
 | `install.sh` | Per-user installer that ships *inside* each Unix tarball. |
 | `install.ps1` | Per-user installer for Windows (also a download bootstrap). |
 | `get-tocin.sh` | `curl \| sh` bootstrap: download the latest release + install. |
@@ -29,12 +30,29 @@ installer/package.sh --bundle-libs
 
 # On macOS  (run on an Intel mac for x86_64, an Apple-silicon mac for arm64):
 installer/package.sh --bundle-libs
-
-# On Windows:
-installer\package.ps1 -BundleLibs
 ```
 
 Each writes its artifact to `dist/`.
+
+### Windows — one turnkey script (no prior setup)
+
+On a clean Windows machine, run **one** script and it does everything —
+installs the toolchain (MSYS2 + LLVM 18 + GCC + CMake + Ninja + Boehm GC via
+`pacman`), builds the compiler, vendors the dependent DLLs so the result runs
+without MSYS2, and writes `dist\tocin-<ver>-windows-x86_64.zip`:
+
+```powershell
+powershell -ExecutionPolicy Bypass -File installer\windows\Build-TocinInstaller.ps1
+```
+
+Useful flags: `-SkipDeps` (toolchain already installed — much faster repeat
+builds), `-Msys2Root <path>` (reuse an existing MSYS2), `-WithPython -WithXml
+-WithZstd` (enable the optional features; off by default to keep a fresh-machine
+build robust), `-NoBundle` (smaller zip that needs mingw64 on PATH). If NSIS
+(`makensis`) is on PATH it also emits a `.exe` installer.
+
+If you already have the MSYS2/mingw64 toolchain set up, `installer\package.ps1
+-BundleLibs` packages an existing `build\` without the bootstrap step.
 
 ## Publish a GitHub Release (no CI required)
 

--- a/installer/windows/Build-TocinInstaller.ps1
+++ b/installer/windows/Build-TocinInstaller.ps1
@@ -1,0 +1,257 @@
+<#
+.SYNOPSIS
+    Turnkey Tocin installer builder for Windows. Run this ONE script on a clean
+    Windows machine and it bootstraps the toolchain, builds the compiler, and
+    produces a self-contained installer package — no other setup required.
+
+.DESCRIPTION
+    Steps, each idempotent (re-running skips finished work):
+      1. Ensure MSYS2 is installed (via winget, or point at an existing install
+         with -Msys2Root). MSYS2/mingw64 is the project's supported Windows
+         toolchain — it provides LLVM 18, GCC, CMake, Ninja and Boehm GC, all
+         ABI-matched, which CMakeLists.txt already expects on Windows.
+      2. pacman-install the mingw64 toolchain + libraries.
+      3. Configure + build tocin (Release) with Ninja from the mingw64 shell.
+      4. Stage a self-contained tree: the compiler, runtime DLL, the *dependent
+         mingw/LLVM DLLs* (so it runs on a machine without MSYS2), the standard
+         library, docs, examples, an installer (install.ps1, which adds Tocin to
+         PATH and writes an uninstaller), and a VERSION file.
+      5. Zip it to  dist\tocin-<version>-windows-x86_64.zip
+      6. If makensis (NSIS) is on PATH, also emit a .exe installer.
+
+    The produced .zip is what you upload to a GitHub Release (Tocin's installs
+    do not depend on CI — this script is the build).
+
+.PARAMETER Msys2Root
+    MSYS2 install root. Default C:\msys64. If MSYS2 is missing here it is
+    installed (winget). Point this at an existing MSYS2 to reuse it.
+
+.PARAMETER SkipDeps
+    Skip the MSYS2 install + pacman step (use when the toolchain is already set
+    up — much faster for repeat builds).
+
+.PARAMETER WithPython, WithXml, WithZstd
+    Enable the optional Python-FFI / LibXml2 / zstd features (off by default to
+    keep a fresh-machine build robust and the package lean; the core language
+    needs none of them).
+
+.PARAMETER NoBundle
+    Do not copy dependent DLLs into the package (produces a smaller zip that
+    requires MSYS2/mingw64 on PATH to run — not self-contained).
+
+.EXAMPLE
+    powershell -ExecutionPolicy Bypass -File installer\windows\Build-TocinInstaller.ps1
+
+.EXAMPLE
+    # reuse an existing toolchain, enable every optional feature
+    .\installer\windows\Build-TocinInstaller.ps1 -SkipDeps -WithPython -WithXml -WithZstd
+#>
+[CmdletBinding()]
+param(
+    [string]$Msys2Root = "C:\msys64",
+    [switch]$SkipDeps,
+    [switch]$WithPython,
+    [switch]$WithXml,
+    [switch]$WithZstd,
+    [switch]$NoBundle
+)
+
+$ErrorActionPreference = "Stop"
+function Info($m) { Write-Host ">> $m" -ForegroundColor Cyan }
+function Warn($m) { Write-Host "!! $m" -ForegroundColor Yellow }
+function Die($m)  { Write-Host "XX $m" -ForegroundColor Red; exit 1 }
+
+# Repo root = two levels up from installer\windows\.
+$repo  = (Resolve-Path (Join-Path $PSScriptRoot "..\..")).Path
+$build = Join-Path $repo "build"
+$dist  = Join-Path $repo "dist"
+$bash  = Join-Path $Msys2Root "usr\bin\bash.exe"
+
+# Select the mingw64 toolchain for every bash -l invocation.
+$env:MSYSTEM = "MINGW64"
+$env:CHERE_INVOKING = "1"
+
+# Convert a Windows path (C:\a\b) to an MSYS path (/c/a/b).
+function To-Msys([string]$p) {
+    $drive = $p.Substring(0,1).ToLowerInvariant()
+    $rest  = ($p.Substring(2) -replace '\\','/')
+    return "/$drive$rest"
+}
+$repoMsys = To-Msys $repo
+
+# Run a command inside the MSYS2 *mingw64* login shell, in the repo dir.
+function Mingw($cmdline) {
+    if (-not (Test-Path $bash)) { Die "MSYS2 bash not found at $bash" }
+    & $bash -lc "cd '$repoMsys' && $cmdline"
+    if ($LASTEXITCODE -ne 0) { Die "mingw64 command failed (exit $LASTEXITCODE): $cmdline" }
+}
+
+# ---------------------------------------------------------------------------
+# 1. Ensure MSYS2
+# ---------------------------------------------------------------------------
+if (-not $SkipDeps) {
+    if (-not (Test-Path $bash)) {
+        Info "MSYS2 not found at $Msys2Root — installing via winget"
+        if (-not (Get-Command winget -ErrorAction SilentlyContinue)) {
+            Die @"
+winget is not available and MSYS2 is not installed.
+Install MSYS2 manually from https://www.msys2.org, then re-run with
+  -Msys2Root <path>  (default C:\msys64), or -SkipDeps if the toolchain is ready.
+"@
+        }
+        winget install -e --id MSYS2.MSYS2 --accept-source-agreements --accept-package-agreements
+        if (-not (Test-Path $bash)) {
+            # winget may install to the default location regardless of $Msys2Root.
+            if (Test-Path "C:\msys64\usr\bin\bash.exe") { $Msys2Root = "C:\msys64"; $bash = Join-Path $Msys2Root "usr\bin\bash.exe" }
+            else { Die "MSYS2 install did not produce $bash. Set -Msys2Root to the install path." }
+        }
+    } else {
+        Info "MSYS2 found at $Msys2Root"
+    }
+
+    # 2. Toolchain + libraries. -S --needed is idempotent (skips installed).
+    #    A fresh MSYS2 wants a full upgrade first; its two-phase core upgrade is
+    #    handled naturally here because each Mingw call is a *separate* bash
+    #    process (the package-install call below is the post-upgrade "restart").
+    Info "updating pacman and installing the mingw64 toolchain (first run can take a while)"
+    Mingw "pacman -Syuu --noconfirm"
+    $pkgs = @(
+        "mingw-w64-x86_64-gcc",
+        "mingw-w64-x86_64-cmake",
+        "mingw-w64-x86_64-ninja",
+        "mingw-w64-x86_64-llvm",
+        "mingw-w64-x86_64-clang",
+        "mingw-w64-x86_64-zlib",
+        "mingw-w64-x86_64-gc",        # Boehm GC (TOCIN_HAVE_GC)
+        "mingw-w64-x86_64-ntldd-git"  # to discover dependent DLLs for bundling
+    )
+    if ($WithZstd)   { $pkgs += "mingw-w64-x86_64-zstd" }
+    if ($WithXml)    { $pkgs += "mingw-w64-x86_64-libxml2" }
+    if ($WithPython) { $pkgs += "mingw-w64-x86_64-python" }
+    Mingw ("pacman -S --needed --noconfirm " + ($pkgs -join " "))
+} else {
+    Info "skipping dependency install (-SkipDeps)"
+    if (-not (Test-Path $bash)) { Die "-SkipDeps set but MSYS2 bash not at $bash" }
+}
+
+# ---------------------------------------------------------------------------
+# 3. Configure + build (Release) in the mingw64 environment.
+# ---------------------------------------------------------------------------
+$py   = if ($WithPython) { "ON" } else { "OFF" }
+$xml  = if ($WithXml)    { "ON" } else { "OFF" }
+$zstd = if ($WithZstd)   { "ON" } else { "OFF" }
+
+Info "configuring (Ninja, Release; Python=$py XML=$xml zstd=$zstd)"
+Mingw "cmake -S . -B build -G Ninja -DCMAKE_BUILD_TYPE=Release -DWITH_PYTHON=$py -DWITH_XML=$xml -DWITH_ZSTD=$zstd"
+
+Info "building tocin + runtime (this is the long step)"
+Mingw "cmake --build build --target tocin tocin_runtime_shared -j"
+
+$exe = Join-Path $build "tocin.exe"
+if (-not (Test-Path $exe)) { Die "build did not produce $exe" }
+
+# ---------------------------------------------------------------------------
+# 4. Stage a self-contained package.
+# ---------------------------------------------------------------------------
+$ver = (& $exe --version) 2>$null
+if ($ver) { $ver = ($ver -replace '(?i)tocin\s+','').Trim() }
+if (-not $ver) { $ver = "0.1.0" }
+$name  = "tocin-$ver-windows-x86_64"
+$stage = Join-Path $dist $name
+Info "staging $name"
+if (Test-Path $stage) { Remove-Item -Recurse -Force $stage }
+foreach ($d in "bin","libexec","lib","stdlib","share\docs","share\examples") {
+    New-Item -ItemType Directory -Force -Path (Join-Path $stage $d) | Out-Null
+}
+
+# Compiler goes in libexec; a bin\ shim is written by install.ps1 on the target.
+Copy-Item $exe (Join-Path $stage "libexec\tocin.exe")
+
+# Runtime shared library (name varies by toolchain).
+$rtCopied = $false
+foreach ($rt in "tocin_runtime_shared.dll","libtocin_runtime_shared.dll","libtocin_runtime.dll","tocin_runtime.dll") {
+    $p = Join-Path $build $rt
+    if (Test-Path $p) { Copy-Item $p (Join-Path $stage "lib\tocin_runtime.dll"); $rtCopied = $true; break }
+}
+if (-not $rtCopied) { Warn "no runtime DLL found in build\ — JIT may still work if statically linked" }
+
+# Payload: stdlib, docs (tutorials), examples, version, installer.
+Copy-Item -Recurse -Force (Join-Path $repo "stdlib\*")   (Join-Path $stage "stdlib")
+Copy-Item -Recurse -Force (Join-Path $repo "docs\*")     (Join-Path $stage "share\docs")
+Copy-Item -Recurse -Force (Join-Path $repo "examples\*") (Join-Path $stage "share\examples")
+Set-Content -Path (Join-Path $stage "VERSION") -Value $ver -Encoding ASCII
+Copy-Item (Join-Path $repo "installer\install.ps1") (Join-Path $stage "install.ps1")
+if (Test-Path (Join-Path $repo "INSTALL.md")) {
+    Copy-Item (Join-Path $repo "INSTALL.md") (Join-Path $stage "README.txt")
+}
+
+# ---------------------------------------------------------------------------
+# 5. Bundle dependent DLLs so the package runs without MSYS2 on PATH.
+#    ntldd -R lists the recursive dependency tree; we copy every DLL whose
+#    resolved path lives under the mingw64 prefix (i.e. not a system DLL).
+# ---------------------------------------------------------------------------
+if (-not $NoBundle) {
+    Info "bundling dependent DLLs (self-contained)"
+    $mingwBinDir = Join-Path $Msys2Root "mingw64\bin"
+    $libOut = Join-Path $stage "lib"
+    $bundled = @{}
+    # Copy a DLL out of mingw64\bin by *name* (only mingw DLLs live there, so
+    # system DLLs like KERNEL32.dll are naturally skipped). Keyed off the name to
+    # match ntldd output without depending on its path format.
+    function Copy-MingwDll($fname) {
+        if ($bundled.ContainsKey($fname)) { return }
+        $srcDll = Join-Path $mingwBinDir $fname
+        if (Test-Path $srcDll) { Copy-Item $srcDll $libOut -Force; $bundled[$fname] = $true }
+    }
+
+    # (a) Best effort: walk ntldd's recursive dependency tree and grab each DLL
+    #     *name* (the token before "=>"), then resolve it in mingw64\bin.
+    $exeMsys = To-Msys $exe
+    $listed = & $bash -lc "ntldd -R '$exeMsys' 2>/dev/null"
+    foreach ($line in $listed) {
+        if ($line -match '([^\s/\\]+\.dll)\s*=>') { Copy-MingwDll $matches[1] }
+    }
+
+    # (b) Safety net: the runtime DLLs a mingw64 LLVM build always needs, in case
+    #     ntldd is unavailable or output parsing missed something.
+    foreach ($llvm in (Get-ChildItem $mingwBinDir -Filter "libLLVM*.dll" -ErrorAction SilentlyContinue)) {
+        Copy-MingwDll $llvm.Name
+    }
+    foreach ($n in @(
+        "libstdc++-6.dll","libgcc_s_seh-1.dll","libwinpthread-1.dll",
+        "libgc-1.dll","libgc.dll","zlib1.dll","libzstd.dll","liblzma-5.dll",
+        "libiconv-2.dll","libxml2-2.dll")) { Copy-MingwDll $n }
+
+    Info "bundled $($bundled.Count) DLL(s) into lib\"
+    if ($bundled.Count -eq 0) { Warn "no DLLs bundled — check the mingw64 toolchain under $mingwBinDir" }
+} else {
+    Info "skipping DLL bundling (-NoBundle): package will require MSYS2/mingw64 on PATH"
+}
+
+# ---------------------------------------------------------------------------
+# 6. Zip, and optionally an NSIS .exe.
+# ---------------------------------------------------------------------------
+$zip = Join-Path $dist "$name.zip"
+if (Test-Path $zip) { Remove-Item -Force $zip }
+Info "compressing $zip"
+Compress-Archive -Path $stage -DestinationPath $zip
+$zipMB = "{0:N1}" -f ((Get-Item $zip).Length / 1MB)
+
+$nsi = Join-Path $PSScriptRoot "installer.nsi"
+if ((Get-Command makensis -ErrorAction SilentlyContinue) -and (Test-Path $nsi)) {
+    Info "building NSIS .exe installer"
+    & makensis "/DVERSION=$ver" "/DSTAGE=$stage" $nsi
+    if ($LASTEXITCODE -ne 0) { Warn "makensis failed; the .zip is still valid" }
+} else {
+    Info "makensis not found — skipping .exe (the .zip installer is complete)"
+}
+
+Write-Host ""
+Info "DONE. Built Tocin $ver"
+Write-Host "   package:  $zip  ($zipMB MB)" -ForegroundColor Green
+Write-Host ""
+Write-Host "   Install locally:" -ForegroundColor Green
+Write-Host "     Expand-Archive '$zip' -DestinationPath ."
+Write-Host "     cd $name; powershell -ExecutionPolicy Bypass -File .\install.ps1"
+Write-Host ""
+Write-Host "   Publish: upload $name.zip to a GitHub Release tagged v$ver." -ForegroundColor Green

--- a/scripts/run_borrow_tests.sh
+++ b/scripts/run_borrow_tests.sh
@@ -18,14 +18,15 @@ for f in "$DIR"/*.to; do
         echo "FAIL  $name  (should compile WITHOUT --borrow-check, but did not)"
         fail=$((fail+1)); continue
     fi
-    # 2. With the flag: "ok" files must pass; others must be rejected with B001.
+    # 2. With the flag: "ok" files must pass; others must be rejected with an
+    #    ownership diagnostic (B001 use-after-move or B002 borrow conflict).
     out="$("$TOCIN" --borrow-check "$f" -o "$TMP/o2.ll" 2>&1)"; rc=$?
     if [[ "$name" == *ok* ]]; then
         if [[ $rc -eq 0 ]]; then echo "PASS  $name  (accepted, as expected)"; pass=$((pass+1))
         else echo "FAIL  $name  (should be ACCEPTED under --borrow-check): $out"; fail=$((fail+1)); fi
     else
-        if [[ $rc -ne 0 && "$out" == *B001* ]]; then echo "PASS  $name  (rejected: B001 use-after-move)"; pass=$((pass+1))
-        else echo "FAIL  $name  (should be REJECTED with B001 under --borrow-check): rc=$rc $out"; fail=$((fail+1)); fi
+        if [[ $rc -ne 0 && ( "$out" == *B001* || "$out" == *B002* ) ]]; then code=B001; [[ "$out" == *B002* ]] && code=B002; echo "PASS  $name  (rejected: $code)"; pass=$((pass+1))
+        else echo "FAIL  $name  (should be REJECTED with B001/B002 under --borrow-check): rc=$rc $out"; fail=$((fail+1)); fi
     fi
 done
 echo "========================================================"

--- a/src/codegen/ir_generator.cpp
+++ b/src/codegen/ir_generator.cpp
@@ -2939,6 +2939,35 @@ namespace
         else if (auto rs = std::dynamic_pointer_cast<ast::ReturnStmt>(stmt))
             collectExprNames(rs->value, used, bound);
     }
+
+    // Collect the names of variables ASSIGNED within an expression (a lambda
+    // body is a single expression). Used to decide which captures are by-ref.
+    void collectAssignedNames(const ast::ExprPtr &expr, std::set<std::string> &out)
+    {
+        if (!expr) return;
+        if (auto a = std::dynamic_pointer_cast<ast::AssignExpr>(expr))
+        {
+            if (auto v = std::dynamic_pointer_cast<ast::VariableExpr>(a->target))
+                out.insert(v->name);
+            else if (!a->name.empty())
+                out.insert(a->name);
+            collectAssignedNames(a->value, out);
+        }
+        else if (auto b = std::dynamic_pointer_cast<ast::BinaryExpr>(expr))
+        {
+            collectAssignedNames(b->left, out);
+            collectAssignedNames(b->right, out);
+        }
+        else if (auto g = std::dynamic_pointer_cast<ast::GroupingExpr>(expr))
+            collectAssignedNames(g->expression, out);
+        else if (auto u = std::dynamic_pointer_cast<ast::UnaryExpr>(expr))
+            collectAssignedNames(u->right, out);
+        else if (auto c = std::dynamic_pointer_cast<ast::CallExpr>(expr))
+        {
+            collectAssignedNames(c->callee, out);
+            for (auto &arg : c->arguments) collectAssignedNames(arg, out);
+        }
+    }
 } // namespace
 
 void IRGenerator::visitLambdaExpr(ast::LambdaExpr *expr)
@@ -2968,10 +2997,16 @@ void IRGenerator::visitLambdaExpr(ast::LambdaExpr *expr)
     for (auto &p : expr->parameters)
         bound.insert(p.name);
     collectExprNames(expr->body, used, bound);
+    // Captures that the lambda WRITES are taken by reference (the env holds a
+    // pointer to the enclosing cell), so the mutation is visible outside.
+    std::set<std::string> assigned;
+    collectAssignedNames(expr->body, assigned);
 
     std::vector<std::string> captureNames;
     std::vector<llvm::Value *> captureVals; // loaded in the *enclosing* scope
     std::vector<llvm::Type *> captureTypes;
+    std::vector<bool> captureByRef;
+    std::vector<llvm::Type *> captureValTypes; // pointed-to value type for by-ref
     for (const auto &name : used)
     {
         if (bound.count(name))
@@ -2979,10 +3014,22 @@ void IRGenerator::visitLambdaExpr(ast::LambdaExpr *expr)
         llvm::AllocaInst *slot = lookupVariable(name);
         if (!slot)
             continue; // not a local (e.g. a global function called inside)
+        bool byref = assigned.count(name) > 0;
         captureNames.push_back(name);
-        captureTypes.push_back(slot->getAllocatedType());
-        captureVals.push_back(
-            builder.CreateLoad(slot->getAllocatedType(), slot, name + ".cap"));
+        captureByRef.push_back(byref);
+        captureValTypes.push_back(slot->getAllocatedType());
+        if (byref)
+        {
+            // Capture the cell's address (the alloca itself is a pointer value).
+            captureTypes.push_back(ptrTy);
+            captureVals.push_back(slot);
+        }
+        else
+        {
+            captureTypes.push_back(slot->getAllocatedType());
+            captureVals.push_back(
+                builder.CreateLoad(slot->getAllocatedType(), slot, name + ".cap"));
+        }
     }
 
     // --- Build the lambda function with the env-first ABI ------------------
@@ -3006,6 +3053,8 @@ void IRGenerator::visitLambdaExpr(ast::LambdaExpr *expr)
     auto savedVarArrayElem = varArrayElem;
     auto savedVarFuncSig = varFuncSig;
     auto savedVarIsString = varIsString;
+    auto savedVarByRef = varByRef;
+    auto savedVarByRefType = varByRefType;
 
     builder.SetInsertPoint(block);
     currentFunction = function;
@@ -3013,6 +3062,8 @@ void IRGenerator::visitLambdaExpr(ast::LambdaExpr *expr)
     namedValues.clear();
     varFuncSig.clear();
     varIsString.clear();
+    varByRef.clear();
+    varByRefType.clear();
 
     // arg 0 is the environment; load each captured value back out of it.
     llvm::Argument *envArg = function->getArg(0);
@@ -3023,9 +3074,16 @@ void IRGenerator::visitLambdaExpr(ast::LambdaExpr *expr)
         llvm::Value *off = llvm::ConstantInt::get(llvm::Type::getInt64Ty(context), 8 * (i + 1));
         llvm::Value *p = builder.CreateGEP(llvm::Type::getInt8Ty(context), envArg, off, captureNames[i] + ".slot");
         llvm::Value *val = builder.CreateLoad(captureTypes[i], p, captureNames[i]);
+        // For a by-ref capture, `val` is a POINTER to the enclosing cell; the
+        // local slot holds that pointer and reads/writes go through it.
         llvm::AllocaInst *a = createEntryBlockAlloca(function, captureNames[i], captureTypes[i]);
         builder.CreateStore(val, a);
         namedValues[captureNames[i]] = a;
+        if (captureByRef[i])
+        {
+            varByRef.insert(captureNames[i]);
+            varByRefType[captureNames[i]] = captureValTypes[i];
+        }
     }
 
     // Bind declared parameters (args 1..N).
@@ -3083,6 +3141,8 @@ void IRGenerator::visitLambdaExpr(ast::LambdaExpr *expr)
     varArrayElem = savedVarArrayElem;
     varFuncSig = savedVarFuncSig;
     varIsString = savedVarIsString;
+    varByRef = savedVarByRef;
+    varByRefType = savedVarByRefType;
     currentFunction = savedFunction;
     if (savedBlock)
         builder.SetInsertPoint(savedBlock);
@@ -5065,6 +5125,33 @@ bool IRGenerator::handleVariableAssignment(ast::AssignExpr *expr, llvm::Value *r
             return false;
         }
 
+        // By-reference capture: the slot holds a POINTER to the original
+        // variable's cell. Load that cell pointer and store through it so the
+        // mutation is visible to the enclosing scope (and to other closures
+        // sharing the same cell). The local slot's allocated type is `ptr`,
+        // so we coerce rhs to the captured value's type before the indirect
+        // store rather than matching against the slot type.
+        if (varByRef.count(name))
+        {
+            llvm::Type *valTy = varByRefType.count(name)
+                                    ? varByRefType[name]
+                                    : llvm::Type::getInt64Ty(context);
+            if (rhs->getType() != valTy)
+            {
+                if (rhs->getType()->isIntegerTy() && valTy->isIntegerTy())
+                    rhs = builder.CreateIntCast(rhs, valTy, true, "cast");
+                else if (rhs->getType()->isFloatingPointTy() && valTy->isFloatingPointTy())
+                    rhs = builder.CreateFPCast(rhs, valTy, "cast");
+                else if (canConvertImplicitly(rhs->getType(), valTy))
+                    rhs = implicitConversion(rhs, valTy);
+            }
+            llvm::Type *ptrTy = llvm::PointerType::get(context, 0);
+            llvm::Value *cell = builder.CreateLoad(ptrTy, alloca, name + ".cellp");
+            builder.CreateStore(rhs, cell);
+            lastValue = rhs;
+            return true;
+        }
+
         // Validate that initializer type matches variable type
         if (rhs->getType() != alloca->getAllocatedType())
         {
@@ -6129,6 +6216,19 @@ void IRGenerator::visitVariableExpr(ast::VariableExpr *expr)
     {
         lastValue = llvm::ConstantInt::get(llvm::Type::getInt64Ty(context), e->second);
         return;
+    }
+    // A by-reference closure capture: the slot holds a pointer to the enclosing
+    // cell, so read through one extra indirection.
+    if (varByRef.count(expr->name))
+    {
+        llvm::AllocaInst *pcell = lookupVariable(expr->name);
+        if (pcell)
+        {
+            llvm::Type *ptrTy = llvm::PointerType::get(context, 0);
+            llvm::Value *cell = builder.CreateLoad(ptrTy, pcell, expr->name + ".cellp");
+            lastValue = builder.CreateLoad(varByRefType[expr->name], cell, expr->name);
+            return;
+        }
     }
     // Look up variable in current scope
     llvm::AllocaInst *alloca = lookupVariable(expr->name);

--- a/src/codegen/ir_generator.cpp
+++ b/src/codegen/ir_generator.cpp
@@ -828,90 +828,12 @@ void IRGenerator::visitDestructureStmt(ast::DestructureStmt *stmt)
 
 void IRGenerator::visitFunctionStmt(ast::FunctionStmt *stmt)
 {
-    // Handle async functions
-    if (stmt->isAsync)
-    {
-        // Transform the async function
-        llvm::Function *asyncFunc = transformAsyncFunction(stmt);
-
-        // If transformation failed, return
-        if (!asyncFunc)
-        {
-            return;
-        }
-
-        // Also create a regular wrapper function that awaits the async result
-        std::string regularFuncName = stmt->name;
-
-        // Create the function signature
-        std::vector<llvm::Type *> paramTypes;
-        for (const auto &param : stmt->parameters)
-        {
-            llvm::Type *paramType = getLLVMType(param.type);
-            if (!paramType)
-            {
-                return;
-            }
-            paramTypes.push_back(paramType);
-        }
-
-        llvm::Type *returnType = getLLVMType(stmt->returnType);
-        if (!returnType)
-        {
-            return;
-        }
-
-        llvm::FunctionType *funcType = llvm::FunctionType::get(
-            returnType, paramTypes, false);
-
-        // Create the function
-        llvm::Function *function = llvm::Function::Create(
-            funcType,
-            llvm::Function::ExternalLinkage,
-            regularFuncName,
-            *module);
-
-        // Set parameter names
-        unsigned idx = 0;
-        for (auto &arg : function->args())
-        {
-            if (idx < stmt->parameters.size())
-            {
-                arg.setName(stmt->parameters[idx].name);
-            }
-            idx++;
-        }
-
-        // Create body that calls the async version and awaits the result
-        llvm::BasicBlock *block = llvm::BasicBlock::Create(context, "entry", function);
-        builder.SetInsertPoint(block);
-
-        // Call the async function with all arguments
-        std::vector<llvm::Value *> args;
-        for (auto &arg : function->args())
-        {
-            args.push_back(&arg);
-        }
-
-        llvm::Value *futureResult = builder.CreateCall(asyncFunc, args, "async.call");
-
-        // Call the blocking get() method to await the result
-        llvm::Function *getFunc = getStdLibFunction("Future_get");
-        if (!getFunc)
-        {
-            errorHandler.reportError(error::ErrorCode::C002_CODEGEN_ERROR,
-                                     "Future_get method not found",
-                                     "", 0, 0, error::ErrorSeverity::ERROR);
-            return;
-        }
-
-        llvm::Value *result = builder.CreateCall(getFunc, {futureResult}, "async.result");
-
-        // Return the result
-        builder.CreateRet(result);
-
-        return;
-    }
+    // Async functions are generated as ordinary synchronous functions: the body
+    // runs eagerly on the calling path and `await f()` evaluates to f()'s result
+    // (see visitAwaitExpr). This gives correct async/await *semantics* today; the
+    // M:N worker-pool scheduler that suspends `await` onto a fiber pool is a
+    // performance layer to add on top (it does not change observable results for
+    // a single awaited result). So we simply fall through to normal codegen.
 
     // Generic functions are templates: record them and instantiate lazily
     // (monomorphize) when called with concrete argument types.
@@ -5237,7 +5159,9 @@ bool IRGenerator::handleVariableAssignment(ast::AssignExpr *expr, llvm::Value *r
 
 llvm::Function *IRGenerator::declareFunctionProto(ast::FunctionStmt *stmt)
 {
-    if (!stmt || stmt->isAsync || stmt->isGeneric())
+    // Async functions are lowered as ordinary synchronous functions, so they get
+    // a normal forward prototype (enables forward references and `go asyncFn()`).
+    if (!stmt || stmt->isGeneric())
         return nullptr;
     if (llvm::Function *existing = module->getFunction(stmt->name))
         return existing;

--- a/src/codegen/ir_generator.cpp
+++ b/src/codegen/ir_generator.cpp
@@ -2684,6 +2684,18 @@ void IRGenerator::visitUnaryExpr(ast::UnaryExpr *expr)
         return;
     }
 
+    // Borrow expressions (`&x`, `&mut x`) and `move x` are transparent at run
+    // time: they evaluate to the operand itself. Tocin references alias (a class
+    // instance is already a pointer); the opt-in borrow *checker* enforces the
+    // aliasing rules statically, so codegen treats a borrow as identity.
+    if (expr->op.type == lexer::TokenType::BORROW ||
+        expr->op.type == lexer::TokenType::MUTABLE_BORROW ||
+        expr->op.type == lexer::TokenType::MOVE)
+    {
+        lastValue = operand;
+        return;
+    }
+
     switch (expr->op.type)
     {
     case lexer::TokenType::MINUS:
@@ -3474,6 +3486,16 @@ std::string IRGenerator::getExprClassName(const ast::ExprPtr &expr)
 {
     if (!expr)
         return "";
+    // Borrow / move expressions are transparent: `&x`, `&mut x`, `move x` have
+    // the same class as `x`, so a `let r = &obj` binding tracks obj's class and
+    // field/method access through the reference resolves correctly.
+    if (auto un = std::dynamic_pointer_cast<ast::UnaryExpr>(expr))
+    {
+        if (un->op.type == lexer::TokenType::BORROW ||
+            un->op.type == lexer::TokenType::MUTABLE_BORROW ||
+            un->op.type == lexer::TokenType::MOVE)
+            return getExprClassName(un->right);
+    }
     if (auto var = std::dynamic_pointer_cast<ast::VariableExpr>(expr))
     {
         if (var->name == "self" || var->name == "this")

--- a/src/codegen/ir_generator.cpp
+++ b/src/codegen/ir_generator.cpp
@@ -1559,6 +1559,37 @@ void IRGenerator::visitCallExpr(ast::CallExpr *expr)
                 auto h = pptr(0); if (!h) return;
                 builder.CreateCall(rt("__tocin_vec_free", voidb, {ptrb}), {h});
                 lastValue = llvm::ConstantInt::get(i64b, 0); return; }
+            // vecToArray(v): copy a vector handle into a fresh Tocin array
+            // ([ i64 length ][ elems... ]) so it can be indexed and iterated with
+            // for-in. Used to finalize a generator's collected yields.
+            if (funcName == "vecToArray" && na == 1) {
+                auto h = pptr(0); if (!h) return;
+                llvm::Value *len = builder.CreateCall(rt("__tocin_vec_len", i64b, {ptrb}), {h}, "g.len");
+                llvm::Function *mallocFn = getStdLibFunction("malloc");
+                llvm::Value *eight = llvm::ConstantInt::get(i64b, 8);
+                llvm::Value *bytes = builder.CreateAdd(eight, builder.CreateMul(len, eight), "g.bytes");
+                llvm::Value *arr = builder.CreateCall(mallocFn->getFunctionType(), mallocFn, {bytes}, "g.arr");
+                builder.CreateStore(len, arr); // header holds the length
+                llvm::Type *i8t = llvm::Type::getInt8Ty(context);
+                llvm::Function *fn = builder.GetInsertBlock()->getParent();
+                llvm::BasicBlock *cond = llvm::BasicBlock::Create(context, "g.cond", fn);
+                llvm::BasicBlock *bodyB = llvm::BasicBlock::Create(context, "g.body", fn);
+                llvm::BasicBlock *doneB = llvm::BasicBlock::Create(context, "g.done", fn);
+                llvm::AllocaInst *iv = builder.CreateAlloca(i64b, nullptr, "g.i");
+                builder.CreateStore(llvm::ConstantInt::get(i64b, 0), iv);
+                builder.CreateBr(cond);
+                builder.SetInsertPoint(cond);
+                llvm::Value *i = builder.CreateLoad(i64b, iv, "g.iv");
+                builder.CreateCondBr(builder.CreateICmpSLT(i, len, "g.cmp"), bodyB, doneB);
+                builder.SetInsertPoint(bodyB);
+                llvm::Value *x = builder.CreateCall(rt("__tocin_vec_get", i64b, {ptrb, i64b}), {h, i}, "g.x");
+                llvm::Value *off = builder.CreateAdd(eight, builder.CreateMul(i, eight), "g.off");
+                llvm::Value *slotp = builder.CreateGEP(i8t, arr, off, "g.slot");
+                builder.CreateStore(x, slotp);
+                builder.CreateStore(builder.CreateAdd(i, llvm::ConstantInt::get(i64b, 1)), iv);
+                builder.CreateBr(cond);
+                builder.SetInsertPoint(doneB);
+                lastValue = arr; return; }
 
             // ---- hashmap ----
             if (funcName == "mapNew" && na == 0) {

--- a/src/codegen/ir_generator.h
+++ b/src/codegen/ir_generator.h
@@ -223,6 +223,12 @@ namespace codegen
         std::map<std::string, std::string> varArrayElemTrait;                  // array var -> trait type of its elements (for trait-object vectors)
         std::string pendingElemTrait;                                          // when building a list<Trait> literal, box each element as this trait
         std::map<std::string, std::string> pendingBindingClasses;              // type-param name -> concrete class, threaded into the next generic instantiation
+        // By-reference closure captures: names whose namedValues slot holds a
+        // POINTER to the original cell (not the value), so a lambda that mutates
+        // the capture writes through to the enclosing variable. Empty outside
+        // such lambdas, so all other code is unaffected.
+        std::set<std::string> varByRef;
+        std::map<std::string, llvm::Type *> varByRefType;                      // by-ref name -> pointed-to value type
         llvm::StructType *traitObjTy = nullptr;                                 // { i64 typeId, ptr data }
         std::map<std::string, llvm::Type *> typeBindings;                        // active type-parameter bindings during instantiation
         std::map<std::string, llvm::Function *> stdLibFunctions;                   // Standard library functions

--- a/src/lexer/lexer.cpp
+++ b/src/lexer/lexer.cpp
@@ -30,6 +30,7 @@ namespace lexer
         {"generator", TokenType::GENERATOR}, {"coroutine", TokenType::COROUTINE}, {"channel", TokenType::CHANNEL},
         {"select", TokenType::SELECT}, {"spawn", TokenType::SPAWN}, {"go", TokenType::GO}, {"join", TokenType::JOIN},
         {"mutex", TokenType::MUTEX}, {"lock", TokenType::LOCK}, {"unlock", TokenType::UNLOCK},
+        {"mut", TokenType::MUT}, {"move", TokenType::MOVE},
         {"atomic", TokenType::ATOMIC}, {"volatile", TokenType::VOLATILE}, {"constexpr", TokenType::CONSTEXPR},
         {"inline", TokenType::INLINE}, {"extern", TokenType::EXTERN}, {"export", TokenType::EXPORT},
         {"module", TokenType::MODULE}, {"package", TokenType::PACKAGE}, {"namespace", TokenType::NAMESPACE},

--- a/src/lexer/token.h
+++ b/src/lexer/token.h
@@ -165,6 +165,7 @@ namespace lexer
         ATOMIC,
         VOLATILE,
         MOVE,
+        MUT,
         BORROW,
         MUTABLE_BORROW,
         CONSTEXPR,

--- a/src/parser/parser.cpp
+++ b/src/parser/parser.cpp
@@ -886,6 +886,27 @@ namespace parser
 
     ast::ExprPtr Parser::unary()
     {
+        // Borrow expressions: `&x` (shared) and `&mut x` (mutable). The `&` is
+        // lexed as BITWISE_AND; in prefix position (an operand, not between two
+        // operands) it introduces a borrow. The opt-in borrow checker enforces
+        // the aliasing rules; at run time a borrow is identity.
+        if (match(lexer::TokenType::BITWISE_AND))
+        {
+            lexer::Token op = previous();
+            bool isMut = match(lexer::TokenType::MUT);
+            ast::ExprPtr right = unary();
+            op.type = isMut ? lexer::TokenType::MUTABLE_BORROW
+                            : lexer::TokenType::BORROW;
+            return std::make_shared<ast::UnaryExpr>(op, op, right);
+        }
+        // `move x` explicitly transfers ownership out of `x` (checked by the
+        // borrow checker; identity at run time).
+        if (match(lexer::TokenType::MOVE))
+        {
+            lexer::Token op = previous();
+            ast::ExprPtr right = unary();
+            return std::make_shared<ast::UnaryExpr>(op, op, right);
+        }
         if (match(lexer::TokenType::BANG) || match(lexer::TokenType::MINUS) ||
             match(lexer::TokenType::BITWISE_NOT))
         {

--- a/src/parser/parser.cpp
+++ b/src/parser/parser.cpp
@@ -178,11 +178,83 @@ namespace parser
             returnType = parseType();
         }
         consume(lexer::TokenType::LEFT_BRACE, "Expected '{' before function body");
+        bool savedSawYield = sawYield;
+        sawYield = false;
         auto body = blockStmt();
+        bool isGenerator = sawYield;
+        sawYield = savedSawYield;
+        if (isGenerator)
+        {
+            // Generator: collect yields into a vector and return it as an array.
+            body = desugarGenerator(body, name);
+            // The call yields a sequence; type it as list<int> so `for x in g()`
+            // drives the array path. (Element slots are 64-bit, like all values.)
+            auto intTok = lexer::Token(lexer::TokenType::IDENTIFIER, "int", name.filename, name.line, name.column);
+            std::vector<ast::TypePtr> targs{std::make_shared<ast::SimpleType>(intTok)};
+            returnType = std::make_shared<ast::GenericType>(name, "list", targs);
+        }
         if (!typeParams.empty())
             return std::make_shared<ast::FunctionStmt>(name, name.value, typeParams,
                                                        parameters, returnType, body, isAsync);
         return std::make_shared<ast::FunctionStmt>(name, name.value, parameters, returnType, body, isAsync);
+    }
+
+    // Build a `vecToArray(__gen_acc)` call expression used to finalize a
+    // generator body into a returnable array.
+    ast::ExprPtr Parser::makeVecToArrayCall(const lexer::Token &tok)
+    {
+        auto acc = std::make_shared<ast::VariableExpr>(tok, "__gen_acc");
+        auto conv = std::make_shared<ast::VariableExpr>(tok, "vecToArray");
+        std::vector<ast::ExprPtr> args{acc};
+        return std::make_shared<ast::CallExpr>(tok, conv, args);
+    }
+
+    // Replace every `return [expr]` in a generator body with
+    // `return vecToArray(__gen_acc)` (the original value, if any, is discarded —
+    // a generator stops at a return rather than producing a scalar). Mutates
+    // ReturnStmt nodes in place; recurses into nested control flow.
+    void Parser::rewriteGeneratorReturns(const ast::StmtPtr &stmt, const lexer::Token &tok)
+    {
+        if (!stmt) return;
+        if (auto r = std::dynamic_pointer_cast<ast::ReturnStmt>(stmt))
+        {
+            r->value = makeVecToArrayCall(tok);
+            return;
+        }
+        if (auto b = std::dynamic_pointer_cast<ast::BlockStmt>(stmt))
+        {
+            for (auto &s : b->statements) rewriteGeneratorReturns(s, tok);
+        }
+        else if (auto i = std::dynamic_pointer_cast<ast::IfStmt>(stmt))
+        {
+            rewriteGeneratorReturns(i->thenBranch, tok);
+            for (auto &e : i->elifBranches) rewriteGeneratorReturns(e.second, tok);
+            rewriteGeneratorReturns(i->elseBranch, tok);
+        }
+        else if (auto w = std::dynamic_pointer_cast<ast::WhileStmt>(stmt))
+            rewriteGeneratorReturns(w->body, tok);
+        else if (auto f = std::dynamic_pointer_cast<ast::ForStmt>(stmt))
+            rewriteGeneratorReturns(f->body, tok);
+    }
+
+    // Wrap a generator body: prepend `let __gen_acc = vecNew();`, rewrite any
+    // returns to finalize the array, and append `return vecToArray(__gen_acc);`.
+    ast::StmtPtr Parser::desugarGenerator(const ast::StmtPtr &body, const lexer::Token &tok)
+    {
+        auto block = std::dynamic_pointer_cast<ast::BlockStmt>(body);
+        std::vector<ast::StmtPtr> stmts;
+
+        auto vecNew = std::make_shared<ast::VariableExpr>(tok, "vecNew");
+        auto newCall = std::make_shared<ast::CallExpr>(tok, vecNew, std::vector<ast::ExprPtr>{});
+        stmts.push_back(std::make_shared<ast::VariableStmt>(tok, "__gen_acc", nullptr, newCall, false));
+
+        if (block)
+        {
+            for (auto &s : block->statements) rewriteGeneratorReturns(s, tok);
+            for (auto &s : block->statements) stmts.push_back(s);
+        }
+        stmts.push_back(std::make_shared<ast::ReturnStmt>(tok, makeVecToArrayCall(tok)));
+        return std::make_shared<ast::BlockStmt>(tok, stmts);
     }
 
     ast::StmtPtr Parser::classDeclaration()
@@ -378,6 +450,22 @@ namespace parser
             return blockStmt();
         if (match(lexer::TokenType::RETURN))
             return returnStmt();
+        if (match(lexer::TokenType::YIELD))
+        {
+            // `yield <expr>` in a generator. Desugared to `vecPush(__gen_acc,
+            // <expr>)`; functionDeclaration() wraps the body to create __gen_acc
+            // and return the collected values as an array. Marks the function a
+            // generator via sawYield.
+            lexer::Token kw = previous();
+            ast::ExprPtr val = expression();
+            match(lexer::TokenType::SEMI_COLON);
+            sawYield = true;
+            auto acc = std::make_shared<ast::VariableExpr>(kw, "__gen_acc");
+            auto push = std::make_shared<ast::VariableExpr>(kw, "vecPush");
+            std::vector<ast::ExprPtr> args{acc, val};
+            auto call = std::make_shared<ast::CallExpr>(kw, push, args);
+            return std::make_shared<ast::ExpressionStmt>(kw, call);
+        }
         if (match(lexer::TokenType::MATCH))
             return matchStmt();
         // `switch` is an alias for `match`: same `case <value>:` / `default:`

--- a/src/parser/parser.h
+++ b/src/parser/parser.h
@@ -57,6 +57,14 @@ namespace parser
         }
 
     private:
+        // Set when a `yield` is parsed inside the current function body; turns
+        // that function into a generator (desugared to collect-and-return-array).
+        bool sawYield = false;
+        // Desugar helpers for generator functions.
+        ast::StmtPtr desugarGenerator(const ast::StmtPtr &body, const lexer::Token &tok);
+        void rewriteGeneratorReturns(const ast::StmtPtr &stmt, const lexer::Token &tok);
+        ast::ExprPtr makeVecToArrayCall(const lexer::Token &tok);
+
         ast::StmtPtr declaration();
         ast::StmtPtr varDeclaration();
         ast::StmtPtr functionDeclaration();

--- a/src/type/borrow_checker.cpp
+++ b/src/type/borrow_checker.cpp
@@ -40,10 +40,10 @@ namespace type_checker
 
     void BorrowChecker::declareOwned(const std::string &name)
     {
-        if (!scopes.empty()) scopes.back()[name] = State::Owned;
+        if (!scopes.empty()) scopes.back()[name] = VarInfo{};
     }
 
-    BorrowChecker::State *BorrowChecker::find(const std::string &name)
+    BorrowChecker::VarInfo *BorrowChecker::find(const std::string &name)
     {
         for (auto it = scopes.rbegin(); it != scopes.rend(); ++it)
         {
@@ -51,6 +51,25 @@ namespace type_checker
             if (f != it->end()) return &f->second;
         }
         return nullptr;
+    }
+
+    // Releasing a scope returns the borrows its bindings held back to the
+    // borrowed variables (lexical lifetimes: a borrow ends when its reference
+    // goes out of scope).
+    void BorrowChecker::popScope()
+    {
+        if (scopes.empty()) return;
+        ScopeMap dying = scopes.back();
+        scopes.pop_back();
+        for (auto &kv : dying)
+        {
+            if (kv.second.borrowOf.empty()) continue;
+            if (VarInfo *t = find(kv.second.borrowOf))
+            {
+                if (kv.second.borrowMut) t->mut = false;
+                else if (t->shared > 0) t->shared--;
+            }
+        }
     }
 
     const ast::VariableExpr *BorrowChecker::asBareVar(const ast::ExprPtr &expr)
@@ -67,6 +86,72 @@ namespace type_checker
         errorHandler.reportError(error::ErrorCode::B001_USE_AFTER_MOVE,
                                  "use of moved value '" + name + "'", tok,
                                  error::ErrorSeverity::ERROR);
+    }
+
+    void BorrowChecker::errBorrow(const std::string &msg, const lexer::Token &tok)
+    {
+        sawError = true;
+        errorHandler.reportError(error::ErrorCode::B002_BORROW_CONFLICT,
+                                 msg, tok, error::ErrorSeverity::ERROR);
+    }
+
+    bool BorrowChecker::hasLiveBorrow(const std::string &name)
+    {
+        VarInfo *v = find(name);
+        return v && (v->shared > 0 || v->mut);
+    }
+
+    // Recognise `&x` / `&mut x` (possibly parenthesised). Sets isMut/target.
+    bool BorrowChecker::isBorrow(const ast::ExprPtr &expr, bool &isMut,
+                                 const ast::VariableExpr *&target)
+    {
+        ast::ExprPtr cur = expr;
+        while (auto g = as<ast::GroupingExpr>(cur)) cur = g->expression;
+        auto u = as<ast::UnaryExpr>(cur);
+        if (!u) return false;
+        if (u->op.type == lexer::TokenType::BORROW) isMut = false;
+        else if (u->op.type == lexer::TokenType::MUTABLE_BORROW) isMut = true;
+        else return false;
+        target = asBareVar(u->right);
+        return target != nullptr;
+    }
+
+    // `let r = &x` / `let r = &mut x`: record the borrow on x and bind r to it.
+    void BorrowChecker::takeBorrow(const std::string &refName,
+                                   const ast::VariableExpr *target, bool isMut)
+    {
+        VarInfo *t = find(target->name);
+        if (!t)
+        {
+            // Borrowing a non-owned (Copy) value carries no aliasing hazard;
+            // still declare the reference binding so its scope is tracked.
+            if (!scopes.empty()) scopes.back()[refName] = VarInfo{};
+            return;
+        }
+        if (t->state == State::Moved)
+            errMoved(target->name, target->token);
+        if (isMut)
+        {
+            if (t->mut || t->shared > 0)
+                errBorrow("cannot borrow '" + target->name +
+                              "' as mutable: it is already borrowed",
+                          target->token);
+            else
+                t->mut = true;
+        }
+        else
+        {
+            if (t->mut)
+                errBorrow("cannot borrow '" + target->name +
+                              "' as shared: it is already mutably borrowed",
+                          target->token);
+            else
+                t->shared++;
+        }
+        VarInfo ref;
+        ref.borrowOf = target->name;
+        ref.borrowMut = isMut;
+        if (!scopes.empty()) scopes.back()[refName] = ref;
     }
 
     bool BorrowChecker::isOwnedDecl(ast::VariableStmt *v)
@@ -125,6 +210,14 @@ namespace type_checker
         }
         if (auto vs = asS<ast::VariableStmt>(stmt))
         {
+            // `let r = &x` / `let r = &mut x` records a borrow, not a move.
+            bool isMut = false;
+            const ast::VariableExpr *tgt = nullptr;
+            if (isBorrow(vs->initializer, isMut, tgt))
+            {
+                takeBorrow(vs->name, tgt, isMut);
+                return;
+            }
             bool owned = isOwnedDecl(vs.get());
             consume(vs->initializer);      // RHS: move a bare owned source, else read
             if (owned) declareOwned(vs->name);
@@ -188,13 +281,26 @@ namespace type_checker
     void BorrowChecker::consume(const ast::ExprPtr &expr)
     {
         if (!expr) return;
+        // A borrow in a consuming position is not a move of the borrowed var;
+        // validate it as a value (checks borrow conflicts) and stop.
+        bool isMut = false;
+        const ast::VariableExpr *bt = nullptr;
+        if (isBorrow(expr, isMut, bt))
+        {
+            checkValue(expr);
+            return;
+        }
         if (const ast::VariableExpr *v = asBareVar(expr))
         {
-            State *st = find(v->name);
+            VarInfo *st = find(v->name);
             if (st)
             {
-                if (*st == State::Moved) errMoved(v->name, v->token);
-                *st = State::Moved;
+                if (st->state == State::Moved)
+                    errMoved(v->name, v->token);
+                else if (st->shared > 0 || st->mut)
+                    errBorrow("cannot move '" + v->name + "' while it is borrowed",
+                              v->token);
+                st->state = State::Moved;
             }
             return; // bare var: either moved (owned) or an untracked copy
         }
@@ -206,8 +312,16 @@ namespace type_checker
         if (!expr) return;
         if (auto v = as<ast::VariableExpr>(expr))
         {
-            State *st = find(v->name);
-            if (st && *st == State::Moved) errMoved(v->name, v->token);
+            VarInfo *st = find(v->name);
+            if (st)
+            {
+                if (st->state == State::Moved)
+                    errMoved(v->name, v->token);
+                else if (st->mut)
+                    errBorrow("cannot use '" + v->name +
+                                  "' while it is mutably borrowed",
+                              v->token);
+            }
             return;
         }
         if (auto g = as<ast::GroupingExpr>(expr)) { checkValue(g->expression); return; }
@@ -216,8 +330,38 @@ namespace type_checker
         if (auto bin = as<ast::BinaryExpr>(expr)) { checkValue(bin->left); checkValue(bin->right); return; }
         if (auto un = as<ast::UnaryExpr>(expr))
         {
-            if (un->op.type == lexer::TokenType::MOVE) consume(un->right);
-            else checkValue(un->right);
+            if (un->op.type == lexer::TokenType::MOVE) { consume(un->right); return; }
+            if (un->op.type == lexer::TokenType::BORROW ||
+                un->op.type == lexer::TokenType::MUTABLE_BORROW)
+            {
+                // A temporary borrow (e.g. `f(&mut a)`): check for a conflict at
+                // the borrow site. It is released immediately (no binding holds
+                // it), so no lasting borrow is recorded.
+                bool isMut = un->op.type == lexer::TokenType::MUTABLE_BORROW;
+                if (const ast::VariableExpr *t = asBareVar(un->right))
+                {
+                    VarInfo *vi = find(t->name);
+                    if (vi)
+                    {
+                        if (vi->state == State::Moved)
+                            errMoved(t->name, t->token);
+                        else if (isMut && (vi->mut || vi->shared > 0))
+                            errBorrow("cannot borrow '" + t->name +
+                                          "' as mutable: it is already borrowed",
+                                      t->token);
+                        else if (!isMut && vi->mut)
+                            errBorrow("cannot borrow '" + t->name +
+                                          "' as shared: it is already mutably borrowed",
+                                      t->token);
+                    }
+                }
+                else
+                {
+                    checkValue(un->right);
+                }
+                return;
+            }
+            checkValue(un->right);
             return;
         }
         if (auto call = as<ast::CallExpr>(expr))
@@ -231,7 +375,14 @@ namespace type_checker
             consume(asg->value);
             if (!asg->name.empty())
             {
-                if (State *st = find(asg->name)) *st = State::Owned; // reassignment revives
+                if (VarInfo *st = find(asg->name))
+                {
+                    if (st->shared > 0 || st->mut)
+                        errBorrow("cannot assign to '" + asg->name +
+                                      "' while it is borrowed",
+                                  asg->token);
+                    st->state = State::Owned; // reassignment revives
+                }
             }
             else if (asg->target)
             {
@@ -260,10 +411,10 @@ namespace type_checker
         for (const auto &snap : ends)
             for (size_t i = 0; i < scopes.size() && i < snap.size(); ++i)
                 for (const auto &kv : snap[i])
-                    if (kv.second == State::Moved)
+                    if (kv.second.state == State::Moved)
                     {
                         auto it = scopes[i].find(kv.first);
-                        if (it != scopes[i].end()) it->second = State::Moved;
+                        if (it != scopes[i].end()) it->second.state = State::Moved;
                     }
     }
 } // namespace type_checker

--- a/src/type/borrow_checker.h
+++ b/src/type/borrow_checker.h
@@ -1,14 +1,22 @@
 #pragma once
 
-// Opt-in ownership / borrow checker (move + use-after-move analysis).
+// Opt-in ownership / borrow checker (move + use-after-move + reference borrows).
 //
 // Tocin is GC-based and lets class instances alias freely by default, so this
 // pass is OFF unless `--borrow-check` is passed. When on, it enforces Rust-like
-// move semantics on *owned* values (class/struct instances): moving a value
-// (binding it elsewhere, passing it by value, returning it, or `move x`)
-// invalidates the source, and using a moved value is a compile error.
-// Reassigning a moved variable revives it. Copy types (int/float/bool/string)
-// are never moved. The pass never changes codegen; it only reports diagnostics.
+// rules on *owned* values (class/struct instances):
+//
+//   Moves: moving a value (binding it elsewhere, passing it by value, returning
+//   it, or `move x`) invalidates the source; using a moved value is a compile
+//   error (B001). Reassigning a moved variable revives it. Copy types
+//   (int/float/bool/string) are never moved.
+//
+//   Borrows: `&x` takes a shared borrow and `&mut x` an exclusive one. While a
+//   `&mut x` is live you cannot use, move, mutate, or re-borrow `x`; while any
+//   `&x` is live you cannot mutably borrow, move, or mutate `x` (B002). Borrows
+//   are released when the borrowing binding leaves scope (lexical lifetimes).
+//
+// The pass never changes codegen; it only reports diagnostics.
 
 #include "../ast/ast.h"
 #include "../error/error_handler.h"
@@ -30,7 +38,17 @@ namespace type_checker
 
     private:
         enum class State { Owned, Moved };
-        using ScopeMap = std::unordered_map<std::string, State>;
+
+        // Per-variable ownership + borrow bookkeeping.
+        struct VarInfo
+        {
+            State state = State::Owned;
+            int shared = 0;          // # of live shared borrows OF this variable
+            bool mut = false;        // a live &mut borrow OF this variable exists
+            std::string borrowOf;    // if this var is a reference, the var it borrows
+            bool borrowMut = false;  // ... and whether that borrow is mutable
+        };
+        using ScopeMap = std::unordered_map<std::string, VarInfo>;
         using Snapshot = std::vector<ScopeMap>;
 
         error::ErrorHandler &errorHandler;
@@ -45,9 +63,9 @@ namespace type_checker
 
         // Scope + state helpers.
         void pushScope() { scopes.emplace_back(); }
-        void popScope() { if (!scopes.empty()) scopes.pop_back(); }
+        void popScope();                              // releases borrows held here
         void declareOwned(const std::string &name);
-        State *find(const std::string &name); // nearest scope entry, or null
+        VarInfo *find(const std::string &name);       // nearest scope entry, or null
 
         // Recursive analysis.
         void checkStmt(const ast::StmtPtr &stmt);
@@ -56,11 +74,17 @@ namespace type_checker
         void consume(const ast::ExprPtr &expr);    // move (by-value) context
         const ast::VariableExpr *asBareVar(const ast::ExprPtr &expr);
 
+        // Borrow helpers. Returns true if `expr` was a borrow and was handled.
+        bool isBorrow(const ast::ExprPtr &expr, bool &isMut, const ast::VariableExpr *&target);
+        void takeBorrow(const std::string &refName, const ast::VariableExpr *target, bool isMut);
+        bool hasLiveBorrow(const std::string &name); // shared>0 or mut
+
         // Branch join: a variable moved on ANY analyzed path is moved after.
         Snapshot snapshot() const { return scopes; }
         void restore(const Snapshot &s) { scopes = s; }
         void mergeMoved(const std::vector<Snapshot> &ends);
 
         void errMoved(const std::string &name, const lexer::Token &tok);
+        void errBorrow(const std::string &msg, const lexer::Token &tok);
     };
 } // namespace type_checker

--- a/tests/borrow/borrow_move_while_borrowed.to
+++ b/tests/borrow/borrow_move_while_borrowed.to
@@ -1,0 +1,9 @@
+// Moving a value while it is borrowed is rejected.
+class Box { v: int; }
+def sink(b: Box) -> int { return b.v; }
+def main() -> int {
+    let a = Box(1);
+    let r = &a;
+    let n = sink(a);     // ERROR: cannot move 'a' while borrowed
+    return n + r.v;
+}

--- a/tests/borrow/borrow_mut_conflict.to
+++ b/tests/borrow/borrow_mut_conflict.to
@@ -1,0 +1,8 @@
+// Two simultaneous &mut borrows are rejected.
+class Box { v: int; }
+def main() -> int {
+    let a = Box(1);
+    let m1 = &mut a;
+    let m2 = &mut a;     // ERROR: 'a' already mutably borrowed
+    return m1.v + m2.v;
+}

--- a/tests/borrow/borrow_mut_ok.to
+++ b/tests/borrow/borrow_mut_ok.to
@@ -1,0 +1,7 @@
+// A single exclusive borrow is fine.
+class Box { v: int; }
+def main() -> int {
+    let a = Box(7);
+    let m = &mut a;
+    return m.v;         // 7
+}

--- a/tests/borrow/borrow_scope_ok.to
+++ b/tests/borrow/borrow_scope_ok.to
@@ -1,0 +1,8 @@
+// A borrow released at block end frees the value for a later exclusive borrow.
+class Box { v: int; }
+def main() -> int {
+    let a = Box(3);
+    { let r = &a; }      // shared borrow ends here
+    let m = &mut a;      // OK now: no live borrow
+    return m.v;          // 3
+}

--- a/tests/borrow/borrow_shared_ok.to
+++ b/tests/borrow/borrow_shared_ok.to
@@ -1,0 +1,8 @@
+// Multiple shared borrows of the same value coexist.
+class Box { v: int; }
+def main() -> int {
+    let a = Box(5);
+    let r = &a;
+    let s = &a;
+    return r.v + s.v;   // 10
+}

--- a/tests/borrow/borrow_shared_then_mut.to
+++ b/tests/borrow/borrow_shared_then_mut.to
@@ -1,0 +1,8 @@
+// A &mut while a shared borrow is live is rejected.
+class Box { v: int; }
+def main() -> int {
+    let a = Box(1);
+    let r = &a;
+    let m = &mut a;      // ERROR: 'a' already borrowed (shared)
+    return r.v + m.v;
+}

--- a/tests/borrow/borrow_use_while_mut.to
+++ b/tests/borrow/borrow_use_while_mut.to
@@ -1,0 +1,7 @@
+// Using the original while it is mutably borrowed is rejected.
+class Box { v: int; }
+def main() -> int {
+    let a = Box(1);
+    let m = &mut a;
+    return a.v + m.v;    // ERROR: use of 'a' while mutably borrowed
+}

--- a/tests/cases/async_await.to
+++ b/tests/cases/async_await.to
@@ -1,0 +1,6 @@
+// expect: 36
+// async/await: the body runs eagerly and `await f()` yields f()'s result.
+async def compute(x: int) -> int { return x * x; }
+def main() -> int {
+    return await compute(6);
+}

--- a/tests/cases/async_chain.to
+++ b/tests/cases/async_chain.to
@@ -1,0 +1,9 @@
+// expect: 30
+// An async function may await another; await composes inside expressions.
+async def double(x: int) -> int { return x * 2; }
+async def addThenDouble(a: int, b: int) -> int {
+    return await double(a + b);
+}
+def main() -> int {
+    return await addThenDouble(3, 4) + await double(8);  // 14 + 16
+}

--- a/tests/cases/closure_byref.to
+++ b/tests/cases/closure_byref.to
@@ -1,0 +1,11 @@
+// expect: 3
+// A lambda that WRITES a captured local takes it by reference: the mutation
+// is visible in the enclosing scope after the closure runs.
+def main() -> int {
+    let count = 0;
+    let inc = lambda () -> int count = count + 1;
+    inc();
+    inc();
+    inc();
+    return count;
+}

--- a/tests/cases/closure_byref_accum.to
+++ b/tests/cases/closure_byref_accum.to
@@ -1,0 +1,10 @@
+// expect: 50
+// By-reference capture lets a closure accumulate into an enclosing local.
+def main() -> int {
+    let total = 0;
+    let add = lambda (x: int) -> int total = total + x;
+    add(10);
+    add(15);
+    add(25);
+    return total;
+}

--- a/tests/cases/generator_filter.to
+++ b/tests/cases/generator_filter.to
@@ -1,0 +1,12 @@
+// expect: 20
+// A generator may yield conditionally (here: only even numbers).
+def evens(n: int) -> int {
+    for i in 0..n {
+        if i % 2 == 0 { yield i; }
+    }
+}
+def main() -> int {
+    let sum = 0;
+    for e in evens(10) { sum = sum + e; }   // 0+2+4+6+8
+    return sum;
+}

--- a/tests/cases/generator_index.to
+++ b/tests/cases/generator_index.to
@@ -1,0 +1,13 @@
+// expect: 34
+// The materialized sequence is a real array: indexable and length-checked.
+def fibs(n: int) -> int {
+    let a = 0; let b = 1;
+    for i in 0..n {
+        yield a;
+        let t = a + b; a = b; b = t;
+    }
+}
+def main() -> int {
+    let f = fibs(10);   // 0 1 1 2 3 5 8 13 21 34
+    return f[9];
+}

--- a/tests/cases/generator_squares.to
+++ b/tests/cases/generator_squares.to
@@ -1,0 +1,14 @@
+// expect: 30
+// A generator yields with `yield`; `for x in gen()` drives the sequence.
+def squares(n: int) -> int {
+    let i = 1;
+    while i <= n {
+        yield i * i;
+        i = i + 1;
+    }
+}
+def main() -> int {
+    let total = 0;
+    for s in squares(4) { total = total + s; }   // 1+4+9+16
+    return total;
+}


### PR DESCRIPTION
Completes the remaining "missing" language features that kept Tocin from Go/Rust/C++ parity, plus a one-shot Windows installer builder. Every change uses an inert-guard pattern so existing code paths are untouched — no regressions across the five commits.

## Features

| Feature | Status | Notes |
|---|---|---|
| **By-reference closure capture** | ✅ | A closure that *writes* a captured local now shares the cell — the mutation is visible in the enclosing scope. Read-only captures stay by-value snapshots. |
| **`&` / `&mut` reference borrows** | ✅ | Extends `--borrow-check` beyond move analysis: shared-XOR-mutable with lexical borrow lifetimes; conflicts are fatal `B002`. Adds `mut`/`move` keywords + prefix borrow parsing; borrows are transparent at runtime. |
| **Generators (`yield`)** | ✅ | A function with `yield` becomes a generator; calling it materializes the yielded values into an array that `for x in gen(...)` iterates or indexes. Parser-level desugaring (no central codegen surgery). Eager/finite sequences. |
| **async / await** | ✅ fixed | Previously failed to compile (emitted no binary). Now lowered as ordinary synchronous functions with correct eager semantics; `await f()` yields `f()`'s result and composes in expressions/across async calls. The true cooperative **M:N** scheduler is scoped in `docs/async-scheduler-design.md` (the GC×fiber-stack item is the genuine blocker — deliberately not shipped half-built). |

## Turnkey Windows installer

`installer/windows/Build-TocinInstaller.ps1` — run once on a clean Windows box and it bootstraps the toolchain (MSYS2 + LLVM 18 + GCC + CMake + Ninja + Boehm GC via `pacman`), builds the compiler, vendors the dependent DLLs (self-contained), and writes `dist\tocin-<ver>-windows-x86_64.zip` (plus an NSIS `.exe` if `makensis` is present).

```powershell
powershell -ExecutionPolicy Bypass -File installer\windows\Build-TocinInstaller.ps1
```

## Verification

- Test suite **146/146** `.to` programs, plus harnesses: borrow-check **12/12**, safety **3/3**, match-exhaustiveness **3/3** — all green.
- Each feature ships tests + an example: `examples/byref_closures.to`, `examples/borrow_check.to` (move + `&`/`&mut`), `examples/generators.to`, `examples/async_await.to`.
- `docs/capability-report.md` updated honestly to reflect what now works and what remains.

## Note

The Windows PowerShell script is validated by inspection (brace/paren/here-string balance, path translation, DLL-bundling logic) — it could not be executed in the Linux build environment, so its first real run on Windows is the true test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Fih5HHhUzVNkusdaXHoSdu

---
_Generated by [Claude Code](https://claude.ai/code/session_01Fih5HHhUzVNkusdaXHoSdu)_