### PR TITLE
Windows follow-ups: mingw build fix, doc corrections, and native linking without gcc

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -392,6 +392,17 @@ list(APPEND SOURCES ${FEATURE_SOURCES})
 # the compiler internals are compiled exactly once and fully testable.
 add_library(tocin_core STATIC ${SOURCES})
 
+# GCC's -O3 optimizer raises a spurious -Wfree-nonheap-object from inside the
+# std::variant special members instantiated in ffi_value.cpp (a known false
+# positive). The translation unit also disables it via an in-source pragma; this
+# is a guaranteed backstop, since the warning is emitted in the middle-end where
+# pragma-region attribution can be unreliable across GCC versions.
+if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+    set_source_files_properties(
+        ${CMAKE_CURRENT_SOURCE_DIR}/src/ffi/ffi_value.cpp
+        PROPERTIES COMPILE_OPTIONS "-Wno-free-nonheap-object")
+endif()
+
 target_include_directories(tocin_core PUBLIC
     ${CMAKE_SOURCE_DIR}/src
     ${LLVM_INCLUDE_DIRS}

--- a/src/ffi/ffi_value.cpp
+++ b/src/ffi/ffi_value.cpp
@@ -4,6 +4,18 @@
 #include <algorithm>
 #include <cstring>
 
+// GCC's -O3 optimizer raises a spurious -Wfree-nonheap-object from inside the
+// std::variant<..., std::string, std::vector<uint8_t>, ...> special members
+// (copy-assign / destructor) when they are inlined: it mis-models the variant's
+// internal heap buffer as a stack object. These are instantiated across this
+// whole translation unit (every FFIValue copy/destroy), and GCC 16 attributes
+// the warning to the library header at the instantiation point, so a
+// function-local pragma does not catch it - suppress it for the whole file.
+// The variant operations are correct; only this false positive is silenced.
+#if defined(__GNUC__) && !defined(__clang__)
+#pragma GCC diagnostic ignored "-Wfree-nonheap-object"
+#endif
+
 namespace ffi {
 
 // FFIValue implementation
@@ -93,14 +105,6 @@ void FFIValue::cleanup() {
     errorMessage_.clear();
 }
 
-// GCC's -O3 optimizer raises a spurious -Wfree-nonheap-object when the
-// std::variant<..., std::string, std::vector<uint8_t>, ...> copy-assignment
-// below is inlined: it mis-models the variant's internal heap buffer as a
-// stack object. The variant copy is correct; silence only this diagnostic.
-#if defined(__GNUC__) && !defined(__clang__)
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wfree-nonheap-object"
-#endif
 void FFIValue::copyFrom(const FFIValue& other) {
     type_ = other.type_;
     value_ = other.value_;
@@ -109,9 +113,6 @@ void FFIValue::copyFrom(const FFIValue& other) {
     functionCallback_ = other.functionCallback_;
     errorMessage_ = other.errorMessage_;
 }
-#if defined(__GNUC__) && !defined(__clang__)
-#pragma GCC diagnostic pop
-#endif
 
 void FFIValue::moveFrom(FFIValue&& other) {
     type_ = other.type_;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -124,20 +124,20 @@ extern "C" {
 }
 
 #if defined(_WIN32) && defined(__GNUC__)
-// On Windows/mingw the backend emits references to a few libgcc/CRT helper
-// symbols in generated code: __main (CRT init, called at the top of main) and a
-// stack-probe routine (___chkstk_ms / ___chkstk / __chkstk, depending on the
-// toolchain) for functions with large stack frames. These are statically linked
-// into this executable but are NOT exported, so the JIT's process-symbol
-// generator (which uses GetProcAddress) cannot find them by name. We register
-// their real addresses with the JIT below. Declared weak so that any name not
-// actually provided by the linked libgcc resolves to nullptr instead of failing
-// the link; we skip the null ones at registration time.
+// On Windows/mingw the backend emits references to two libgcc/CRT helper symbols
+// in generated code: __main (CRT init, called at the top of main) and
+// ___chkstk_ms (the x86-64 stack-probe routine for functions with large stack
+// frames). These are statically linked into this executable but are NOT
+// exported, so the JIT's process-symbol generator (which uses GetProcAddress)
+// cannot find them by name; we register their real addresses with the JIT below.
+//
+// Only symbols that actually exist in the linked libgcc/CRT may be named here:
+// unlike ELF, a PE/COFF *undefined* weak reference is NOT resolved to null, so
+// taking the address of a missing symbol breaks the link. These two are always
+// provided by mingw-w64 on x86-64.
 extern "C" {
     void __main(void) __attribute__((weak));
     void ___chkstk_ms(void) __attribute__((weak));
-    void ___chkstk(void) __attribute__((weak));
-    void __chkstk(void) __attribute__((weak));
 }
 #endif
 
@@ -636,8 +636,6 @@ public:
             };
             defabs("__main", reinterpret_cast<void *>(&__main));
             defabs("___chkstk_ms", reinterpret_cast<void *>(&___chkstk_ms));
-            defabs("___chkstk", reinterpret_cast<void *>(&___chkstk));
-            defabs("__chkstk", reinterpret_cast<void *>(&__chkstk));
             if (!mingwrt.empty())
                 llvm::cantFail(jit->getMainJITDylib().define(
                     llvm::orc::absoluteSymbols(std::move(mingwrt))));


### PR DESCRIPTION
Follow-up to #31. Three commits, all verified on LLVM 18 (146/146 `.to` + 12/12 borrow-check, 0 warnings).

### 1. Fix mingw/GCC 16 build (`52efd20`)
- **Link error `undefined reference to '__chkstk'`**: #31 declared several stack-probe spellings `weak` assuming a missing one resolves to null. That holds on ELF but **not on PE/COFF**, so `&__chkstk` (the MSVC spelling, absent in mingw-w64) broke the link of `tocin.exe`. Now only `__main` and `___chkstk_ms` are referenced — both always present in mingw-w64 x86-64, and the two the JIT needs.
- **`-Wfree-nonheap-object`** still fired under GCC 16 (emitted from `std::variant` in the middle-end, where the function-local pragma doesn't apply). Moved to file scope in `ffi_value.cpp` + a CMake backstop.

### 2. Doc corrections (`2653bd2`)
`docs/tocin-for-ai.md`: three lines contradicted the rest of the file and verified behavior. `break`/`continue` (incl. labeled) are fully implemented; lambdas capture enclosing locals by value and can escape. Corrected the stale "unsupported"/"do not capture" wording.

### 3. Native linking without a system gcc/clang (`7bf8f8c`)
Spike result: `tocin file.to -o app.exe` now links a native binary with **no external C toolchain on PATH** (was C002 + shelling to `cc`). See `docs/native-linking.md`.
- **Engine** (`tryBundledLink`): if `libexec/link/` is present, drive a vendored `ld.lld` from a **data-driven recipe** (`%LINKDIR%`/`%OBJ%`/`%OUT%` placeholders), with tocin's dir prepended to `PATH` so the linker finds the shared libs already in `libexec`. Falls back to the C driver when absent — no regression.
- **Recipe generator** (`installer/make-link-recipe.sh`): derives the link line from the real `gcc -v` spec (not guessed), vendoring every CRT object / static lib into `link/sysroot`. Self-contained mode for Windows; `--keep-syslibs` for Linux/macOS.
- **Packaging**: `Build-TocinInstaller.ps1` vendors `ld.lld.exe` + calls the generator with `-static-libgcc -static-libstdc++` and a static `libgc` so `app.exe` is standalone. Non-fatal — falls back to gcc if it can't be produced.
- **Why bundled `ld.lld` over in-process `lld::coff::link`**: LLD isn't part of `libLLVM` (separate libs+headers, absent here), its C++ API is version-unstable, and our objects are mingw-ABI (so the MSVC/UCRT COFF path is the wrong runtime). Driving a vendored `ld.lld` hits the goal with far less coupling.

**Validated end-to-end on Linux** (engine + generator): with `PATH`/`CC` pointed at nothing, `tocin x.to -o x` links through the bundled `ld.lld` and runs. The Windows recipe *contents* are derived from the build machine's mingw gcc and need one on-box validation pass; because the recipe is data, any tweak needs no compiler rebuild.

🤖 Generated with [Claude Code](https://claude.com/claude-code)