### PR TITLE
Warning-clean build, Windows runtime fixes, and a turnkey Linux installer

### DIFF
--- a/installer/README.md
+++ b/installer/README.md
@@ -8,8 +8,9 @@ producing and publishing the release packages.
 
 | File | Role |
 |---|---|
+| `linux/Build-TocinInstaller.sh` | **Turnkey Linux builder** — bootstraps the toolchain, builds, bundles, and packages in one run (see below). |
 | `windows/Build-TocinInstaller.ps1` | **Turnkey Windows builder** — bootstraps the toolchain, builds, and packages in one run (see below). |
-| `package.sh` | Build a Linux/macOS tarball (`dist/tocin-<ver>-<os>-<arch>.tar.gz`). |
+| `package.sh` | Build a Linux/macOS tarball (`dist/tocin-<ver>-<os>-<arch>.tar.gz`); `--bundle-libs` for the self-contained flavor. |
 | `package.ps1` | Build a Windows zip when the toolchain is *already* installed. |
 | `install.sh` | Per-user installer that ships *inside* each Unix tarball. |
 | `install.ps1` | Per-user installer for Windows (also a download bootstrap). |
@@ -33,6 +34,26 @@ installer/package.sh --bundle-libs
 ```
 
 Each writes its artifact to `dist/`.
+
+### Linux — one turnkey script (no prior setup)
+
+On a clean Linux machine, run **one** script and it does everything — installs
+the toolchain (CMake + Ninja + GCC + LLVM 18 + Boehm GC + libffi/zlib via
+`apt`/`dnf`/`pacman`/`zypper`), builds the compiler, vendors every non-system
+shared library so the result runs with no dependencies beyond glibc, and writes
+`dist/tocin-<ver>-linux-x86_64.tar.gz`:
+
+```bash
+installer/linux/Build-TocinInstaller.sh
+```
+
+Useful flags: `--skip-deps` (toolchain already installed — much faster repeat
+builds), `--no-python` (configure `WITH_PYTHON=OFF` for a slimmer, Python-free
+package), `--out DIR` (output directory). Extract the tarball and run
+`./install.sh` to put `tocin` on `PATH`.
+
+If the toolchain is already present, `installer/package.sh --bundle-libs`
+packages an existing `build/` without the bootstrap step.
 
 ### Windows — one turnkey script (no prior setup)
 

--- a/installer/install.ps1
+++ b/installer/install.ps1
@@ -1,4 +1,4 @@
-# install.ps1 — install Tocin on Windows into a per-user prefix, add it to the
+# install.ps1 - install Tocin on Windows into a per-user prefix, add it to the
 # user PATH, and write an uninstaller. Run from inside an extracted package:
 #
 #   tar xzf tocin-<ver>-windows-x86_64.zip   (or Expand-Archive)
@@ -43,17 +43,19 @@ foreach ($d in "bin","libexec","lib","stdlib","share") {
 }
 New-Item -ItemType Directory -Force -Path (Join-Path $Prefix "bin") | Out-Null
 Copy-Item -Recurse -Force (Join-Path $src "libexec") (Join-Path $Prefix "libexec")
-Copy-Item -Recurse -Force (Join-Path $src "lib")     (Join-Path $Prefix "lib")
 Copy-Item -Recurse -Force (Join-Path $src "stdlib")  (Join-Path $Prefix "stdlib")
 Copy-Item -Recurse -Force (Join-Path $src "share")   (Join-Path $Prefix "share")
 Copy-Item -Force (Join-Path $src "VERSION") (Join-Path $Prefix "VERSION")
 
-# Launcher: a .cmd shim that sets TOCIN_PATH + the DLL search path, then runs the exe.
+# Launcher: a .cmd shim that points TOCIN_PATH at the stdlib, then runs the exe.
+# The DLLs live next to tocin.exe in libexec, so no PATH change is needed for the
+# loader to find them; we still prepend libexec defensively for any DLL that does
+# a bare LoadLibrary at runtime.
 $launcher = @"
 @echo off
 set "TOCIN_HOME=%~dp0.."
 if not defined TOCIN_PATH set "TOCIN_PATH=%TOCIN_HOME%\stdlib"
-set "PATH=%TOCIN_HOME%\lib;%PATH%"
+set "PATH=%TOCIN_HOME%\libexec;%PATH%"
 "%TOCIN_HOME%\libexec\tocin.exe" %*
 "@
 Set-Content -Path (Join-Path $Prefix "bin\tocin.cmd") -Value $launcher -Encoding ASCII

--- a/installer/linux/Build-TocinInstaller.sh
+++ b/installer/linux/Build-TocinInstaller.sh
@@ -1,0 +1,145 @@
+#!/usr/bin/env bash
+#
+# Build-TocinInstaller.sh - turnkey, self-contained Tocin builder + packager for
+# Linux. The counterpart to installer/windows/Build-TocinInstaller.ps1.
+#
+# On a clean machine this single command:
+#   1. installs the build toolchain (apt / dnf / pacman / zypper),
+#   2. configures and builds the compiler and runtime,
+#   3. bundles every non-system shared library (LLVM, GC, libffi, ...), and
+#   4. produces dist/tocin-<ver>-linux-<arch>.tar.gz
+# that runs on any compatible Linux with no dependencies beyond glibc. Extract
+# it and run ./install.sh to put `tocin` on PATH.
+#
+# Usage:
+#   installer/linux/Build-TocinInstaller.sh [--skip-deps] [--no-python] [--out DIR]
+#
+#   --skip-deps   Toolchain already present; do not install system packages.
+#   --no-python   Configure WITH_PYTHON=OFF for a slimmer, Python-free package.
+#   --out DIR     Output directory for the tarball (default: ./dist).
+#
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+SKIP_DEPS=0
+NO_PYTHON=0
+OUT="$REPO_ROOT/dist"
+
+log()  { printf '\033[0;32m>>\033[0m %s\n' "$*"; }
+warn() { printf '\033[1;33m!!\033[0m %s\n' "$*" >&2; }
+die()  { printf '\033[0;31mxx\033[0m %s\n' "$*" >&2; exit 1; }
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --skip-deps) SKIP_DEPS=1 ;;
+        --no-python) NO_PYTHON=1 ;;
+        --out) OUT="${2:?--out needs a directory}"; shift ;;
+        -h|--help) sed -n '3,26p' "$0"; exit 0 ;;
+        *) die "unknown option: $1 (try --help)" ;;
+    esac
+    shift
+done
+
+# ---------------------------------------------------------------------------
+# 1. Toolchain. Best-effort: a wrong package name on one distro must not abort
+#    the whole build, so each manager's install is allowed to fail with a warning.
+# ---------------------------------------------------------------------------
+install_deps() {
+    local SUDO=""
+    [ "$(id -u)" -ne 0 ] && command -v sudo >/dev/null 2>&1 && SUDO=sudo
+
+    if command -v apt-get >/dev/null 2>&1; then
+        log "installing dependencies via apt"
+        local pkgs="build-essential cmake ninja-build git patchelf \
+            llvm-18-dev libllvm18 libgc-dev libffi-dev zlib1g-dev"
+        [ "$NO_PYTHON" = 0 ] && pkgs="$pkgs libpython3-dev python3-dev"
+        $SUDO apt-get update -y || warn "apt-get update failed; continuing"
+        # shellcheck disable=SC2086
+        $SUDO apt-get install -y --no-install-recommends $pkgs \
+            || warn "some apt packages failed; if llvm-18-dev is unavailable, install your distro's llvm-dev"
+    elif command -v dnf >/dev/null 2>&1; then
+        log "installing dependencies via dnf"
+        local pkgs="gcc-c++ cmake ninja-build git patchelf llvm-devel libffi-devel zlib-devel gc-devel"
+        [ "$NO_PYTHON" = 0 ] && pkgs="$pkgs python3-devel"
+        # shellcheck disable=SC2086
+        $SUDO dnf install -y $pkgs || warn "some dnf packages failed; continuing"
+    elif command -v pacman >/dev/null 2>&1; then
+        log "installing dependencies via pacman"
+        local pkgs="base-devel cmake ninja git patchelf llvm libffi zlib gc"
+        [ "$NO_PYTHON" = 0 ] && pkgs="$pkgs python"
+        # shellcheck disable=SC2086
+        $SUDO pacman -Sy --needed --noconfirm $pkgs || warn "some pacman packages failed; continuing"
+    elif command -v zypper >/dev/null 2>&1; then
+        log "installing dependencies via zypper"
+        local pkgs="gcc-c++ cmake ninja git patchelf llvm-devel libffi-devel zlib-devel gc-devel"
+        [ "$NO_PYTHON" = 0 ] && pkgs="$pkgs python3-devel"
+        # shellcheck disable=SC2086
+        $SUDO zypper install -y $pkgs || warn "some zypper packages failed; continuing"
+    else
+        warn "no known package manager (apt/dnf/pacman/zypper); assuming the toolchain is already installed"
+    fi
+}
+
+if [ "$SKIP_DEPS" = 0 ]; then
+    install_deps
+else
+    log "skipping dependency install (--skip-deps)"
+fi
+
+command -v cmake >/dev/null 2>&1 || die "cmake not found. Re-run without --skip-deps, or install it manually."
+
+# ---------------------------------------------------------------------------
+# 2. Locate an LLVM CMake package. Prefer 18 (the version Tocin targets), then
+#    fall back to whatever llvm-config advertises.
+# ---------------------------------------------------------------------------
+LLVM_DIR_ARG=""
+for d in /usr/lib/llvm-18/lib/cmake/llvm /usr/lib/llvm-18/cmake \
+         /usr/lib/cmake/llvm /usr/lib64/cmake/llvm; do
+    if [ -d "$d" ]; then LLVM_DIR_ARG="-DLLVM_DIR=$d"; break; fi
+done
+if [ -z "$LLVM_DIR_ARG" ]; then
+    for cfg in llvm-config-18 llvm-config; do
+        if command -v "$cfg" >/dev/null 2>&1; then
+            d="$("$cfg" --cmakedir 2>/dev/null || true)"
+            [ -n "$d" ] && { LLVM_DIR_ARG="-DLLVM_DIR=$d"; break; }
+        fi
+    done
+fi
+[ -n "$LLVM_DIR_ARG" ] && log "using ${LLVM_DIR_ARG#-DLLVM_DIR=}" || warn "no explicit LLVM_DIR found; letting CMake search"
+
+# ---------------------------------------------------------------------------
+# 3. Configure + build.
+# ---------------------------------------------------------------------------
+# Reuse the generator an existing build/ was created with (avoids CMake's
+# "does not match the generator used previously" error on a dev checkout);
+# otherwise prefer Ninja, falling back to Make.
+GEN=""
+if [ -f "$REPO_ROOT/build/CMakeCache.txt" ]; then
+    GEN="$(grep -m1 '^CMAKE_GENERATOR:' "$REPO_ROOT/build/CMakeCache.txt" | cut -d= -f2- || true)"
+fi
+if [ -z "$GEN" ]; then
+    GEN="Unix Makefiles"
+    command -v ninja >/dev/null 2>&1 && GEN="Ninja"
+fi
+PY_ARG=""
+[ "$NO_PYTHON" = 1 ] && PY_ARG="-DWITH_PYTHON=OFF"
+
+log "configuring (generator: $GEN)"
+# shellcheck disable=SC2086
+cmake -S "$REPO_ROOT" -B "$REPO_ROOT/build" -G "$GEN" \
+    -DCMAKE_BUILD_TYPE=Release $LLVM_DIR_ARG $PY_ARG
+
+log "building tocin + runtime"
+cmake --build "$REPO_ROOT/build" --target tocin tocin_runtime_shared \
+    -j"$(nproc 2>/dev/null || echo 4)"
+
+# ---------------------------------------------------------------------------
+# 4. Bundle every non-system shared library and tar it up. Delegates to the
+#    proven packager so there is a single source of truth for the layout.
+# ---------------------------------------------------------------------------
+log "packaging self-contained tarball"
+bash "$REPO_ROOT/installer/package.sh" --bundle-libs --out "$OUT"
+
+echo
+log "done - self-contained Linux package written to: $OUT"
+log "test it with:  tar xzf $OUT/tocin-*-linux-*.tar.gz && cd tocin-* && ./install.sh"

--- a/installer/package.ps1
+++ b/installer/package.ps1
@@ -1,4 +1,4 @@
-# package.ps1 — build a self-contained Tocin distribution zip on Windows:
+# package.ps1 - build a self-contained Tocin distribution zip on Windows:
 #
 #   dist\tocin-<version>-windows-x86_64.zip
 #

--- a/installer/windows/Build-TocinInstaller.ps1
+++ b/installer/windows/Build-TocinInstaller.ps1
@@ -185,11 +185,15 @@ $name  = "tocin-$ver-windows-x86_64"
 $stage = Join-Path $dist $name
 Info "staging $name"
 if (Test-Path $stage) { Remove-Item -Recurse -Force $stage }
-foreach ($d in @("bin","libexec","lib","stdlib","share\docs","share\examples")) {
+foreach ($d in @("bin","libexec","stdlib","share\docs","share\examples")) {
     New-Item -ItemType Directory -Force -Path (Join-Path $stage $d) | Out-Null
 }
 
-# Compiler goes in libexec; a bin\ shim is written by install.ps1 on the target.
+# Compiler and ALL its DLLs go together in libexec; a bin\ shim is written by
+# install.ps1 on the target. Co-locating the DLLs with tocin.exe is what makes
+# the binary self-contained: Windows always searches the executable's own
+# directory for dependencies first, so it runs whether launched directly, via
+# the bin\ shim, or via a shortcut - from any working directory.
 Copy-Item $exe (Join-Path $stage "libexec\tocin.exe")
 
 # Runtime shared library (name varies by toolchain).
@@ -197,7 +201,7 @@ $rtCopied = $false
 foreach ($rt in @("tocin_runtime_shared.dll","libtocin_runtime_shared.dll","libtocin_runtime.dll","tocin_runtime.dll")) {
     $p = Join-Path $build $rt
     if (Test-Path $p) {
-        Copy-Item $p (Join-Path $stage "lib\tocin_runtime.dll")
+        Copy-Item $p (Join-Path $stage "libexec\tocin_runtime.dll")
         $rtCopied = $true
         break
     }
@@ -220,7 +224,8 @@ if (Test-Path (Join-Path $repo "INSTALL.md")) {
 if (-not $NoBundle) {
     Info "bundling dependent DLLs (self-contained)"
     $mingwBinDir = Join-Path $Msys2Root "mingw64\bin"
-    $libOut = Join-Path $stage "lib"
+    # Bundle next to tocin.exe (libexec) so the loader finds them automatically.
+    $dllOut = Join-Path $stage "libexec"
     $bundled = @{}
     # Copy a DLL out of mingw64\bin by name (only mingw DLLs live there, so
     # system DLLs like KERNEL32.dll are naturally skipped).
@@ -228,7 +233,7 @@ if (-not $NoBundle) {
         if ($bundled.ContainsKey($fname)) { return }
         $srcDll = Join-Path $mingwBinDir $fname
         if (Test-Path $srcDll) {
-            Copy-Item $srcDll $libOut -Force
+            Copy-Item $srcDll $dllOut -Force
             $bundled[$fname] = $true
         }
     }
@@ -250,7 +255,7 @@ if (-not $NoBundle) {
         "libgc-1.dll","libgc.dll","zlib1.dll","libzstd.dll","liblzma-5.dll",
         "libiconv-2.dll","libxml2-2.dll")) { Copy-MingwDll $n }
 
-    Info ("bundled " + $bundled.Count + " DLL(s) into lib")
+    Info ("bundled " + $bundled.Count + " DLL(s) into libexec")
     if ($bundled.Count -eq 0) { Warn "no DLLs bundled - check the mingw64 toolchain under $mingwBinDir" }
 } else {
     Info "skipping DLL bundling (-NoBundle): package will require MSYS2/mingw64 on PATH"

--- a/src/codegen/ir_generator.cpp
+++ b/src/codegen/ir_generator.cpp
@@ -92,7 +92,7 @@ void IRGenerator::declareStdLibFunctions()
     // Print function for debugging
     llvm::FunctionType *printfType = llvm::FunctionType::get(
         llvm::Type::getInt32Ty(context),
-        {llvm::PointerType::get(llvm::Type::getInt8Ty(context), 0)},
+        {llvm::PointerType::get(context, 0)},
         true);
     llvm::Function *printfFunc = llvm::Function::Create(
         printfType, llvm::Function::ExternalLinkage, "printf", *module);
@@ -109,7 +109,7 @@ void IRGenerator::declareStdLibFunctions()
     // with Boehm GC it returns collected memory (no leaks); otherwise it is a
     // thin malloc wrapper. Keyed as "malloc" so existing call sites are unchanged.
     llvm::FunctionType *mallocType = llvm::FunctionType::get(
-        llvm::PointerType::get(llvm::Type::getInt8Ty(context), 0),
+        llvm::PointerType::get(context, 0),
         {llvm::Type::getInt64Ty(context)},
         false);
     llvm::Function *mallocFunc = llvm::Function::Create(
@@ -118,7 +118,7 @@ void IRGenerator::declareStdLibFunctions()
 
     llvm::FunctionType *freeType = llvm::FunctionType::get(
         llvm::Type::getVoidTy(context),
-        {llvm::PointerType::get(llvm::Type::getInt8Ty(context), 0)},
+        {llvm::PointerType::get(context, 0)},
         false);
     // Pair with __tocin_alloc: under GC this is GC_free, otherwise libc free.
     // Calling libc free() on a GC pointer would abort ("invalid pointer").
@@ -145,7 +145,7 @@ void IRGenerator::declareStdLibFunctions()
 
     // Example: Promise_create
     llvm::FunctionType *promiseCreateType = llvm::FunctionType::get(
-        llvm::PointerType::get(llvm::Type::getInt8Ty(context), 0), // Opaque promise pointer
+        llvm::PointerType::get(context, 0), // Opaque promise pointer
         {},
         false);
     llvm::Function *promiseCreateFunc = llvm::Function::Create(
@@ -154,8 +154,8 @@ void IRGenerator::declareStdLibFunctions()
 
     // Example: Promise_getFuture
     llvm::FunctionType *promiseGetFutureType = llvm::FunctionType::get(
-        llvm::PointerType::get(llvm::Type::getInt8Ty(context), 0),   // Opaque future pointer
-        {llvm::PointerType::get(llvm::Type::getInt8Ty(context), 0)}, // Promise pointer
+        llvm::PointerType::get(context, 0),   // Opaque future pointer
+        {llvm::PointerType::get(context, 0)}, // Promise pointer
         false);
     llvm::Function *promiseGetFutureFunc = llvm::Function::Create(
         promiseGetFutureType, llvm::Function::ExternalLinkage, "Promise_getFuture", *module);
@@ -164,7 +164,7 @@ void IRGenerator::declareStdLibFunctions()
     // Example: Future_get
     llvm::FunctionType *futureGetType = llvm::FunctionType::get(
         llvm::Type::getInt8Ty(context),                              // Generic return type, will be cast
-        {llvm::PointerType::get(llvm::Type::getInt8Ty(context), 0)}, // Future pointer
+        {llvm::PointerType::get(context, 0)}, // Future pointer
         false);
     llvm::Function *futureGetFunc = llvm::Function::Create(
         futureGetType, llvm::Function::ExternalLinkage, "Future_get", *module);
@@ -3247,8 +3247,8 @@ void IRGenerator::visitDictionaryExpr(ast::DictionaryExpr *expr)
     // { int64_t size, keyType* keys, valueType* values }
     std::vector<llvm::Type *> dictFields = {
         llvm::Type::getInt64Ty(context),        // size
-        llvm::PointerType::getUnqual(keyType),  // keys
-        llvm::PointerType::getUnqual(valueType) // values
+        llvm::PointerType::getUnqual(context),  // keys
+        llvm::PointerType::getUnqual(context) // values
     };
     llvm::StructType *dictType = llvm::StructType::get(context, dictFields);
 
@@ -3278,7 +3278,7 @@ void IRGenerator::visitDictionaryExpr(ast::DictionaryExpr *expr)
 
     // Call malloc for keys
     llvm::Value *keysPtr = builder.CreateCall(mallocFunc, {totalKeysSize}, "dict.keys");
-    llvm::Value *typedKeysPtr = builder.CreateBitCast(keysPtr, llvm::PointerType::get(keyType, 0), "typed_keys");
+    llvm::Value *typedKeysPtr = builder.CreateBitCast(keysPtr, llvm::PointerType::get(context, 0), "typed_keys");
 
     // Calculate size for values
     llvm::Value *valueSize = llvm::ConstantExpr::getSizeOf(valueType);
@@ -3286,7 +3286,7 @@ void IRGenerator::visitDictionaryExpr(ast::DictionaryExpr *expr)
 
     // Call malloc for values
     llvm::Value *valuesPtr = builder.CreateCall(mallocFunc, {totalValuesSize}, "dict.values");
-    llvm::Value *typedValuesPtr = builder.CreateBitCast(valuesPtr, llvm::PointerType::get(valueType, 0), "typed_values");
+    llvm::Value *typedValuesPtr = builder.CreateBitCast(valuesPtr, llvm::PointerType::get(context, 0), "typed_values");
 
     // Store pointers
     llvm::Value *keysStorePtr = builder.CreateStructGEP(dictType, dictAlloc, 1, "dict.keys_ptr");
@@ -3362,15 +3362,15 @@ void IRGenerator::createEmptyDictionary(ast::TypePtr dictType)
     if (!keyType || !valueType)
     {
         // Default to string->int if unable to determine
-        keyType = llvm::PointerType::getUnqual(llvm::Type::getInt8Ty(context)); // string
+        keyType = llvm::PointerType::getUnqual(context); // string
         valueType = llvm::Type::getInt64Ty(context);                            // int
     }
 
     // Create dictionary struct type
     std::vector<llvm::Type *> dictFields = {
         llvm::Type::getInt64Ty(context),        // size
-        llvm::PointerType::getUnqual(keyType),  // keys
-        llvm::PointerType::getUnqual(valueType) // values
+        llvm::PointerType::getUnqual(context),  // keys
+        llvm::PointerType::getUnqual(context) // values
     };
     llvm::StructType *dictStructType = llvm::StructType::get(context, dictFields);
 
@@ -3383,10 +3383,10 @@ void IRGenerator::createEmptyDictionary(ast::TypePtr dictType)
 
     // Set pointers to null
     llvm::Value *keysStorePtr = builder.CreateStructGEP(dictStructType, dictAlloc, 1, "dict.keys_ptr");
-    builder.CreateStore(llvm::ConstantPointerNull::get(llvm::PointerType::getUnqual(keyType)), keysStorePtr);
+    builder.CreateStore(llvm::ConstantPointerNull::get(llvm::PointerType::getUnqual(context)), keysStorePtr);
 
     llvm::Value *valuesStorePtr = builder.CreateStructGEP(dictStructType, dictAlloc, 2, "dict.values_ptr");
-    builder.CreateStore(llvm::ConstantPointerNull::get(llvm::PointerType::getUnqual(valueType)), valuesStorePtr);
+    builder.CreateStore(llvm::ConstantPointerNull::get(llvm::PointerType::getUnqual(context)), valuesStorePtr);
 
     // Return dictionary
     lastValue = dictAlloc;
@@ -5679,7 +5679,7 @@ void IRGenerator::declarePrintFunction()
     // Declare printf function
     llvm::FunctionType *printfType = llvm::FunctionType::get(
         llvm::Type::getInt32Ty(context),
-        {llvm::PointerType::get(llvm::Type::getInt8Ty(context), 0)},
+        {llvm::PointerType::get(context, 0)},
         true);
     
     llvm::Function *printfFunc = llvm::Function::Create(
@@ -5887,7 +5887,7 @@ void IRGenerator::visitBinaryExpr(ast::BinaryExpr *expr)
             };
             if (const ast::LiteralExpr *ls = strLit(expr->left))
                 if (const ast::LiteralExpr *rs = strLit(expr->right)) {
-                    lastValue = builder.CreateGlobalStringPtr(ls->value + rs->value, "cstr");
+                    lastValue = builder.CreateGlobalString(ls->value + rs->value, "cstr");
                     break;
                 }
             // String concatenation: malloc(strlen(a)+strlen(b)+1); strcpy; strcat.

--- a/src/compiler/compiler.cpp
+++ b/src/compiler/compiler.cpp
@@ -239,7 +239,12 @@ namespace compiler
 
         // Look up the target
         std::string error;
+        // LLVM 21 changed TargetRegistry::lookupTarget to accept an llvm::Triple.
+#if LLVM_VERSION_MAJOR >= 21
+        auto target = llvm::TargetRegistry::lookupTarget(llvm::Triple(targetTriple), error);
+#else
         auto target = llvm::TargetRegistry::lookupTarget(targetTriple, error);
+#endif
 
         if (!target)
         {

--- a/src/ffi/ffi_value.cpp
+++ b/src/ffi/ffi_value.cpp
@@ -93,6 +93,14 @@ void FFIValue::cleanup() {
     errorMessage_.clear();
 }
 
+// GCC's -O3 optimizer raises a spurious -Wfree-nonheap-object when the
+// std::variant<..., std::string, std::vector<uint8_t>, ...> copy-assignment
+// below is inlined: it mis-models the variant's internal heap buffer as a
+// stack object. The variant copy is correct; silence only this diagnostic.
+#if defined(__GNUC__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wfree-nonheap-object"
+#endif
 void FFIValue::copyFrom(const FFIValue& other) {
     type_ = other.type_;
     value_ = other.value_;
@@ -101,6 +109,9 @@ void FFIValue::copyFrom(const FFIValue& other) {
     functionCallback_ = other.functionCallback_;
     errorMessage_ = other.errorMessage_;
 }
+#if defined(__GNUC__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
 
 void FFIValue::moveFrom(FFIValue&& other) {
     type_ = other.type_;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -644,7 +644,12 @@ public:
 #endif
 
         std::string error;
+        // LLVM 21 changed TargetRegistry::lookupTarget to accept an llvm::Triple.
+#if LLVM_VERSION_MAJOR >= 21
+        const llvm::Target* target = llvm::TargetRegistry::lookupTarget(llvm::Triple(triple), error);
+#else
         const llvm::Target* target = llvm::TargetRegistry::lookupTarget(triple, error);
+#endif
         if (!target)
         {
             errorHandler.reportError(error::ErrorCode::C002_CODEGEN_ERROR,

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -123,6 +123,24 @@ extern "C" {
     void __tocin_oob(int64_t, int64_t);
 }
 
+#if defined(_WIN32) && defined(__GNUC__)
+// On Windows/mingw the backend emits references to a few libgcc/CRT helper
+// symbols in generated code: __main (CRT init, called at the top of main) and a
+// stack-probe routine (___chkstk_ms / ___chkstk / __chkstk, depending on the
+// toolchain) for functions with large stack frames. These are statically linked
+// into this executable but are NOT exported, so the JIT's process-symbol
+// generator (which uses GetProcAddress) cannot find them by name. We register
+// their real addresses with the JIT below. Declared weak so that any name not
+// actually provided by the linked libgcc resolves to nullptr instead of failing
+// the link; we skip the null ones at registration time.
+extern "C" {
+    void __main(void) __attribute__((weak));
+    void ___chkstk_ms(void) __attribute__((weak));
+    void ___chkstk(void) __attribute__((weak));
+    void __chkstk(void) __attribute__((weak));
+}
+#endif
+
 // Conditionally include Python
 #ifdef WITH_PYTHON
 #include <Python.h>
@@ -605,6 +623,27 @@ public:
             llvm::cantFail(jit->getMainJITDylib().define(llvm::orc::absoluteSymbols(std::move(rt))));
         }
 
+#if defined(_WIN32) && defined(__GNUC__)
+        // Provide the mingw/libgcc helper symbols the backend references in
+        // generated code (see the weak declarations above). Only the ones the
+        // linked libgcc actually defines are non-null; register those.
+        {
+            llvm::orc::SymbolMap mingwrt;
+            auto defabs = [&](const char *name, void *addr) {
+                if (!addr) return;
+                mingwrt[jit->mangleAndIntern(name)] = llvm::orc::ExecutorSymbolDef(
+                    llvm::orc::ExecutorAddr::fromPtr(addr), llvm::JITSymbolFlags::Exported);
+            };
+            defabs("__main", reinterpret_cast<void *>(&__main));
+            defabs("___chkstk_ms", reinterpret_cast<void *>(&___chkstk_ms));
+            defabs("___chkstk", reinterpret_cast<void *>(&___chkstk));
+            defabs("__chkstk", reinterpret_cast<void *>(&__chkstk));
+            if (!mingwrt.empty())
+                llvm::cantFail(jit->getMainJITDylib().define(
+                    llvm::orc::absoluteSymbols(std::move(mingwrt))));
+        }
+#endif
+
         if (auto err = jit->addIRModule(
                 llvm::orc::ThreadSafeModule(std::move(module), std::move(context))))
         {
@@ -697,7 +736,34 @@ public:
      */
     bool linkExecutable(const std::string& objPath, const std::string& exePath)
     {
-        std::string cc = std::getenv("CC") ? std::getenv("CC") : "cc";
+        // Pick a C toolchain driver to link with. $CC wins; otherwise probe the
+        // usual driver names and use the first that actually runs. mingw-w64
+        // ships 'gcc' (there is no 'cc'), so it is tried first on Windows.
+        std::string cc;
+        if (const char* env = std::getenv("CC"); env && *env) {
+            cc = env;
+        } else {
+#if defined(_WIN32)
+            const char* devnull = "NUL";
+            const char* candidates[] = {"gcc", "clang", "cc"};
+#else
+            const char* devnull = "/dev/null";
+            const char* candidates[] = {"cc", "gcc", "clang"};
+#endif
+            for (const char* cand : candidates) {
+                std::string probe = std::string(cand) + " --version >" + devnull + " 2>&1";
+                if (std::system(probe.c_str()) == 0) { cc = cand; break; }
+            }
+        }
+        if (cc.empty()) {
+            errorHandler.reportError(error::ErrorCode::C002_CODEGEN_ERROR,
+                                     "No C toolchain driver found to link the native executable. "
+                                     "Install a C compiler (Windows: mingw-w64 'gcc'; Linux/macOS: "
+                                     "gcc or clang) and put it on PATH, or set the CC environment "
+                                     "variable. (Tip: 'tocin file.to --run' needs no external tools.)",
+                                     "", 0, 0);
+            return false;
+        }
         std::string cmd = cc + " \"" + objPath + "\" -o \"" + exePath + "\"";
         // Link the Tocin runtime (channels/goroutines) so programs that use
         // concurrency resolve their __tocin_* calls.
@@ -925,7 +991,7 @@ void displayUsage()
 {
     std::cout << "Usage: tocin [options] [filename]\n"
               << "Options:\n"
-              << "  --help                 Display this help message\n"
+              << "  --help, -h             Display this help message\n"
               << "  --version, -V          Print the compiler version and exit\n"
               << "  --dump-ir              Dump LLVM IR to stdout\n"
               << "  --jit, --run           JIT-compile and run the program immediately\n"
@@ -1115,7 +1181,7 @@ int main(int argc, char *argv[])
     {
         std::string arg = argv[i];
 
-        if (arg == "--help")
+        if (arg == "--help" || arg == "-help" || arg == "-h" || arg == "/?")
         {
             displayUsage();
             return 0;

--- a/src/runtime/concurrency_runtime.cpp
+++ b/src/runtime/concurrency_runtime.cpp
@@ -212,7 +212,9 @@ extern "C"
 // ---------------------------------------------------------------------------
 namespace
 {
-    thread_local std::vector<std::jmp_buf *> g_handlerStack;
+    // Stored as void* (not std::jmp_buf*) so jmp_buf's alignment attributes are
+    // not dropped on a template argument (-Wignored-attributes); cast back at use.
+    thread_local std::vector<void *> g_handlerStack;
     thread_local int64_t g_excValue = 0;
 }
 
@@ -221,7 +223,7 @@ extern "C"
     // Register a setjmp buffer as the innermost active exception handler.
     void __tocin_try_register(void *buf)
     {
-        g_handlerStack.push_back(static_cast<std::jmp_buf *>(buf));
+        g_handlerStack.push_back(buf);
     }
 
     // Remove the innermost handler (try body completed without throwing).
@@ -249,7 +251,7 @@ extern "C"
                          static_cast<long long>(value));
             std::abort();
         }
-        std::jmp_buf *buf = g_handlerStack.back();
+        std::jmp_buf *buf = static_cast<std::jmp_buf *>(g_handlerStack.back());
         g_handlerStack.pop_back();
         std::longjmp(*buf, 1);
     }


### PR DESCRIPTION
## Summary

Three related changes that make Tocin build cleanly on modern toolchains, actually run on Windows, and ship a self-contained Linux package with one command.

Verified on LLVM 18 throughout: **146/146 `.to` tests + 12/12 borrow-check cases pass**, and a clean rebuild emits **zero warnings**.

### 1. Silence LLVM 22 / GCC build warnings with modern APIs
Behaviour-preserving migration so the build is warning-clean on LLVM 19–22 and GCC 13:
- **Codegen:** deprecated typed-pointer overloads → opaque-pointer forms `PointerType::get(context, 0)` / `getUnqual(context)` (already returned an opaque `ptr` on LLVM 17+, so the IR is identical); `CreateGlobalStringPtr` → `CreateGlobalString`.
- **AOT:** guard `TargetRegistry::lookupTarget` behind `LLVM_VERSION_MAJOR >= 21` for the new `llvm::Triple` overload (matches the existing `createTargetMachine`/`setTargetTriple` guards).
- **Runtime:** store exception-handler buffers as `void*` instead of `std::jmp_buf*` so `jmp_buf`'s alignment attributes aren't dropped on a `std::vector` template argument (`-Wignored-attributes`).
- **FFI:** suppress a spurious GCC `-O3` `-Wfree-nonheap-object` in `FFIValue::copyFrom`, raised when the `std::variant` copy is inlined.

### 2. Make Tocin run on Windows: JIT symbols, AOT linker, DLL layout
Fixes the Windows runtime gaps surfaced by real on-machine testing:
- **JIT (`--run`)** failed with `Symbols not found: [___chkstk_ms, __main]`. These are mingw/libgcc helpers the backend references in generated code (CRT init at the top of `main`; stack-probe for large frames). They're statically linked into `tocin.exe` but not *exported*, so the process-symbol generator (`GetProcAddress`) can't see them. They're now registered as absolute JIT symbols on Windows. Candidate names are declared **weak**, so a name not provided by the linked libgcc resolves to null and is skipped rather than breaking the link.
- **AOT (`-o`)** invoked `cc`, which mingw-w64 doesn't ship (it provides `gcc`). Now honors `$CC`, then probes `gcc`/`clang`/`cc` and uses the first that runs (gcc first on Windows), with a clear, actionable error if none is found.
- **CLI:** accept `-h`, `-help`, and `/?` as aliases for `--help`.
- **Installer:** co-locate the bundled DLLs with `tocin.exe` in `libexec\` instead of a sibling `lib\` — Windows searches the executable's own directory first, so the binary is self-contained however it's launched (this was the cause of the earlier "no output" runs). Also made `install.ps1`/`package.ps1` pure-ASCII so PowerShell 5.1 parses them under its ANSI default.

### 3. Turnkey self-contained Linux installer
Adds `installer/linux/Build-TocinInstaller.sh`, the counterpart to the Windows `Build-TocinInstaller.ps1`. One command on a clean machine installs the toolchain (apt/dnf/pacman/zypper), builds, vendors every non-system shared library, and produces `dist/tocin-<ver>-linux-x86_64.tar.gz` that runs with no dependencies beyond glibc.

Verified locally end-to-end: the bundled binary resolves `libLLVM`/`libpython`/`libgc` from its own `lib/` (not the system), and in a **cleared environment** `tocin --version` → `tocin 0.1.0` and `tocin file.to --run` produce the correct output and exit code.

## Test plan
- [x] LLVM 18 clean rebuild: 0 warnings, 0 errors
- [x] `.to` suite: 146/146
- [x] borrow-check suite: 12/12
- [x] JIT (`--run`) and AOT (`-o`) verified on Linux; `CC` override honored; help aliases work
- [x] Self-bundled Linux tarball built and run in an isolated environment

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Fih5HHhUzVNkusdaXHoSdu)_