### PR TITLE
Hotfix: don't include &lt;windows.h&gt; in main.cpp (its macros break the Windows build)

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -42,7 +42,11 @@
 
 // Platform APIs for locating this executable (used to find the bundled linker).
 #if defined(_WIN32)
-#include <windows.h>
+// Forward-declare the single Win32 API we need rather than including <windows.h>,
+// whose macros (IN, OUT, VOID, CONST, TRUE, FALSE, ERROR, ...) would clobber the
+// enum members of the Tocin headers included below and break the whole build.
+extern "C" __declspec(dllimport) unsigned long __stdcall
+GetModuleFileNameA(void *hModule, char *lpFilename, unsigned long nSize);
 #elif defined(__APPLE__)
 #include <mach-o/dyld.h>
 #else
@@ -213,8 +217,8 @@ extern "C" {
 static std::string tocinExecutableDir()
 {
 #if defined(_WIN32)
-    char buf[MAX_PATH];
-    DWORD n = GetModuleFileNameA(nullptr, buf, static_cast<DWORD>(sizeof(buf)));
+    char buf[4096];
+    unsigned long n = GetModuleFileNameA(nullptr, buf, static_cast<unsigned long>(sizeof(buf)));
     if (n == 0 || n >= sizeof(buf)) return {};
     std::string p(buf, n);
 #elif defined(__APPLE__)


### PR DESCRIPTION
**Build-breaking regression in master** (from the native-linking change in #34): the Windows build fails to compile `src/main.cpp` with a cascade of `'Token'/'ErrorHandler'/'TypePtr' does not name a type` errors.

## Cause
The native-linking work added `#include <windows.h>` to `main.cpp` (for `GetModuleFileNameA`). On Windows that pulls in the macros `IN`, `OUT`, `VOID`, `CONST`, `TRUE`, `FALSE`, `ERROR` (from `minwindef.h`/`windef.h`/`wingdi.h`) **before** the Tocin headers — and those names are enum members:
- `token.h` → `TokenType::IN`, `OUT`, `CONST`, `TRUE`, `FALSE`
- `ast/types.h` → `TypeKind::VOID`
- `error_handler.h` → `ErrorSeverity::ERROR`

The macros rewrite the enum members, collapsing the whole parse. `WIN32_LEAN_AND_MEAN`/`NOMINMAX` don't suppress these particular ones. The Linux CI never includes `windows.h`, so it stayed green and missed it.

## Fix
Forward-declare just `GetModuleFileNameA` instead of including the header, and use `unsigned long`/a fixed buffer rather than `DWORD`/`MAX_PATH`. No Windows header is pulled into `main.cpp`; `_putenv_s` and the rest come from `<cstdlib>`.

## Verification
- Linux: clean build, **146/146** `.to` + **12/12** borrow-check.
- Bundled-link engine re-verified: with `PATH`/`CC` pointing at nothing, `tocin x.to -o x` still links via the bundled `ld.lld` and runs.
- The actual Windows compile fix can only be confirmed on the mingw box — but this removes exactly the header whose macros the compiler flagged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Fih5HHhUzVNkusdaXHoSdu)_