### PR TITLE
build(llvm22/mingw): fix LLVM_DEFINITIONS splitting, &lt;cstdint&gt;, setTargetTriple

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -74,7 +74,14 @@ if(LLVM_FOUND)
     set(LLVM_ENABLE_ZLIB ON)
 
     include_directories(${LLVM_INCLUDE_DIRS})
-    add_definitions(${LLVM_DEFINITIONS})
+    # LLVM_DEFINITIONS is a single space-separated string (e.g. on mingw it is
+    # "-D_GLIBCXX_USE_CXX11_ABI=1 -D_FILE_OFFSET_BITS=64 ..."). Passing it to
+    # add_definitions() verbatim makes the whole thing ONE bogus -D, so
+    # _GLIBCXX_USE_CXX11_ABI gets defined to a string containing '=' tokens,
+    # which corrupts libstdc++ <string> and breaks every translation unit. Split
+    # it into individual flags first.
+    separate_arguments(LLVM_DEFINITIONS_LIST UNIX_COMMAND "${LLVM_DEFINITIONS}")
+    add_definitions(${LLVM_DEFINITIONS_LIST})
     link_directories(${LLVM_LIBRARY_DIRS})
 
     # Optional header test for Windows environments only

--- a/src/ast/ast.h
+++ b/src/ast/ast.h
@@ -7,6 +7,7 @@
 #include <vector>
 #include <stdexcept>
 #include <map>
+#include <cstdint> // int64_t (not transitively included on newer libstdc++)
 #include "types.h"
 
 // Forward declare these types from other namespaces

--- a/src/compiler/compiler.cpp
+++ b/src/compiler/compiler.cpp
@@ -299,8 +299,13 @@ namespace compiler
             return false;
         }
 
-        // Set the module's target triple
+        // Set the module's target triple. LLVM 21 changed Module::setTargetTriple
+        // to take an llvm::Triple instead of a string.
+#if LLVM_VERSION_MAJOR >= 21
+        module->setTargetTriple(targetMachine->getTargetTriple());
+#else
         module->setTargetTriple(targetMachine->getTargetTriple().getTriple());
+#endif
 
         // Set the data layout
         module->setDataLayout(targetMachine->createDataLayout());

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -636,7 +636,12 @@ public:
     bool emitObjectFile(llvm::Module& module, const std::string& outputPath, bool asAssembly)
     {
         std::string triple = llvm::sys::getDefaultTargetTriple();
+        // LLVM 21 changed Module::setTargetTriple to take an llvm::Triple.
+#if LLVM_VERSION_MAJOR >= 21
+        module.setTargetTriple(llvm::Triple(triple));
+#else
         module.setTargetTriple(triple);
+#endif
 
         std::string error;
         const llvm::Target* target = llvm::TargetRegistry::lookupTarget(triple, error);


### PR DESCRIPTION
Fixes the actual blockers from a real **LLVM 22 / mingw GCC 16** build (after the previous PR's createTargetMachine + scaffolding-exclusion fixes). Verified: clean configure + build and full suite **146/146** still green on LLVM 18.

### 1. `LLVM_DEFINITIONS` passed as one bogus `-D` (the big one)
`add_definitions(${LLVM_DEFINITIONS})` received a single space-separated string, so the whole thing collapsed into one definition:
```
-D_GLIBCXX_USE_CXX11_ABI="1 -D_FILE_OFFSET_BITS=64 -D__STDC_CONSTANT_MACROS ..."
```
`_GLIBCXX_USE_CXX11_ABI` thus became a garbage string, which **corrupted libstdc++ `<string>`** (the `basic_string.tcc ... differs in constexpr` errors) and emitted *hundreds* of `token '=' is not valid in preprocessor expressions` across every translation unit. Fixed by `separate_arguments(... UNIX_COMMAND ...)` before `add_definitions`.

### 2. `ast.h` used `int64_t` without `<cstdint>`
Newer libstdc++ (GCC 16) no longer pulls it in transitively → `'int64_t' was not declared`. Added the include (GCC even suggested it).

### 3. `Module::setTargetTriple` — two more LLVM 21 Triple sites
The previous PR guarded `createTargetMachine`; the real build surfaced `setTargetTriple` taking the removed `std::string` overload in `compiler.cpp::outputToFile` and `main.cpp::emitObjectFile`. Guarded both with `#if LLVM_VERSION_MAJOR >= 21`.

### Not addressed (non-blocking)
The build also emits **deprecation warnings** (`PointerType::get(Type*,…)`, `CreateGlobalStringPtr`, `lookupTarget(StringRef,…)`) — these are warnings, not errors, and don't stop the build. They can be cleaned up later if `-Werror` is ever enabled.

After this, `installer\windows\Build-TocinInstaller.ps1 -SkipDeps` should get through the compile. If a *new* hard error appears, it'll be a fresh one to chase — paste it and I'll fix it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Fih5HHhUzVNkusdaXHoSdu

---
_Generated by [Claude Code](https://claude.ai/code/session_01Fih5HHhUzVNkusdaXHoSdu)_