### PR TITLE
Native linking on Windows without a system gcc/clang (Tier 2: bundled…

### DIFF
--- a/docs/native-linking.md
+++ b/docs/native-linking.md
@@ -1,0 +1,84 @@
+# Native linking without an external toolchain
+
+`tocin file.to -o app` (or `app.exe`) emits a native object and then links it
+into an executable. Historically that link shelled out to a C compiler driver
+(`cc`/`gcc`/`clang`) — so producing a binary required a system toolchain on
+`PATH`. This document describes the self-contained linker that removes that
+requirement on Windows (and works the same way everywhere).
+
+`.ll`, `.s`, and `.o` outputs never need a linker and are unaffected.
+
+## How it works
+
+Two pieces:
+
+1. **A bundled linker + recipe** shipped beside the compiler in
+   `libexec/link/`:
+   - `ld.lld(.exe)` — LLVM's linker.
+   - `link-recipe.txt` — the linker argument list as **data**, with three
+     placeholders the compiler fills in at link time:
+     - `%LINKDIR%` → the absolute path of `libexec/link`
+     - `%OBJ%` → the object the compiler just emitted
+     - `%OUT%` → the output executable
+   - `sysroot/` — every input the link needs that is *not* present on a target
+     machine: the CRT startup objects and the static/import libs (libgcc,
+     libstdc++, libmingw*, the GC, `libtocin_runtime.a`, …).
+
+2. **The compiler engine** (`tryBundledLink` in `src/main.cpp`): if
+   `libexec/link/` is present it reads the recipe, substitutes the placeholders,
+   prepends its own directory to `PATH` (so `ld.lld` finds the shared libs that
+   live next to `tocin` in `libexec`), and runs `ld.lld @response`. If the
+   bundle is absent it falls back to the C-driver path — so there is no
+   regression where a toolchain is available.
+
+Keeping the link line as data means a wrong argument can be fixed by editing
+`link-recipe.txt` in the package — no recompile of the compiler.
+
+## How the recipe is produced
+
+`installer/make-link-recipe.sh` derives the recipe from the **real C compiler's
+own link line** rather than guessing it. It compiles a throwaway object, runs
+`gcc -v` to capture the exact `collect2`/`ld` invocation, then rewrites that line
+into a relocatable recipe: every absolute input is copied into `sysroot/` and
+referenced via `%LINKDIR%`, and the object/output tokens become `%OBJ%`/`%OUT%`.
+
+Two modes:
+
+- **self-contained** (default, used on Windows): collapse library search to the
+  vendored `sysroot/` and copy every `-l` input. Correct on Windows because the
+  mingw import libs are not on the target, but the system DLLs they import
+  (`kernel32`, `ucrtbase`, …) always are.
+- **`--keep-syslibs`** (Linux/macOS): keep the toolchain's search dirs and rely
+  on the target's system `libc`/`libgcc_s`/… These always exist there.
+
+The Windows packager (`installer/windows/Build-TocinInstaller.ps1`) calls this
+with the mingw `gcc`, `-static-libgcc -static-libstdc++`, and a static `libgc.a`
+when available, so the produced `app.exe` is standalone. The step is non-fatal:
+if `ld.lld` or the recipe can't be produced, the package still builds and native
+`-o` falls back to requiring `gcc` on `PATH`.
+
+## Status
+
+The compiler engine and `make-link-recipe.sh` are validated end-to-end on Linux:
+with `PATH`/`CC` pointed at nothing, `tocin x.to -o x` links through the bundled
+`ld.lld` and produces a working binary. The Windows recipe *contents* are derived
+from the mingw `gcc` on the build machine; validate on Windows by building the
+installer and running:
+
+```
+tocin file.to -o app.exe      # should produce app.exe with no gcc/clang on PATH
+.\app.exe
+```
+
+If a link argument needs adjusting for a particular mingw version, edit the
+generated `libexec/link/link-recipe.txt` (or `installer/make-link-recipe.sh`) —
+the compiler itself does not need rebuilding.
+
+## Licensing
+
+Everything vendored is redistributable: the mingw-w64 runtime is permissive
+(MIT/BSD/public-domain); `libgcc`/`libstdc++` are GPLv3 **with the GCC Runtime
+Library Exception**, which explicitly permits shipping them linked into non-GPL
+programs; winpthreads is MIT; Boehm GC is MIT-style; `ld.lld` is Apache-2.0 with
+the LLVM exception. Ship the corresponding license/exception notices in the
+package.

--- a/installer/make-link-recipe.sh
+++ b/installer/make-link-recipe.sh
@@ -1,0 +1,132 @@
+#!/usr/bin/env bash
+#
+# make-link-recipe.sh - build the self-contained native-link bundle that lets
+# `tocin file.to -o app` link a native executable WITHOUT a system gcc/clang.
+#
+# It asks the real C compiler what it would pass to the linker (`gcc -v` on a
+# throwaway object), then turns that ground-truth link line into a relocatable
+# recipe: every absolute input (CRT objects, static/import libs) is copied into
+# <out-dir>/sysroot and the link line is rewritten with placeholders the Tocin
+# compiler substitutes at link time:
+#     %LINKDIR%  -> the bundle directory (.../libexec/link)
+#     %OBJ%      -> the program object Tocin just emitted
+#     %OUT%      -> the output executable
+#
+# The result is <out-dir>/link-recipe.txt + <out-dir>/sysroot/*. Drop a matching
+# ld.lld(.exe) into <out-dir> and Tocin links natively with no external toolchain.
+#
+# Usage:
+#   make-link-recipe.sh --gcc <gcc> --out-dir <dir> --runtime <libtocin_runtime.a>
+#                       [--gc <libgc>] [--extra "<ld args>"]
+#
+# Run it under the SAME toolchain Tocin was built with (mingw64 on Windows).
+set -euo pipefail
+
+GCC=gcc
+OUTDIR=""
+RUNTIME=""
+GC=""
+EXTRA="-lm -lpthread -lstdc++"
+# KEEP_SYS=1 keeps the toolchain's original -L search dirs and relies on the
+# target's system libs (libc/libgcc_s/...) at link time - correct on Linux/macOS,
+# where those always exist. KEEP_SYS=0 (the Windows default) collapses search to
+# the vendored sysroot and copies every -l input, so the bundle is fully
+# self-contained: on Windows the mingw import libs are NOT present on the target,
+# but the system DLLs they import (kernel32, ucrtbase, ...) always are.
+KEEP_SYS=0
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --gcc) GCC="$2"; shift ;;
+        --out-dir) OUTDIR="$2"; shift ;;
+        --runtime) RUNTIME="$2"; shift ;;
+        --gc) GC="$2"; shift ;;
+        --extra) EXTRA="$2"; shift ;;
+        --keep-syslibs) KEEP_SYS=1 ;;
+        -h|--help) sed -n '3,32p' "$0"; exit 0 ;;
+        *) echo "make-link-recipe: unknown option: $1" >&2; exit 2 ;;
+    esac
+    shift
+done
+
+[ -n "$OUTDIR" ]  || { echo "make-link-recipe: --out-dir is required" >&2; exit 2; }
+[ -n "$RUNTIME" ] || { echo "make-link-recipe: --runtime is required" >&2; exit 2; }
+command -v "$GCC" >/dev/null 2>&1 || { echo "make-link-recipe: '$GCC' not found" >&2; exit 2; }
+
+# Absolute-ify inputs so they appear as absolute paths in the captured link line
+# and get vendored into sysroot (a relative path would be left untouched).
+abspath() { case "$1" in /*|[A-Za-z]:[/\\]*) printf '%s' "$1" ;; *) printf '%s/%s' "$(pwd)" "$1" ;; esac; }
+RUNTIME="$(abspath "$RUNTIME")"
+[ -n "$GC" ] && GC="$(abspath "$GC")"
+
+SYSROOT="$OUTDIR/sysroot"
+mkdir -p "$SYSROOT"
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+printf 'int main(void){return 0;}\n' > "$WORK/td.c"
+"$GCC" -c "$WORK/td.c" -o "$WORK/td.o"
+
+# Capture the real linker invocation. `gcc -v` prints the collect2/ld line,
+# space-separated and unquoted (toolchain paths contain no spaces).
+LINKLINE="$("$GCC" -v "$WORK/td.o" -o "$WORK/td_out" "$RUNTIME" ${GC:+$GC} $EXTRA 2>&1 \
+            | grep -E '/collect2|[/\\]ld(\.exe)?( |$)|[/\\]ld\.lld' | tail -1 || true)"
+[ -n "$LINKLINE" ] || { echo "make-link-recipe: could not capture the linker line from '$GCC -v'" >&2; exit 1; }
+
+# Resolve a -l<name> to a real file via the compiler and copy it into sysroot.
+# Tries the static archive first, then the import lib.
+vendor_lib() {
+    local name="$1" f
+    for cand in "lib${name}.a" "lib${name}.dll.a"; do
+        f="$("$GCC" -print-file-name="$cand")"
+        if [ "$f" != "$cand" ] && [ -f "$f" ]; then
+            cp -L "$f" "$SYSROOT/$(basename "$f")" 2>/dev/null || true
+            return 0
+        fi
+    done
+    return 1
+}
+
+# Walk the link line, vendoring inputs and rewriting paths to placeholders.
+read -r -a TOKS <<< "$LINKLINE"
+OUT_TOKS=()
+HAVE_L=0
+i=1                          # skip TOKS[0] = the collect2/ld program path
+n=${#TOKS[@]}
+while [ "$i" -lt "$n" ]; do
+    t="${TOKS[$i]}"
+    case "$t" in
+        -plugin)        i=$((i+2)); continue ;;     # drop gcc LTO plugin (lld-incompatible)
+        -plugin-opt*)   i=$((i+1)); continue ;;
+        "$WORK/td.o")   OUT_TOKS+=("%OBJ%") ;;
+        "$WORK/td_out") OUT_TOKS+=("%OUT%") ;;
+        -o)             OUT_TOKS+=("-o" "%OUT%"); i=$((i+2)); continue ;;
+        -L*)
+            if [ "$HAVE_L" -eq 0 ]; then OUT_TOKS+=("-L%LINKDIR%/sysroot"); HAVE_L=1; fi
+            [ "$KEEP_SYS" -eq 1 ] && OUT_TOKS+=("$t")   # keep system search dirs (Linux/macOS)
+            ;;
+        -l*)
+            [ "$KEEP_SYS" -eq 0 ] && { vendor_lib "${t#-l}" || true; }
+            OUT_TOKS+=("$t")
+            ;;
+        /*|[A-Za-z]:[/\\]*)
+            # Absolute path: an input file (CRT object or explicit archive).
+            if [ -f "$t" ]; then
+                cp -L "$t" "$SYSROOT/$(basename "$t")" 2>/dev/null || true
+                OUT_TOKS+=("%LINKDIR%/sysroot/$(basename "$t")")
+            else
+                OUT_TOKS+=("$t")
+            fi ;;
+        *)              OUT_TOKS+=("$t") ;;
+    esac
+    i=$((i+1))
+done
+
+# Ensure our sysroot is searched even if the captured line had no -L.
+[ "$HAVE_L" -eq 0 ] && OUT_TOKS=("-L%LINKDIR%/sysroot" "${OUT_TOKS[@]}")
+
+printf '%s ' "${OUT_TOKS[@]}" > "$OUTDIR/link-recipe.txt"
+printf '\n' >> "$OUTDIR/link-recipe.txt"
+
+echo "make-link-recipe: wrote $OUTDIR/link-recipe.txt"
+echo "make-link-recipe: vendored $(find "$SYSROOT" -type f | wc -l) input file(s) into $SYSROOT"

--- a/installer/windows/Build-TocinInstaller.ps1
+++ b/installer/windows/Build-TocinInstaller.ps1
@@ -257,6 +257,43 @@ if (-not $NoBundle) {
 
     Info ("bundled " + $bundled.Count + " DLL(s) into libexec")
     if ($bundled.Count -eq 0) { Warn "no DLLs bundled - check the mingw64 toolchain under $mingwBinDir" }
+
+    # ---- Self-contained native linker (ld.lld + mingw link inputs) ----------
+    # Lets `tocin file.to -o app.exe` produce a native binary with NO external
+    # gcc/clang. We vendor ld.lld.exe plus the CRT objects / static libs gcc
+    # would otherwise supply, and a data-driven recipe (installer/make-link-
+    # recipe.sh derives it from the real gcc spec). Non-fatal: if anything here
+    # fails the package still works, native -o just needs gcc on PATH as before.
+    Info "bundling native linker (ld.lld + link inputs)"
+    $linkDir = Join-Path $stage "libexec\link"
+    New-Item -ItemType Directory -Force -Path $linkDir | Out-Null
+    $lldSrc = Join-Path $mingwBinDir "ld.lld.exe"
+    if (Test-Path $lldSrc) {
+        Copy-Item $lldSrc (Join-Path $linkDir "ld.lld.exe") -Force
+        # ld.lld.exe shares tocin's shared-lib deps (libLLVM, libstdc++, ...),
+        # already bundled in libexec; tocin puts libexec on PATH when invoking it,
+        # so we don't duplicate those DLLs here.
+        # Prefer a static GC archive so the produced app.exe needs no GC DLL.
+        $gcArg = ""
+        foreach ($g in @("libgc.a","libgc.dll.a")) {
+            $gp = Join-Path $Msys2Root "mingw64\lib\$g"
+            if (Test-Path $gp) { $gcArg = "--gc '" + (ConvertTo-Msys $gp) + "'"; break }
+        }
+        $linkDirMsys = ConvertTo-Msys $linkDir
+        $rtMsys = ConvertTo-Msys (Join-Path $build "libtocin_runtime.a")
+        # Static C++/gcc runtime so app.exe is standalone (no libstdc++-6.dll etc).
+        $extra = "-static-libgcc -static-libstdc++ -lm -lpthread -lstdc++"
+        & $bash -lc "cd '$repoMsys' && bash installer/make-link-recipe.sh --gcc gcc --out-dir '$linkDirMsys' --runtime '$rtMsys' $gcArg --extra '$extra'"
+        if ($LASTEXITCODE -eq 0 -and (Test-Path (Join-Path $linkDir "link-recipe.txt"))) {
+            Info "native linker bundled: 'tocin file.to -o app.exe' needs no external compiler"
+        } else {
+            Warn "could not build the link recipe; native -o will fall back to requiring gcc on PATH"
+            Remove-Item -Recurse -Force $linkDir -ErrorAction SilentlyContinue
+        }
+    } else {
+        Warn "ld.lld.exe not in mingw64\bin (pacman -S mingw-w64-x86_64-lld) - native -o will require gcc on PATH"
+        Remove-Item -Recurse -Force $linkDir -ErrorAction SilentlyContinue
+    }
 } else {
     Info "skipping DLL bundling (-NoBundle): package will require MSYS2/mingw64 on PATH"
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -36,6 +36,18 @@
 #include <llvm/Support/CodeGen.h>
 #include <cstdlib>
 #include <cstdint>
+#include <filesystem>
+#include <fstream>
+#include <sstream>
+
+// Platform APIs for locating this executable (used to find the bundled linker).
+#if defined(_WIN32)
+#include <windows.h>
+#elif defined(__APPLE__)
+#include <mach-o/dyld.h>
+#else
+#include <unistd.h>
+#endif
 
 // The Tocin runtime (channels/goroutines) lives in the static core library.
 // Declared here so the JIT can register their addresses; referencing them in
@@ -190,6 +202,35 @@ extern "C" {
 #include "type/extension_functions.h"
 #include "runtime/concurrency.h"
 #include "runtime/linq.h"
+
+/**
+ * @brief Absolute directory containing the running tocin executable.
+ *
+ * Used to locate the optional self-contained linker bundle (a vendored ld.lld
+ * plus the CRT objects / import libs) that lets `-o <exe>` produce a native
+ * binary without a system gcc/clang on PATH. Returns "" if it can't be found.
+ */
+static std::string tocinExecutableDir()
+{
+#if defined(_WIN32)
+    char buf[MAX_PATH];
+    DWORD n = GetModuleFileNameA(nullptr, buf, static_cast<DWORD>(sizeof(buf)));
+    if (n == 0 || n >= sizeof(buf)) return {};
+    std::string p(buf, n);
+#elif defined(__APPLE__)
+    char buf[4096];
+    uint32_t sz = sizeof(buf);
+    if (_NSGetExecutablePath(buf, &sz) != 0) return {};
+    std::string p(buf);
+#else
+    char buf[4096];
+    ssize_t n = readlink("/proc/self/exe", buf, sizeof(buf));
+    if (n <= 0) return {};
+    std::string p(buf, static_cast<size_t>(n));
+#endif
+    auto pos = p.find_last_of("/\\");
+    return pos == std::string::npos ? std::string() : p.substr(0, pos);
+}
 
 /**
  * @brief Enhanced compiler structure with all new features
@@ -732,8 +773,99 @@ public:
     /**
      * @brief Link an object file into a native executable using the system C toolchain.
      */
+    // Result of attempting the self-contained bundled linker.
+    enum class BundledLink { Ok, Failed, NotBundled };
+
+    // Link <objPath> -> <exePath> using a vendored ld.lld driven by a data-driven
+    // recipe shipped next to the compiler (libexec/link/). The recipe is an
+    // ld.lld argument list (whitespace/newline separated) with placeholders:
+    //   %LINKDIR% -> absolute path of the link/ bundle dir
+    //   %OBJ%     -> the input object
+    //   %OUT%     -> the output executable
+    // Returns NotBundled when no bundle is present (caller falls back to the C
+    // driver), Ok on success, or Failed (error reported) when the bundled linker
+    // is present but the link fails. Keeping the recipe as data means the link
+    // line can be corrected without rebuilding the compiler.
+    BundledLink tryBundledLink(const std::string& objPath, const std::string& exePath)
+    {
+        namespace fs = std::filesystem;
+        std::string dir = tocinExecutableDir();
+        if (dir.empty()) return BundledLink::NotBundled;
+        fs::path linkDir = fs::path(dir) / "link";
+#if defined(_WIN32)
+        fs::path lld = linkDir / "ld.lld.exe";
+#else
+        fs::path lld = linkDir / "ld.lld";
+#endif
+        fs::path recipePath = linkDir / "link-recipe.txt";
+        std::error_code ec;
+        if (!fs::exists(lld, ec) || !fs::exists(recipePath, ec))
+            return BundledLink::NotBundled;
+
+        std::ifstream in(recipePath);
+        if (!in) return BundledLink::NotBundled;
+        std::stringstream buf;
+        buf << in.rdbuf();
+        std::string args = buf.str();
+
+        auto substAll = [&](const std::string& key, const std::string& val) {
+            for (size_t p = args.find(key); p != std::string::npos;
+                 p = args.find(key, p + val.size()))
+                args.replace(p, key.size(), val);
+        };
+        substAll("%LINKDIR%", linkDir.string());
+        substAll("%OBJ%", objPath);
+        substAll("%OUT%", exePath);
+
+        // Pass the (possibly long) argument list via an @response file so command
+        // length limits and path quoting are not a concern.
+        fs::path resp = fs::path(exePath).parent_path() / ".tocin-link.rsp";
+        {
+            std::ofstream o(resp);
+            o << args;
+        }
+        // The bundled ld.lld is dynamically linked against the same shared libs
+        // (libLLVM, libstdc++, ...) that sit next to tocin in libexec. Prepend
+        // our own directory to PATH for the child so it finds them, instead of
+        // duplicating ~100MB of DLLs into link/.
+        std::string oldPath = std::getenv("PATH") ? std::getenv("PATH") : "";
+#if defined(_WIN32)
+        _putenv_s("PATH", (dir + ";" + oldPath).c_str());
+#else
+        std::string oldLd = std::getenv("LD_LIBRARY_PATH") ? std::getenv("LD_LIBRARY_PATH") : "";
+        setenv("PATH", (dir + ":" + oldPath).c_str(), 1);
+        setenv("LD_LIBRARY_PATH", (dir + ":" + oldLd).c_str(), 1);
+#endif
+        std::string cmd = "\"" + lld.string() + "\" @\"" + resp.string() + "\"";
+        int rc = std::system(cmd.c_str());
+#if defined(_WIN32)
+        _putenv_s("PATH", oldPath.c_str());
+#else
+        setenv("PATH", oldPath.c_str(), 1);
+#endif
+        fs::remove(resp, ec);
+        if (rc != 0) {
+            errorHandler.reportError(error::ErrorCode::C002_CODEGEN_ERROR,
+                                     "Bundled linker (ld.lld) failed (exit " +
+                                         std::to_string(rc) + "). Recipe: " +
+                                         recipePath.string(),
+                                     "", 0, 0);
+            return BundledLink::Failed;
+        }
+        return BundledLink::Ok;
+    }
+
     bool linkExecutable(const std::string& objPath, const std::string& exePath)
     {
+        // Prefer the self-contained bundled linker (vendored ld.lld + CRT/import
+        // libs) so native output needs no external gcc/clang. Fall through to the
+        // C driver only when no bundle is present.
+        switch (tryBundledLink(objPath, exePath)) {
+            case BundledLink::Ok:         return true;
+            case BundledLink::Failed:     return false;
+            case BundledLink::NotBundled: break;
+        }
+
         // Pick a C toolchain driver to link with. $CC wins; otherwise probe the
         // usual driver names and use the first that actually runs. mingw-w64
         // ships 'gcc' (there is no 'cc'), so it is tried first on Windows.


### PR DESCRIPTION
… ld.lld)

Make 'tocin file.to -o app.exe' produce a native binary with no external C toolchain on PATH, by shipping a self-contained linker bundle and driving it directly instead of shelling out to a C driver.

Design (see docs/native-linking.md):
- Engine (src/main.cpp tryBundledLink): if libexec/link/ exists, read a data-driven recipe (ld.lld arg list with %LINKDIR%/%OBJ%/%OUT% placeholders), prepend tocin's own dir to PATH so ld.lld finds the shared libs already in libexec, and run 'ld.lld @response'. Falls back to the C driver when no bundle is present - no regression where a toolchain exists. The recipe is data, so a bad link arg is fixable without recompiling the compiler.
- Recipe generator (installer/make-link-recipe.sh): derive the link line from the real 'gcc -v' spec rather than guessing it; vendor every absolute input (CRT objects, static/import libs) into link/sysroot and rewrite paths to %LINKDIR%. Self-contained mode for Windows (vendor all -l, collapse search to sysroot); --keep-syslibs for Linux/macOS (rely on system libc/libgcc_s).
- Packaging (Build-TocinInstaller.ps1): vendor ld.lld.exe + call the recipe generator with mingw gcc, -static-libgcc -static-libstdc++ and a static libgc when available so app.exe is standalone. Non-fatal: the package still builds and -o falls back to gcc if the linker bundle can't be produced.

Why bundled ld.lld over in-process lld::coff::link: LLD is not part of libLLVM (separate lldCOFF/lldMinGW libs + headers, absent in the current build), its C++ API is unstable across versions, and our objects are mingw-ABI so the MSVC/UCRT COFF path is the wrong runtime. Driving a vendored ld.lld with explicit inputs hits the goal with far less coupling.

Validated end-to-end on Linux (engine + generator): with PATH/CC pointed at nothing, 'tocin x.to -o x' links through the bundled ld.lld and runs. Windows recipe contents are derived from the build machine's mingw gcc and need one on-box validation pass. Suite stays green: 146/146 + 12/12.