### PR TITLE
docs: bring all documentation in line with the implemented language

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -39,9 +39,8 @@ Thank you for your interest in contributing to Tocin! We welcome contributions o
 ## Continuous Integration (CI/CD)
 
 - All pull requests and pushes are automatically built and tested using GitHub Actions.
-- The workflow runs on Windows, Linux, and macOS using a build matrix.
-- All tests in `tests/` must pass for a PR to be merged.
-- Code coverage is collected and reported for each build.
+- The Linux builds (Release and Debug) are the authoritative gate; macOS and Windows builds are best-effort and do not block a PR.
+- The Linux CI jobs (ctest and the `.to` test suites) must pass for a PR to be merged.
 - Contributors can check CI status on the PR page or in the Actions tab.
 - If CI fails, review the logs, fix issues, and push updates until all checks pass.
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Tocin — a statically-typed, LLVM-compiled programming language
 
-[![CI Status](https://github.com/tafolabi009/tocin-compiler/workflows/CI/badge.svg)](https://github.com/tafolabi009/tocin-compiler/actions)
+[![CI Status](https://github.com/tafolabi009/TocinLang/workflows/CI/badge.svg)](https://github.com/tafolabi009/TocinLang/actions)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
-[![Platform](https://img.shields.io/badge/platform-Linux%20%7C%20macOS%20%7C%20Windows-blue)](https://github.com/tafolabi009/tocin-compiler)
+[![Platform](https://img.shields.io/badge/platform-Linux%20%7C%20macOS%20%7C%20Windows-blue)](https://github.com/tafolabi009/TocinLang)
 
 > Tocin is a statically-typed, compiled programming language with type inference,
 > classes, and an LLVM backend. Programs can be **JIT-executed** for fast iteration
@@ -32,25 +32,39 @@ publish one, see [installer/README.md](installer/README.md).
 
 ## Highlights (implemented and tested)
 
-- **Compiles to native code via LLVM 18** — every example below produces a real
-  ELF/Mach-O/PE executable, or can be JIT-executed in-process.
+- **Compiles to native code via LLVM (18–22)** — every example below produces a
+  real ELF/Mach-O/PE executable, or can be JIT-executed in-process.
 - **Type inference** — variable and function return types are inferred when not
   annotated; a real type checker reports genuine type errors.
+- **Strict, readable diagnostics** — type checking is strict by default: unknown
+  names, wrong argument counts (builtins included), and type mismatches stop
+  compilation with rustc-style errors — the offending source line, a caret
+  underline, colors on terminals, `did you mean 'sqrt'?` suggestions — and a
+  final `N errors generated.` summary. `--permissive` downgrades them to
+  warnings if you need the old behavior.
 - **Functions** — parameters, recursion, mutual recursion, and use-before-definition
   (declarations are order-independent via two-pass code generation).
 - **First-class functions & closures** — functions are values: pass them as
   arguments (`f: (int) -> int`), store them, return them, and call them
-  indirectly; `lambda (x: int) -> int  x * 2` lambdas **capture enclosing
-  locals by value** and can be returned from a function (escaping closures with
-  independent state). Nested `def` helpers are also supported.
+  indirectly; `lambda (x: int) -> int  x * 2` lambdas capture enclosing locals
+  (**reads snapshot by value; writes share the cell**, so `counter = counter + 1`
+  inside a lambda is visible outside) and can be returned from a function
+  (escaping read-captures with independent state). Nested `def` helpers are
+  also supported.
 - **Control flow** — `if / elif / else`, `while`, range-based `for i in a..b`,
   `for v in arr`, `break` / `continue`, and `match` / `case` / `default`.
 - **Operators** — full arithmetic with automatic int→float promotion, compound
   assignment (`+= -= *= /= %=`), bitwise & shifts (`& | ^ << >> ~`), logical
   (`&&`/`and`, `||`/`or`, `!`), and string equality by value (`s == "x"`).
   Integer literals support `0x`/`0o`/`0b` and `_` separators.
+- **Ternary & default parameters** — conditional expressions
+  (`let m = a > b ? a : b;`) and default parameter values
+  (`def pad(s: string, width: int = 8)`), filled in per call site.
 - **Error handling** — `throw`, `try` / `catch (e)` / `finally`; exceptions unwind
   across function calls (setjmp/longjmp runtime) in both JIT and native builds.
+- **Runtime traps** — integer division/modulo by zero and out-of-bounds indexing
+  never silently corrupt state: they abort with a located message, e.g.
+  `panic: integer division by zero at app.to:4:16`.
 - **Null safety** — safe navigation `a?.b`, elvis/coalescing `a ?: b`, and
   force-unwrap `a!!` over nullable references.
 - **Option / Result** — `Some`/`None`/`Ok`/`Err` with destructuring `match`
@@ -87,15 +101,25 @@ publish one, see [installer/README.md](installer/README.md).
   building blocks for symbol tables and real data structures.
 - **Concurrency** — `go f(args)` goroutines (real OS threads), typed `channel<T>`
   send/receive, and `select` over multiple channels, in both JIT and native builds.
+- **Async/await** — `async def` + `await` compile and run with correct (eager)
+  semantics and compose in expressions and across async calls; pair with
+  goroutines + channels for real parallelism (a suspending M:N scheduler is
+  designed but not wired in — see docs/async-scheduler-design.md).
 - **Networking & system services** — TCP sockets (`tcpListen`/`tcpAccept`/
   `tcpConnect`/`tcpSend`/`tcpRecv`/`tcpClose`) for clients and concurrent servers,
   wall-clock + monotonic **time** (`timeSec`/`timeMs`/`monoNanos`/`sleepMs`),
   **hashing** (FNV-1a `hashStr`/`hashBytes`, splitmix64 `hashInt`), seeded
   **random** (`randSeed`/`randInt`/`randRange`), and `envGet`/`sysExit`. See
   `examples/tcp_echo.to`.
-- **Modules** — `import a.b.c` / `import "path"` resolves and merges other `.to`
-  files; a small standard library ships in `stdlib/std/` (math, list, LINQ-style
-  collection ops).
+- **Modules & standard library** — `import a.b.c` / `import "path"` resolves and
+  merges other `.to` files. The bundled stdlib spans **34 modules across 13
+  domains**: `std` (math, strings, sequences, functional `map`/`filter`/`fold`
+  with function-value callbacks, JSON, a test framework), `data` (algorithms +
+  classic data structures), `math` (stats, linear algebra, geometry, calculus),
+  `ml` (neural networks, deep learning, computer vision, and **TEN — Temporal
+  Eigenstate Networks**), plus `web`, `net`, `database`, `game`, `gui`, `audio`,
+  `embedded`, `scripting`, and `pkg`. Every module compiles and runs under
+  `tocin --run` and is exercised by the JIT test suite (`tests/jit/`).
 - **Macros** — function-like `macro name(params) { body }` expanded at the token
   level before parsing; invoked as `name!(args)` with precedence-safe, composable
   expansion.
@@ -113,8 +137,12 @@ publish one, see [installer/README.md](installer/README.md).
   needed, so long-running programs don't leak. `free`/`vecFree`/`mapFree` remain
   for eager release.
 - **Systems / low-level** — raw memory (`alloc`, `memcpy`, `memset`, `ptrAdd`,
-  `loadByte`/`storeByte`/`loadInt`/`storeInt`) and inline assembly
-  (`asm("...")`, native builds) for VCS-style tools and OS/kernel work.
+  `loadByte`/`storeByte`/`loadInt`/`storeInt`), **volatile MMIO accessors**
+  (`volatileLoad8/16/32/64`, `volatileStore8/16/32/64` — never elided or merged,
+  even at `-O3`), memory **`fence()`**, and **inline assembly with operands and
+  constraints** — `asm("lea 100($1), $0", "=r,r", x)` returns a value, and
+  clobbers work too (`asm("rdtsc", "={ax},~{dx}")`) — for VCS-style tools and
+  OS/kernel work. See `tests/jit/kernel_primitives.to`.
 - **`switch`** — C-style `switch`/`case`/`default` (alias of `match`).
 - **`defer`** — `defer <statement>` runs cleanup at function return (LIFO, every
   return path); pairs with `free`/`vecFree` for deterministic resource release.
@@ -129,8 +157,16 @@ publish one, see [installer/README.md](installer/README.md).
 - **Opt-in borrow checker** — `--borrow-check` adds Rust-like compile-time move /
   use-after-move enforcement on owned (class) values, on top of the GC's
   always-on safety. Off by default (instances alias freely under GC).
-- **Native performance** — default `-O2` (the full LLVM pipeline); a compute
-  benchmark runs within ~9% of the equivalent C at `-O2`.
+- **Native performance** — default `-O2`; `-O3 --native` adds CPU-specific
+  vectorization (POPCNT/AVX), whole-program internalization, and alias-aware
+  buffer optimization. On a 12-kernel C/C++/Rust comparison, Tocin's geomean
+  **ties Rust** (~1.4× of C overall) and it is outright fastest on 5 of the 12
+  kernels (e.g. `sqrtsum`, ~2× faster than the C version); `matmul` and
+  `levenshtein` remain the known gaps.
+- **Project tooling** — `tocin new <name>` scaffolds a project, `tocin check
+  file.to` typechecks without generating code (fast pre-commit/CI gate), and
+  `tocin doc file.to` emits Markdown API docs from signatures and the `//`
+  comment blocks above declarations.
 - **Formatted output** — `print` / `println`, including `println("x = {}", x)`.
 
 ## Documentation
@@ -149,7 +185,8 @@ code snippet in them has been compiled and run against the in-tree compiler.
 
 ### Prerequisites
 
-- LLVM 18 (development package, e.g. `llvm-18-dev` on Debian/Ubuntu)
+- LLVM 18–22 development package (18 is the Linux CI baseline, e.g.
+  `llvm-18-dev` on Debian/Ubuntu; MSYS2's LLVM 22 works on Windows)
 - CMake ≥ 3.16 and a C++20 compiler (GCC 11+, Clang 14+)
 - `zlib`, `libffi` (and optionally `libzstd`, `libxml2`, Python 3 for FFI)
 
@@ -162,8 +199,8 @@ sudo apt-get install -y llvm-18-dev libffi-dev zlib1g-dev libzstd-dev libxml2-de
 ### Build
 
 ```bash
-git clone https://github.com/tafolabi009/tocin-compiler.git
-cd tocin-compiler
+git clone https://github.com/tafolabi009/TocinLang.git
+cd TocinLang
 cmake -S . -B build -G Ninja -DCMAKE_BUILD_TYPE=Release \
       -DWITH_V8=OFF -DLLVM_DIR=$(llvm-config-18 --cmakedir)
 cmake --build build -j
@@ -342,7 +379,11 @@ Source (.to)
 
 The driver (`src/main.cpp`) drives this pipeline. `--run` JIT-executes `main`
 in-process; `-o <file>` selects output by extension (`.ll` IR, `.s` assembly,
-`.o` object, anything else → a linked native executable).
+`.o` object, anything else → a linked native executable). Executables link
+through the system C compiler when one is available — or through the **bundled
+`ld.lld` + static link recipe** shipped by the installer packages, so an
+installed Tocin builds native binaries on machines with **no compiler toolchain
+at all** ([docs/native-linking.md](docs/native-linking.md)).
 
 ## Project structure
 
@@ -352,14 +393,15 @@ tocin-compiler/
 │   ├── lexer/       # Tokenizer
 │   ├── parser/      # Recursive-descent parser → AST
 │   ├── ast/         # AST and type node definitions
-│   ├── type/        # Type checker and (in-progress) advanced type features
+│   ├── type/        # Type checker (strict by default) and advanced type features
 │   ├── codegen/     # LLVM IR generation
-│   ├── compiler/    # Compilation context, optimization, (in-progress) macros
-│   ├── runtime/     # Scheduler, async, concurrency support (in-progress)
-│   ├── ffi/         # Python / C / JavaScript FFI (see Roadmap)
-│   └── error/       # Diagnostics
-├── stdlib/          # Standard-library modules written in Tocin (in-progress)
-├── tests/           # Unit tests and .to integration programs
+│   ├── compiler/    # Compilation context, optimization pipeline, macros
+│   ├── runtime/     # Scheduler, async, concurrency, GC runtime
+│   ├── ffi/         # C / Python / JavaScript FFI (see Roadmap for scope)
+│   └── error/       # Diagnostics (caret rendering, suggestions)
+├── stdlib/          # The standard library — 34 Tocin modules, all runnable
+├── installer/       # Native installers: NSIS .exe, .deb, .run, .pkg/.dmg
+├── tests/           # C++ unit tests, lli programs (cases/), JIT suites (jit/)
 ├── examples/        # Example programs
 └── docs/            # Language and design documentation
 ```
@@ -371,7 +413,8 @@ tocin-compiler/
 # symbols used by concurrency and exception programs.
 cmake --build build --target tocin tocin_tests tocin_runtime_shared
 ctest --test-dir build --output-on-failure       # C++ unit tests
-bash scripts/run_to_tests.sh                      # .to integration programs
+bash scripts/run_to_tests.sh                      # .to integration programs (lli)
+bash tests/run_stdlib_tests.sh                    # JIT runtime + stdlib suites
 ```
 
 ## Roadmap
@@ -382,16 +425,15 @@ end-to-end**. They are listed honestly so expectations match reality:
 - **Explicit generic type arguments** — generic functions and classes infer their
   type arguments from the call/constructor today; turbofish-style annotations
   (`Box<int>(...)`) and generic types in parameter/field signatures are pending.
-- **Higher-order LINQ** — `where`/`select`/`aggregate` ship today as stdlib
-  functions over int lists (`import std.linq`); arbitrary lambda predicates/maps
-  need first-class function values (pending).
+- **Generic higher-order stdlib** — `std.functional` ships real
+  `map`/`filter`/`fold`/`zip` with function-value callbacks, and `std.linq`
+  ships allocation-light reductions, both over int lists; generalizing these
+  helpers over arbitrary element types is pending.
 - **Nullable-type flow analysis** — the `?.`/`?:`/`!!` operators work today;
   static tracking of which references are nullable is pending.
 - **`Option` / `Result` ergonomics** — `Some`/`None`/`Ok`/`Err` and `case`
   destructuring work today; exhaustiveness checking, `?` propagation and typed
   payloads (the bound value is an int slot) are pending.
-- **`async` / `await`** — goroutines, channels and `select` work; structured
-  async is pending.
 - **Typed exceptions** — `throw` / `catch` carry an integer code today; throwing and
   binding arbitrary typed payloads (e.g. error objects) is pending.
 - **Python / JavaScript FFI** — C FFI works via `extern`; deep CPython and V8

--- a/docs/02_Getting_Started.md
+++ b/docs/02_Getting_Started.md
@@ -1,287 +1,138 @@
 # Getting Started with Tocin
 
-This guide will help you set up your development environment, install the Tocin compiler, and write your first Tocin program.
+Install the compiler, run your first program, and learn the everyday commands.
 
-## System Requirements
+## 1. Install Tocin
 
-Tocin can be installed on the following operating systems:
+### Option A — native installers (recommended)
 
-- **Windows**: Windows 10 or later (64-bit)
-- **macOS**: 10.14 (Mojave) or later
-- **Linux**: Most modern distributions including Ubuntu 18.04+, Debian 10+, Fedora 32+, and CentOS 8+
+Download the file for your platform and open it (full details in
+[../INSTALL.md](../INSTALL.md)):
 
-Hardware requirements:
-- 2 GHz dual-core processor or better
-- 4 GB RAM (8 GB recommended)
-- 1 GB disk space for the Tocin toolchain and standard library
+| Platform | File |
+|---|---|
+| Windows | `Tocin-<ver>-Setup.exe` — GUI wizard; adds `tocin` to PATH and a `.to` file association |
+| Debian/Ubuntu | `tocin_<ver>_amd64.deb` — double-click or `sudo apt install ./tocin_<ver>_amd64.deb` |
+| Any Linux | `tocin-<ver>-linux-<arch>.run` — `sh tocin-*.run`; installs to `~/.tocin`, no root |
+| macOS | `tocin-<ver>-macos-<arch>.pkg` / `.dmg` — native Installer GUI |
 
-## Installing Tocin
+Or use the quick-install one-liners (they fetch the latest GitHub Release):
 
-### Using the Official Installer
+```bash
+# Linux / macOS
+curl -fsSL https://raw.githubusercontent.com/tafolabi009/TocinLang/master/installer/get-tocin.sh | sh
+```
 
-1. Download the latest Tocin installer from the [official website](https://tocin.io/downloads).
-2. Run the installer and follow the on-screen instructions.
-3. Verify the installation by opening a terminal or command prompt and running:
+```powershell
+# Windows (PowerShell)
+irm https://raw.githubusercontent.com/tafolabi009/TocinLang/master/installer/install.ps1 | iex
+```
+
+The installed packages are **self-contained**: compiler, runtime, the full
+standard library, docs, examples, an uninstaller — and a bundled linker, so
+compiling to native executables needs **no C compiler on your machine**.
+
+### Option B — build from source
+
+You need CMake ≥ 3.16, a C++20 compiler, and LLVM 18–22 dev packages
+(see [BUILDING.md](BUILDING.md)):
+
+```bash
+git clone https://github.com/tafolabi009/TocinLang.git
+cd TocinLang
+cmake -S . -B build -G Ninja -DCMAKE_BUILD_TYPE=Release \
+      -DWITH_V8=OFF -DLLVM_DIR=$(llvm-config-18 --cmakedir)
+cmake --build build -j
+```
+
+This produces `build/tocin`.
+
+### Verify
 
 ```bash
 tocin --version
 ```
 
-This should display the version of the Tocin compiler you installed.
-
-### Using Package Managers
-
-#### Windows (via Chocolatey)
-
-```bash
-choco install tocin
-```
-
-#### macOS (via Homebrew)
-
-```bash
-brew install tocin
-```
-
-#### Linux (via Apt for Ubuntu/Debian)
-
-```bash
-sudo apt update
-sudo apt install tocin
-```
-
-### Building from Source
-
-For advanced users who want to build Tocin from source:
-
-1. Ensure you have a C++ compiler (GCC 8+, Clang 10+, or MSVC 2019+), CMake 3.15+, and Git installed.
-2. Clone the repository:
-
-```bash
-git clone https://github.com/tocin-lang/tocin-compiler.git
-cd tocin-compiler
-```
-
-3. Build the compiler:
-
-```bash
-mkdir build && cd build
-cmake ..
-cmake --build . --config Release
-```
-
-4. Install the compiler:
-
-```bash
-cmake --install .
-```
-
-## Setting Up Your Development Environment
-
-### Command Line Tools
-
-The basic Tocin installation includes:
-
-- `tocin`: The compiler
-- `tocin-fmt`: Code formatter
-- `tocin-doc`: Documentation generator
-- `tocin-pkg`: Package manager
-
-### Integrated Development Environment (IDE) Support
-
-Tocin has excellent IDE support through plugins:
-
-#### Visual Studio Code
-
-1. Install Visual Studio Code
-2. Open the Extensions view (Ctrl+Shift+X or Cmd+Shift+X)
-3. Search for "Tocin"
-4. Install the "Tocin Language Support" extension
-
-The extension provides:
-- Syntax highlighting
-- Code completion
-- Error diagnostics
-- Code navigation
-- Refactoring tools
-
-#### JetBrains IDEs (IntelliJ IDEA, CLion, etc.)
-
-1. Open Settings/Preferences
-2. Go to Plugins > Marketplace
-3. Search for "Tocin"
-4. Install the "Tocin" plugin
-
-#### Other Editors
-
-- **Vim/Neovim**: Install the `tocin.vim` plugin
-- **Emacs**: Install the `tocin-mode` package
-- **Sublime Text**: Install the "Tocin" package from Package Control
-
-## Your First Tocin Program
-
-Let's write a simple "Hello, World!" program to verify your setup.
-
-1. Create a new file named `hello.to`
-2. Add the following code:
+## 2. Your first program
 
 ```tocin
-def main() -> int {
-    println("Hello, World!");
+// hello.to
+def main() {
+    println("Hello from Tocin!");
     return 0;
 }
 ```
 
-3. Compile and run the program:
+Run it immediately with the JIT — no separate build step:
 
 ```bash
-tocin build hello.to
-./hello
+tocin hello.to --run
 ```
 
-You should see "Hello, World!" printed to the console.
+Or compile a native executable:
 
-### Understanding the Hello World Program
+```bash
+tocin hello.to -o hello
+./hello                     # (hello.exe on Windows)
+```
 
-Let's break down the Hello World program:
+The process exit code is whatever `main` returns.
+
+## 3. Start a project
+
+```bash
+tocin new myapp
+cd myapp
+tocin main.to --run
+```
+
+`tocin new` scaffolds a directory with `main.to`, a `README.md`, and a
+`.gitignore`.
+
+## 4. The commands you'll use daily
+
+| Command | What it does |
+|---|---|
+| `tocin app.to --run` | JIT-compile and run right now (fastest iteration loop). |
+| `tocin app.to -o app` | Build a native executable. `-o app.ll` / `app.s` / `app.o` emit IR / assembly / an object instead. |
+| `tocin check app.to` | Typecheck only — full strict diagnostics, no codegen. Great as a pre-commit or CI gate. |
+| `tocin doc app.to` | Print Markdown API docs generated from signatures and the `//` comments above them. |
+| `tocin app.to -o app -O3 --native` | Maximum optimization, tuned to your CPU. Default is `-O2`. |
+
+When something is wrong, the compiler tells you precisely where and often what
+you meant:
+
+```text
+app.to:3:8: error [T013]: Cannot assign to constant 'X' (declared with `const`). Use `let` for a mutable binding.
+    3 |     X = 6;
+      |        ^
+1 error generated.
+```
+
+## 5. Use the standard library
+
+The stdlib ships with the installer (34 modules — math, data structures,
+strings, JSON, testing, ML, web, and more). Import what you need; names are
+global after import:
 
 ```tocin
-def main() -> int {
-    println("Hello, World!");
+import std.math;
+
+def main() {
+    println("{}", clamp(15, 0, 10));   // 10
     return 0;
 }
 ```
 
-- `def main() -> int {`: Defines the main function, which is the entry point of the program. It returns an integer.
-- `println("Hello, World!");`: Calls the `println` function to print a string to the console.
-- `return 0;`: Returns the value 0, indicating successful execution.
+The installer's launcher sets `TOCIN_PATH` so imports just work; when running
+a source checkout, `export TOCIN_PATH=/path/to/TocinLang/stdlib`.
 
-## Creating a More Complex Program
+## 6. Where to next
 
-Let's create a slightly more complex program that calculates the factorial of a number:
-
-```tocin
-def factorial(n: int) -> int {
-    if (n <= 1) {
-        return 1;
-    }
-    return n * factorial(n - 1);
-}
-
-def main() -> int {
-    println("Calculate factorials");
-    
-    for (let i = 1; i <= 10; i++) {
-        println("Factorial of " + i.toString() + " is " + factorial(i).toString());
-    }
-    
-    return 0;
-}
-```
-
-Save this as `factorial.to`, then compile and run it:
-
-```bash
-tocin build factorial.to
-./factorial
-```
-
-## Project Structure
-
-For larger projects, Tocin uses a project structure with a configuration file. Here's how to create a new project:
-
-1. Create a new directory for your project:
-
-```bash
-mkdir my_project
-cd my_project
-```
-
-2. Initialize a new Tocin project:
-
-```bash
-tocin init
-```
-
-This creates a basic project structure:
-
-```
-my_project/
-├── src/
-│   └── main.to
-├── tests/
-├── .gitignore
-└── tocin.toml
-```
-
-3. The `tocin.toml` file contains your project configuration:
-
-```toml
-[package]
-name = "my_project"
-version = "0.1.0"
-authors = ["Your Name <your.email@example.com>"]
-
-[dependencies]
-# Add dependencies here
-```
-
-4. Build and run your project:
-
-```bash
-tocin build
-./out/my_project
-```
-
-## Using the Package Manager
-
-Tocin has a built-in package manager called `tocin-pkg`. Here's how to use it:
-
-1. Add a dependency to your `tocin.toml` file:
-
-```toml
-[dependencies]
-json = "1.0.2"
-```
-
-2. Install the dependency:
-
-```bash
-tocin-pkg install
-```
-
-3. Use the package in your code:
-
-```tocin
-import json;
-
-def main() -> int {
-    let data = json.parse("{\"name\": \"John\", \"age\": 30}");
-    println("Name: " + data["name"].toString());
-    return 0;
-}
-```
-
-## Debugging
-
-Tocin integrates with common debuggers like GDB and LLDB. To compile with debug information:
-
-```bash
-tocin build --debug
-```
-
-Then use your debugger:
-
-```bash
-gdb ./out/my_project
-```
-
-## Next Steps
-
-Now that you've set up your environment and written your first programs, you're ready to explore more of what Tocin has to offer:
-
-1. Continue to [Language Basics](03_Language_Basics.md) to learn more about Tocin's syntax and features
-2. Explore the [Standard Library](04_Standard_Library.md) to see what built-in functionality is available
-3. Check out the [Tocin Cookbook](../cookbook/README.md) for practical examples and recipes
-
-Happy coding!
+- **Learn the language**: [tutorial.md](tutorial.md) — every feature, with
+  runnable code.
+- **Look something up**: [language-reference.md](language-reference.md) and
+  [stdlib-reference.md](stdlib-reference.md).
+- **Explore the stdlib**: [04_Standard_Library.md](04_Standard_Library.md).
+- **Run the examples**: `tocin ~/.tocin/share/examples/hello.to --run`
+  (installed) or the `examples/` directory of a checkout.

--- a/docs/03_Language_Basics.md
+++ b/docs/03_Language_Basics.md
@@ -22,9 +22,6 @@ Tocin uses a clean, readable syntax that will feel familiar to developers with e
 Tocin source files use the `.to` extension. A simple program might look like this:
 
 ```tocin
-// Import standard library modules
-import system.io;
-
 // Define the main function
 def main() -> int {
     println("Hello, Tocin!");

--- a/docs/04_Standard_Library.md
+++ b/docs/04_Standard_Library.md
@@ -1,1102 +1,432 @@
 # Tocin Standard Library
 
-The Tocin Standard Library provides a rich set of modules and functions that enable developers to build sophisticated applications without reinventing common functionality. This document provides an overview of the core modules available in the standard library.
+The Tocin standard library is a set of 34 modules written in pure Tocin,
+shipped as source under `stdlib/`. Every module builds on the compiler's
+built-in functions (`println`, `len`, `sqrt`, `vecNew`, `mapNew`, `alloc`,
+`tcpListen`, ...), which are always available with no import — see
+[stdlib-reference.md](stdlib-reference.md) for that list. Every function name
+and example in this document was verified against the in-tree source and, for
+complete programs, by running them with `build/tocin FILE.to --run`.
 
-## Table of Contents
+## Imports and `TOCIN_PATH`
 
-- [Tocin Standard Library](#tocin-standard-library)
-  - [Table of Contents](#table-of-contents)
-  - [System Modules](#system-modules)
-    - [system.io](#systemio)
-    - [system.time](#systemtime)
-    - [system.json](#systemjson)
-  - [Mathematics Modules](#mathematics-modules)
-    - [math.basic](#mathbasic)
-    - [math.linear](#mathlinear)
-    - [math.geometry](#mathgeometry)
-    - [math.stats](#mathstats)
-  - [Concurrency Modules](#concurrency-modules)
-    - [concurrency.coroutine](#concurrencycoroutine)
-    - [concurrency.channel](#concurrencychannel)
-  - [Data Structure Modules](#data-structure-modules)
-    - [collections.array](#collectionsarray)
-    - [collections.map](#collectionsmap)
-    - [collections.set](#collectionsset)
-    - [collections.list](#collectionslist)
-  - [Networking Modules](#networking-modules)
-    - [net.http](#nethttp)
-    - [net.server](#netserver)
-    - [net.advanced.rest](#netadvancedrest)
-  - [GUI Modules](#gui-modules)
-    - [gui.core](#guicore)
-    - [gui.widgets](#guiwidgets)
-    - [gui.layout](#guilayout)
-    - [gui.events](#guievents)
-  - [Game Development Modules](#game-development-modules)
-    - [game.engine](#gameengine)
-    - [game.graphics](#gamegraphics)
-    - [game.physics](#gamephysics)
-    - [game.input](#gameinput)
-    - [game.audio](#gameaudio)
-  - [Machine Learning Modules](#machine-learning-modules)
-    - [ml.model](#mlmodel)
-    - [ml.nn](#mlnn)
-    - [ml.optimizer](#mloptimizer)
-    - [ml.data](#mldata)
-    - [ml.preprocessing](#mlpreprocessing)
-
-## System Modules
-
-### system.io
-
-The `system.io` module provides functionality for file and directory operations.
+A dotted import maps to a relative file path; a string import is used as-is
+(the trailing `.to` is added if absent):
 
 ```tocin
-import system.io;
+import std.math;          // resolves to std/math.to
+import data.algorithms;   // resolves to data/algorithms.to
+import "std/math";        // same file, string form
+```
 
-// Reading a file
-let content = io.readFile("path/to/file.txt");
+For each import the compiler searches, in order:
 
-// Writing to a file
-io.writeFile("path/to/output.txt", "Hello, Tocin!");
+1. the directory of the importing file,
+2. the directory named by the **`TOCIN_PATH`** environment variable, if set,
+3. the compiled-in standard-library path.
 
-// Checking if a file exists
-if (io.fileExists("path/to/file.txt")) {
-    println("File exists");
+The installers create a launcher that sets `TOCIN_PATH` to the installed
+`stdlib/` automatically. When running from a source checkout, set it yourself:
+
+```sh
+TOCIN_PATH=/path/to/TocinLang/stdlib ./build/tocin program.to --run
+```
+
+**There is no namespacing.** An imported file's top-level declarations are
+merged into the program, so you call imported functions by their bare names
+(`gcd(12, 18)`, never `std.math.gcd(...)`). Stdlib names are prefixed by
+module or data structure (`listSum`, `strTrim`, `heapPush`, `tenScan`) to keep
+them unique. A few short names do repeat across distant domains (`countWhere`,
+`mix`, `step`); importing two modules that define the same name into one
+program is not supported — see [STDLIB_GUIDE.md](STDLIB_GUIDE.md).
+
+Two conventions run through the whole library:
+
+- **Booleans are `int`**: predicates return `1` (true) or `0` (false).
+- **Handles are `int`**: structures built on raw buffers (`heapNew`,
+  `tableNew`, `worldNew`, ...) return an `int` address; pass it to the
+  structure's functions and release it with the matching `*Free`.
+
+| Domain | Modules |
+|---|---|
+| `std` | `std/math`, `std/list`, `std/functional`, `std/linq`, `std/strings`, `std/strseq`, `std/json`, `std/testing` |
+| `data` | `data/algorithms`, `data/structures`, `data/collections` |
+| `math` | `math/basic`, `math/linear`, `math/geometry`, `math/stats`, `math/stats_advanced`, `math/differential` |
+| `ml` | `ml/neural_network`, `ml/deep_learning`, `ml/computer_vision`, `ml/ten` |
+| `web`, `net` | `web/http`, `web/websocket`, `net/advanced` |
+| `database` | `database/database` |
+| `game` | `game/engine`, `game/graphics`, `game/shader` |
+| `gui` | `gui/core`, `gui/widgets` |
+| `audio` | `audio/audio` |
+| `embedded` | `embedded/gpio` |
+| `scripting` | `scripting/automation` |
+| `pkg` | `pkg/manager` |
+
+## std — core utilities
+
+The `std` modules cover everyday programming: integer math (`std.math`),
+`list<int>` helpers (`std.list`), higher-order functions over int lists
+(`std.functional`), query-style reductions (`std.linq`, see
+[LINQ.md](LINQ.md)), string cleanup and parsing (`std.strings`), splitting and
+joining (`std.strseq`), a JSON parser/serializer (`std.json`), and a test
+harness (`std.testing`, see [STDLIB_GUIDE.md](STDLIB_GUIDE.md)).
+
+| Function | Module | Description |
+|---|---|---|
+| `gcd(a: int, b: int) -> int` | `std.math` | Greatest common divisor |
+| `isPrime(n: int) -> int` | `std.math` | Primality test |
+| `listSum(xs: list<int>) -> int` | `std.list` | Sum of the elements |
+| `listContains(xs: list<int>, target: int) -> int` | `std.list` | Membership test |
+| `mapInts(xs: list<int>, f: (int) -> int) -> list<int>` | `std.functional` | Apply a function value to every element |
+| `foldInts(xs: list<int>, init: int, f: (int, int) -> int) -> int` | `std.functional` | Left fold with a binary function |
+| `reduceSum(xs: list<int>) -> int` | `std.linq` | Sum reduction |
+| `strTrim(s: string) -> string` | `std.strings` | Strip surrounding whitespace |
+| `strParseIntOr(s: string, fallback: int) -> int` | `std.strings` | Parse an integer, with fallback |
+| `splitChar(s: string, delim: int) -> vector` | `std.strseq` | Split on a character code |
+| `joinStr(parts: vector, sep: string) -> string` | `std.strseq` | Join a vector of strings |
+| `jsonParse(s: string) -> int` | `std.json` | Parse JSON text into a node handle |
+
+`std.json` follows the handle convention: `jsonParse` returns a node you read
+with `jsonType`, `jsonAsInt`, `jsonAsString`, `jsonArrayGet`,
+`jsonObjectGet`, or the shortcut accessors `jsonGetInt(v, key, dflt)` and
+`jsonGetString(v, key, dflt)`; `jsonStringify(v)` serializes a node back to
+text.
+
+```tocin
+import std.strseq;
+import std.strings;
+
+def main() {
+    let parts = splitChar("alpha,beta,gamma", 44);   // ',' is char code 44
+    println("{}", joinStr(parts, " | "));
+    println("{}", strTrim("   padded   "));
+    println("{}", strParseIntOr("42", 0) + strParseIntOr("oops", -1));
+    return 0;
 }
+```
 
-// Creating a directory
-io.createDirectory("path/to/new/directory");
+```text
+alpha | beta | gamma
+padded
+41
+```
 
-// Listing directory contents
-let files = io.listDirectory("path/to/directory");
-for (let file of files) {
-    println(file);
+## data — algorithms and containers
+
+`data.algorithms` sorts and searches `list<int>` (quicksort, binary search,
+arg-min/max, counting). `data.structures` wraps the `vector`/`map` builtins
+into a stack, FIFO queue, integer set, and frequency counter.
+`data.collections` builds classic structures on raw buffers: a binary
+min-heap, union-find, bitset, ring buffer, string list, binary search tree,
+and a double-ended queue.
+
+| Function | Module | Description |
+|---|---|---|
+| `sort(xs: list<int>)` | `data.algorithms` | In-place quicksort |
+| `binarySearch(xs: list<int>, target: int) -> int` | `data.algorithms` | Index in a sorted list, `-1` if absent |
+| `argMax(xs: list<int>) -> int` | `data.algorithms` | Index of the largest element |
+| `stackPush(s, x)` / `stackPop(s)` | `data.structures` | LIFO stack over a `vector` |
+| `enqueue(q, x)` / `dequeue(q)` | `data.structures` | FIFO queue |
+| `setAdd(s, x)` / `setContains(s, x)` | `data.structures` | Integer set over a `map` |
+| `countAdd(c, x)` / `countOf(c, x)` | `data.structures` | Frequency counter |
+| `heapPush(h, x)` / `heapPop(h)` | `data.collections` | Binary min-heap (priority queue) |
+| `ufUnion(uf, a, b)` / `ufConnected(uf, a, b)` | `data.collections` | Union-find over disjoint sets |
+| `bstPut(t, key, value)` / `bstGet(t, key, dflt)` | `data.collections` | Binary search tree map |
+| `pushBack(d, x)` / `popFront(d)` | `data.collections` | Double-ended queue |
+| `bitSet(bs, i)` / `bitGet(bs, i)` | `data.collections` | Fixed-size bitset |
+
+```tocin
+import data.algorithms;
+import data.structures;
+
+def main() {
+    let xs = [9, 4, 7, 1, 4];
+    sort(xs);
+    println("{} {} {}", xs[0], xs[4], binarySearch(xs, 7));
+    let s = stackNew();
+    stackPush(s, 10);
+    stackPush(s, 20);
+    println("{} {}", stackPop(s), stackSize(s));
+    return 0;
 }
 ```
 
-### system.time
-
-The `system.time` module provides functionality for working with dates, times, and durations.
-
-```tocin
-import system.time;
-
-// Getting the current time
-let now = time.now();
-println("Current time: " + now.toString());
-
-// Creating a specific date and time
-let birthday = time.Date(1990, 5, 15, 14, 30, 0);
-
-// Formatting dates
-println(now.format("yyyy-MM-dd HH:mm:ss"));
-
-// Calculating duration
-let duration = now - birthday;
-println("Duration in days: " + duration.toDays());
-
-// Sleeping (pausing execution)
-println("Waiting for 2 seconds...");
-time.sleep(2000);  // Sleep for 2000 milliseconds
-println("Done waiting");
+```text
+1 9 3
+20 1
 ```
 
-### system.json
+## math — numerics
 
-The `system.json` module provides functionality for working with JSON data.
+`math.basic` adds constants (`PI`, `TAU`, `E`, `SQRT2`, `EPSILON`) and float
+and integer helpers on top of the math builtins. `math.linear` works on flat
+row-major matrices stored in `list<float>`; `math.geometry` provides 2-D and
+3-D vector math on scalar components; `math.stats` and `math.stats_advanced`
+cover descriptive statistics through regression and the normal distribution;
+`math.differential` does numeric calculus on function values.
 
-```tocin
-import system.json;
+| Function | Module | Description |
+|---|---|---|
+| `lerp(a: float, b: float, t: float) -> float` | `math.basic` | Linear interpolation |
+| `clampf(x, lo, hi) -> float` | `math.basic` | Clamp a float to a range |
+| `hypot(a: float, b: float) -> float` | `math.basic` | `sqrt(a*a + b*b)` without intermediate overflow |
+| `ipow(base: int, n: int) -> int` | `math.basic` | Integer power |
+| `matMul(a, b, dst, r, m, p)` | `math.linear` | Matrix product of flat row-major matrices |
+| `vecDot(a, b) -> float` / `vecNorm(a) -> float` | `math.linear` | Dot product / Euclidean norm |
+| `dist2(ax, ay, bx, by) -> float` | `math.geometry` | Distance between 2-D points |
+| `circleArea(r: float) -> float` | `math.geometry` | Area of a circle |
+| `mean(xs)` / `median(xs)` / `stddev(xs)` | `math.stats` | Descriptive statistics over `list<float>` |
+| `correlation(x, y) -> float` | `math.stats_advanced` | Pearson correlation |
+| `linearRegression(x, y, out)` | `math.stats_advanced` | Least squares; writes slope to `out[0]`, intercept to `out[1]` |
+| `derivative(f: (float) -> float, x: float) -> float` | `math.differential` | Numeric derivative of a function value |
 
-// Parsing JSON from a string
-let jsonString = "{\"name\": \"Alice\", \"age\": 30}";
-let data = json.parse(jsonString);
-
-// Accessing JSON data
-println("Name: " + data["name"]);
-println("Age: " + data["age"]);
-
-// Creating JSON objects
-let person = {
-    name: "Bob",
-    age: 25,
-    address: {
-        city: "New York",
-        country: "USA"
-    }
-};
-
-// Converting to JSON string
-let personJson = json.stringify(person);
-println(personJson);
-
-// Pretty printing JSON
-println(json.stringify(person, true));  // With pretty printing
-```
-
-## Mathematics Modules
-
-### math.basic
-
-The `math.basic` module provides basic mathematical functions and constants.
-
-```tocin
-import math.basic;
-
-// Mathematical constants
-println("Pi: " + Math.PI);
-println("Euler's number: " + Math.E);
-
-// Basic functions
-println("Square root of 16: " + Math.sqrt(16));
-println("Absolute value of -5: " + Math.abs(-5));
-println("5 raised to power 2: " + Math.pow(5, 2));
-
-// Trigonometric functions
-println("Sine of 30 degrees: " + Math.sin(Math.toRadians(30)));
-println("Cosine of 60 degrees: " + Math.cos(Math.toRadians(60)));
-println("Tangent of 45 degrees: " + Math.tan(Math.toRadians(45)));
-
-// Rounding
-println("Round 3.7: " + Math.round(3.7));
-println("Floor 3.7: " + Math.floor(3.7));
-println("Ceiling 3.2: " + Math.ceil(3.2));
-
-// Random numbers
-println("Random number between 0 and 1: " + Math.random());
-println("Random integer between 1 and 10: " + Math.floor(Math.random() * 10) + 1);
-```
-
-### math.linear
-
-The `math.linear` module provides functionality for linear algebra operations.
-
-```tocin
-import math.linear;
-
-// Creating vectors
-let v1 = new Vector2(3, 4);
-let v2 = new Vector2(1, 2);
-
-// Vector operations
-let v3 = v1 + v2;  // Addition
-let v4 = v1 - v2;  // Subtraction
-let dotProduct = v1.dot(v2);  // Dot product
-let magnitude = v1.magnitude();  // Magnitude
-let normalized = v1.normalize();  // Normalization
-
-// Creating matrices
-let m1 = new Matrix(2, 2);
-m1.set(0, 0, 1);  // Row 0, Col 0
-m1.set(0, 1, 2);  // Row 0, Col 1
-m1.set(1, 0, 3);  // Row 1, Col 0
-m1.set(1, 1, 4);  // Row 1, Col 1
-
-// Matrix operations
-let m2 = Matrix.identity(2);  // Identity matrix
-let m3 = m1 * m2;  // Matrix multiplication
-let determinant = m1.determinant();  // Determinant
-let transpose = m1.transpose();  // Transpose
-let inverse = m1.inverse();  // Inverse
-```
-
-### math.geometry
-
-The `math.geometry` module provides functionality for geometric calculations.
-
-```tocin
-import math.geometry;
-
-// Working with points
-let p1 = new Point(2, 3);
-let p2 = new Point(5, 7);
-let distance = p1.distanceTo(p2);
-
-// Working with lines
-let line = new Line(p1, p2);
-let length = line.length();
-let midpoint = line.midpoint();
-
-// Working with rectangles
-let rect = new Rectangle(10, 10, 100, 50);  // x, y, width, height
-let area = rect.area();
-let perimeter = rect.perimeter();
-
-// Working with circles
-let circle = new Circle(new Point(50, 50), 25);  // center, radius
-let circleArea = circle.area();
-let circumference = circle.circumference();
-
-// Checking if a point is inside a shape
-let isInside = rect.contains(new Point(15, 20));
-```
-
-### math.stats
-
-The `math.stats` module provides functionality for statistical calculations.
+`math.differential` also offers `integrateTrapezoid`, `integrateSimpson`,
+`newtonRoot`, `bisectRoot`, and `eulerIntegrate` — all taking
+`(float) -> float` function values (named functions or lambdas).
 
 ```tocin
 import math.stats;
+import math.linear;
 
-// Creating a dataset
-let data = [12, 15, 18, 22, 25, 27, 30];
-
-// Basic statistics
-let mean = stats.mean(data);
-let median = stats.median(data);
-let mode = stats.mode(data);
-let stdDev = stats.standardDeviation(data);
-let variance = stats.variance(data);
-
-// Range statistics
-let min = stats.min(data);
-let max = stats.max(data);
-let range = stats.range(data);
-
-// Percentiles
-let percentile75 = stats.percentile(data, 75);
-
-// Probability distributions
-let normalPdf = stats.normalPdf(0, 0, 1);  // PDF of standard normal at x=0
-let normalCdf = stats.normalCdf(1.96, 0, 1);  // CDF of standard normal at x=1.96
-```
-
-## Concurrency Modules
-
-### concurrency.coroutine
-
-The `concurrency.coroutine` module provides support for coroutines, which enable efficient asynchronous programming.
-
-```tocin
-import concurrency.coroutine;
-import system.time;
-
-// Define a function to be run as a coroutine
-def longTask(name: string, duration: int) -> string {
-    println(name + " started");
-    time.sleep(duration);
-    println(name + " completed after " + duration.toString() + "ms");
-    return name + " result";
-}
-
-// Spawn multiple coroutines
-def main() -> int {
-    println("Starting tasks");
-    
-    // Spawn coroutines
-    let task1 = coroutine.spawn(longTask, "Task 1", 1000);
-    let task2 = coroutine.spawn(longTask, "Task 2", 500);
-    let task3 = coroutine.spawn(longTask, "Task 3", 1500);
-    
-    // Wait for all tasks to complete and collect results
-    let results = coroutine.waitAll([task1, task2, task3]);
-    
-    println("All tasks completed");
-    for (let result of results) {
-        println("Result: " + result);
-    }
-    
+def main() {
+    let xs = [2.0, 4.0, 4.0, 4.0, 5.0, 5.0, 7.0, 9.0];
+    println("mean {}  stddev {}", mean(xs), stddev(xs));
+    let a = [1.0, 2.0, 2.0];
+    println("norm {}", vecNorm(a));
     return 0;
 }
 ```
 
-### concurrency.channel
+```text
+mean 5  stddev 2
+norm 3
+```
 
-The `concurrency.channel` module provides channels for communication between coroutines.
+## ml — machine learning
+
+`ml.neural_network` implements the numeric core of a multilayer perceptron:
+activations, a dense forward pass, softmax, MSE and cross-entropy losses, and
+`trainStep` — one in-place SGD step of a one-hidden-layer sigmoid MLP that
+returns the pre-update loss. `ml.deep_learning` adds evaluation metrics,
+weight initialization, and learning-rate schedules; `ml.computer_vision`
+processes grayscale images stored in raw byte buffers.
+
+| Function | Module | Description |
+|---|---|---|
+| `sigmoid(x)` / `reluf(x)` / `tanhf(x)` | `ml.neural_network` | Activation functions |
+| `softmax(src, dst)` | `ml.neural_network` | Softmax over a `list<float>` |
+| `denseForward(w, b, x, out, outN, inN)` | `ml.neural_network` | Dense layer: `out = W*x + b` |
+| `mseLoss(pred, target)` / `crossEntropy(pred, target)` | `ml.neural_network` | Loss functions |
+| `trainStep(w1, b1, w2, b2, x, y, h, o, inN, hidN, outN, lr) -> float` | `ml.neural_network` | One SGD step of a 2-layer sigmoid MLP |
+| `argmax(v: list<float>) -> int` | `ml.deep_learning` | Index of the largest score |
+| `accuracy(preds, labels, rows, classes) -> float` | `ml.deep_learning` | Classification accuracy |
+| `heScale(fanIn)` / `xavierScale(fanIn)` / `initWeights(w, scale, seed)` | `ml.deep_learning` | Weight initialization |
+| `lrExpDecay(lr0, decay, epoch)` / `lrStepDecay(lr0, factor, stepEpochs, epoch)` | `ml.deep_learning` | Learning-rate schedules |
+| `threshold` / `boxBlur` / `sobel` / `resize` | `ml.computer_vision` | Grayscale image operations on byte buffers |
+
+### ml.ten — Temporal Eigenstate Networks
+
+`ml.ten` is an implementation of **Temporal Eigenstate Networks (TEN)**: a
+sequence model that replaces attention with a spectral recurrence. Each layer
+projects the (layer-normed) input to K complex eigenstate drives, evolves them
+with a diagonal complex recurrence `c_k(t) = lambda_k * c_k(t-1) + beta_k(t)`
+where each `lambda_k = mag_k * e^(i*freq_k)` is a learned per-head complex
+eigenvalue, mixes the eigenstates with per-head block-diagonal coupling, and
+reconstructs the hidden state through a gated output projection plus a SiLU
+MLP, both with residual connections. The result is an exact `O(T*K)` causal
+convolution instead of `O(T^2)` attention. All tensors are flat row-major
+`list<float>`, batch size 1, with caller-owned weights.
+
+Key entry points: `tenEigenInit(mag, freq, K)` parameterizes the eigenvalues;
+`tenScan(br, bi, mag, freq, cr, ci, T, K)` runs the complex recurrence
+(`tenScanRegions` is a variant reading both drive halves from one buffer);
+`tenMix(cr, ci, coupling, scratch, T, K, heads)` applies the per-head
+coupling; `tenLayerNorm(x, out, T, D)` is the pre-norm;
+`tenLayerForward(...)` chains the full layer; and
+`tenClosedFormReal`/`tenClosedFormImag` give the analytic impulse response
+used to validate the scan.
 
 ```tocin
-import concurrency.channel;
-import concurrency.coroutine;
-import system.time;
+import ml.ten;
 
-// Producer function that sends values through a channel
-def producer(ch: Channel<int>, count: int) -> void {
-    for (let i = 1; i <= count; i++) {
-        println("Producing: " + i.toString());
-        ch.send(i);
-        time.sleep(100);
-    }
-    ch.close();  // Close the channel when done
-}
-
-// Consumer function that receives values from a channel
-def consumer(ch: Channel<int>) -> void {
-    while (true) {
-        let value = ch.tryReceive();
-        if (value != null) {
-            println("Consuming: " + value.toString());
-        } else {
-            // Channel is closed and empty
-            println("Channel closed");
-            break;
-        }
-    }
-}
-
-def main() -> int {
-    // Create a channel
-    let channel = new Channel<int>(5);  // Buffer size of 5
-    
-    // Spawn producer and consumer coroutines
-    coroutine.spawn(producer, channel, 10);
-    coroutine.spawn(consumer, channel);
-    
-    // Wait for both coroutines to finish
-    time.sleep(2000);
-    
+def main() {
+    let mag = [0.0, 0.0];
+    let freq = [0.0, 0.0];
+    tenEigenInit(mag, freq, 2);                       // K = 2 eigenstates
+    let br = [1.0, 1.0, 0.0, 0.0, 0.0, 0.0];          // impulse at t = 0 (T x K)
+    let bi = [0.0, 0.0, 0.0, 0.0, 0.0, 0.0];
+    let cr = [0.0, 0.0, 0.0, 0.0, 0.0, 0.0];
+    let ci = [0.0, 0.0, 0.0, 0.0, 0.0, 0.0];
+    tenScan(br, bi, mag, freq, cr, ci, 3, 2);         // T = 3 steps
+    println("state 0: {} {} {}", cr[0], cr[2], cr[4]);
     return 0;
 }
 ```
 
-## Data Structure Modules
-
-The Tocin Standard Library provides various data structure modules for efficient data management.
-
-For more detailed information on these modules and others in the standard library, please refer to the API reference documentation or use the built-in documentation tools:
-
-```tocin
-// Display help information for a specific module
-help(collections.array);
+```text
+state 0: 1 0.0474259 0.00224921
 ```
 
-### collections.array
-
-The `collections.array` module provides enhanced functionality for working with arrays.
-
-```tocin
-import collections.array;
-
-// Creating arrays
-let numbers = [1, 2, 3, 4, 5];
-let strings = ["apple", "banana", "cherry"];
-
-// Array operations
-numbers.push(6);  // Add an element to the end
-numbers.pop();    // Remove an element from the end
-numbers.insert(0, 0);  // Insert 0 at index 0
-numbers.remove(2);  // Remove element at index 2
-
-// Higher-order functions
-let doubled = numbers.map(n => n * 2);
-let evens = numbers.filter(n => n % 2 == 0);
-let sum = numbers.reduce((acc, n) => acc + n, 0);
-
-// Sorting
-numbers.sort();  // Sort in ascending order
-strings.sort((a, b) => b.compareTo(a));  // Sort in descending order
-
-// Finding elements
-let found = numbers.find(n => n > 3);
-let index = numbers.findIndex(n => n == 2);
-let includes = numbers.includes(5);
-
-// Slicing
-let sliced = numbers.slice(1, 3);  // Elements at index 1 and 2
-```
-
-### collections.map
-
-The `collections.map` module provides functionality for key-value pair collections.
-
-```tocin
-import collections.map;
-
-// Creating a map
-let userAges = new Map<string, int>();
-
-// Adding entries
-userAges.set("Alice", 30);
-userAges.set("Bob", 25);
-userAges.set("Charlie", 35);
-
-// Accessing entries
-let aliceAge = userAges.get("Alice");  // 30
-let unknownAge = userAges.get("Unknown");  // null
-
-// Checking if a key exists
-if (userAges.has("Bob")) {
-    println("Bob's age is " + userAges.get("Bob").toString());
-}
-
-// Removing entries
-userAges.delete("Charlie");
-
-// Getting all keys, values, or entries
-let keys = userAges.keys();
-let values = userAges.values();
-let entries = userAges.entries();
-
-// Iterating over a map
-for (let [name, age] of userAges) {
-    println(name + " is " + age.toString() + " years old");
-}
-
-// Getting the size of a map
-println("Map has " + userAges.size.toString() + " entries");
-```
-
-### collections.set
-
-The `collections.set` module provides functionality for unique value collections.
-
-```tocin
-import collections.set;
-
-// Creating a set
-let uniqueNumbers = new Set<int>();
-
-// Adding values
-uniqueNumbers.add(1);
-uniqueNumbers.add(2);
-uniqueNumbers.add(3);
-uniqueNumbers.add(1);  // Duplicate, will be ignored
-
-// Checking if a value exists
-if (uniqueNumbers.has(2)) {
-    println("Set contains 2");
-}
-
-// Removing values
-uniqueNumbers.delete(3);
-
-// Getting the size of a set
-println("Set has " + uniqueNumbers.size.toString() + " values");
-
-// Set operations
-let setA = new Set<int>([1, 2, 3]);
-let setB = new Set<int>([3, 4, 5]);
-
-let union = setA.union(setB);          // {1, 2, 3, 4, 5}
-let intersection = setA.intersection(setB);  // {3}
-let difference = setA.difference(setB);      // {1, 2}
-```
-
-### collections.list
-
-The `collections.list` module provides a doubly-linked list implementation.
-
-```tocin
-import collections.list;
-
-// Creating a linked list
-let list = new LinkedList<string>();
-
-// Adding elements
-list.addFirst("apple");  // Add to the front
-list.addLast("banana");  // Add to the end
-list.insert(1, "cherry");  // Insert at index 1
-
-// Accessing elements
-let first = list.first();  // "apple"
-let last = list.last();    // "banana"
-let item = list.get(1);    // "cherry"
-
-// Removing elements
-list.removeFirst();  // Remove from the front
-list.removeLast();   // Remove from the end
-list.remove(0);      // Remove at index 0
-
-// Iterating over a list
-for (let item of list) {
-    println(item);
-}
-
-// Getting the size of a list
-println("List has " + list.size.toString() + " elements");
-```
-
-## Networking Modules
-
-### net.http
-
-The `net.http` module provides functionality for making HTTP requests.
-
-```tocin
-import net.http;
-
-// Making a GET request
-let response = http.get("https://api.example.com/data");
-println("Status: " + response.status.toString());
-println("Body: " + response.body);
-
-// Making a POST request
-let postResponse = http.post("https://api.example.com/users", {
-    headers: {
-        "Content-Type": "application/json"
-    },
-    body: json.stringify({
-        name: "John Doe",
-        email: "john@example.com"
-    })
-});
-
-// Working with JSON responses
-let data = json.parse(response.body);
-println("Data: " + data["name"]);
-
-// Asynchronous requests
-http.get("https://api.example.com/data", (response) => {
-    println("Async response received");
-    println(response.body);
-});
-
-// Using fetch API
-let fetchResponse = await http.fetch("https://api.example.com/data", {
-    method: "GET",
-    headers: {
-        "Accept": "application/json"
-    }
-});
-
-let jsonData = await fetchResponse.json();
-```
-
-### net.server
-
-The `net.server` module provides functionality for creating HTTP servers.
-
-```tocin
-import net.server;
-
-// Create a simple HTTP server
-let server = new server.HttpServer({
-    port: 3000
-});
-
-// Add a route for the root path
-server.get("/", (req, res) => {
-    res.send("Hello, Tocin!");
-});
-
-// Add a route for a specific path
-server.get("/users", (req, res) => {
-    let users = [
-        { id: 1, name: "Alice" },
-        { id: 2, name: "Bob" }
-    ];
-    res.json(users);
-});
-
-// Add a route with URL parameters
-server.get("/users/:id", (req, res) => {
-    let id = parseInt(req.params.get("id"));
-    res.json({ id: id, name: "User " + id.toString() });
-});
-
-// Handle POST requests
-server.post("/users", (req, res) => {
-    let user = req.body;
-    // Process the user data
-    res.status(201).json({ id: 3, ...user });
-});
-
-// Start the server
-server.start();
-println("Server running on port 3000");
-```
-
-### net.advanced.rest
-
-The `net.advanced.rest` module provides functionality for creating RESTful APIs.
-
-```tocin
-import net.advanced.rest;
-
-// Create a REST API
-let api = new rest.Api();
-
-// Define a resource
-let userResource = api.resource("users");
-
-// Define CRUD operations for the resource
-userResource.get((req, res) => {
-    // Get all users
-    res.json([
-        { id: 1, name: "Alice" },
-        { id: 2, name: "Bob" }
-    ]);
-});
-
-userResource.get("/:id", (req, res) => {
-    // Get a specific user
-    let id = parseInt(req.params.get("id"));
-    res.json({ id: id, name: "User " + id.toString() });
-});
-
-userResource.post((req, res) => {
-    // Create a new user
-    let user = req.body;
-    // Process the user data
-    res.status(201).json({ id: 3, ...user });
-});
-
-userResource.put("/:id", (req, res) => {
-    // Update a user
-    let id = parseInt(req.params.get("id"));
-    let user = req.body;
-    res.json({ id: id, ...user });
-});
-
-userResource.delete("/:id", (req, res) => {
-    // Delete a user
-    let id = parseInt(req.params.get("id"));
-    res.status(204).send();
-});
-
-// Create a server with the API
-let server = new server.HttpServer({
-    port: 3000
-});
-
-// Mount the API at the /api path
-server.use("/api", api);
-
-// Start the server
-server.start();
-println("REST API server running on port 3000");
-```
-
-## GUI Modules
-
-### gui.core
-
-The `gui.core` module provides core functionality for building graphical user interfaces.
-
-```tocin
-import gui.core;
-
-// Create an application
-class MyApp extends Application {
-    def initialize() {
-        // Initialize the application with a title and dimensions
-        super.initialize("My Tocin App", 800, 600);
-    }
-    
-    def createUI() -> void {
-        // Create the UI here
-    }
-    
-    override def start() -> void {
-        createUI();
-        // Additional setup code
-    }
-}
-
-// Run the application
-let app = new MyApp();
-app.run();
-```
-
-### gui.widgets
-
-The `gui.widgets` module provides UI widgets like buttons, text fields, and labels.
-
-```tocin
-import gui.widgets;
-
-// Create various widgets
-let button = new Button("Click Me");
-let label = new Label("Hello, Tocin!");
-let textField = new TextField("Enter text here");
-let checkbox = new Checkbox("Enable feature", true);
-let comboBox = new ComboBox(["Option 1", "Option 2", "Option 3"]);
-let slider = new Slider(0, 100, 50);  // min, max, current value
-let progressBar = new ProgressBar(0, 100, 25);  // min, max, current value
-
-// Configure widget properties
-button.enabled = true;
-label.textColor = ColorRGBA.BLUE;
-textField.width = 200;
-checkbox.checked = true;
-```
-
-### gui.layout
-
-The `gui.layout` module provides layout managers for arranging widgets.
-
-```tocin
-import gui.layout;
-
-// Create various layouts
-let vLayout = new VerticalLayout();
-let hLayout = new HorizontalLayout();
-let gridLayout = new GridLayout(3, 2);  // 3 columns, 2 rows
-let stackLayout = new StackLayout();
-let flowLayout = new FlowLayout();
-
-// Configure layout properties
-vLayout.spacing = 10;
-hLayout.padding = EdgeInsets.all(8);
-gridLayout.cellSpacing = 5;
-
-// Add widgets to layouts
-vLayout.add(new Label("Top"));
-vLayout.add(new Button("Middle"));
-vLayout.add(new TextField("Bottom"));
-
-// Add widgets to grid layout
-gridLayout.add(new Label("Name:"), 0, 0);  // column 0, row 0
-gridLayout.add(new TextField(""), 1, 0);  // column 1, row 0
-gridLayout.add(new Label("Email:"), 0, 1);  // column 0, row 1
-gridLayout.add(new TextField(""), 1, 1);  // column 1, row 1
-```
-
-### gui.events
-
-The `gui.events` module provides functionality for handling UI events.
-
-```tocin
-import gui.events;
-
-// Create a button
-let button = new Button("Click Me");
-
-// Add a click event listener
-button.addEventListener("click", (event) => {
-    println("Button clicked!");
-});
-
-// Add mouse event listeners
-button.addEventListener("mouseEnter", (event) => {
-    button.backgroundColor = ColorRGBA.LIGHT_BLUE;
-});
-
-button.addEventListener("mouseLeave", (event) => {
-    button.backgroundColor = ColorRGBA.WHITE;
-});
-
-// Add a key event listener to a text field
-let textField = new TextField("");
-textField.addEventListener("keyPress", (event) => {
-    println("Key pressed: " + event.key);
-});
-
-// Using the event object
-button.addEventListener("click", (event) => {
-    println("Clicked at: " + event.x.toString() + ", " + event.y.toString());
-    event.stopPropagation();  // Prevent event from bubbling up
-});
-```
-
-## Game Development Modules
-
-### game.engine
-
-The `game.engine` module provides core functionality for game development.
-
-```tocin
-import game.engine;
-
-// Create a game
-class MyGame extends Game {
-    def initialize() {
-        // Initialize the game with a title and dimensions
-        super.initialize("My Tocin Game", 800, 600);
-    }
-    
-    override def load() -> void {
-        // Load resources
-    }
-    
-    override def update(deltaTime: float) -> void {
-        // Update game state
-    }
-    
-    override def render() -> void {
-        // Render the game
-    }
-}
-
-// Run the game
-let game = new MyGame();
-game.run();
-```
-
-### game.graphics
-
-The `game.graphics` module provides functionality for rendering graphics.
-
-```tocin
-import game.graphics;
-
-// Load a sprite
-let playerSprite = new Sprite("assets/player.png");
-
-// Draw the sprite
-graphics.drawSprite(playerSprite, 100, 100);
-
-// Draw shapes
-graphics.setFillColor(ColorRGBA.RED);
-graphics.fillRect(50, 50, 100, 100);
-
-graphics.setStrokeColor(ColorRGBA.BLUE);
-graphics.setStrokeWidth(2);
-graphics.drawCircle(400, 300, 50);
-
-graphics.drawLine(0, 0, 800, 600);
-
-// Draw text
-graphics.setFont(new Font("Arial", 24));
-graphics.setFillColor(ColorRGBA.BLACK);
-graphics.fillText("Game Score: 100", 20, 30);
-```
-
-### game.physics
-
-The `game.physics` module provides functionality for game physics.
-
-```tocin
-import game.physics;
-
-// Create physics bodies
-let playerBody = new RigidBody2D();
-playerBody.position = new Vector2(100, 100);
-playerBody.velocity = new Vector2(5, 0);
-playerBody.mass = 1.0;
-
-// Create colliders
-let playerCollider = new BoxCollider2D(50, 50);  // 50x50 box
-let enemyCollider = new CircleCollider2D(25);  // Circle with radius 25
-
-// Check for collisions
-if (physics.checkCollision(playerCollider, enemyCollider)) {
-    println("Collision detected!");
-}
-
-// Apply forces
-playerBody.applyForce(new Vector2(0, -10));  // Apply upward force
-
-// Update physics
-physics.step(0.016);  // Update physics for 16ms timestep
-```
-
-### game.input
-
-The `game.input` module provides functionality for handling user input.
-
-```tocin
-import game.input;
-
-// Check keyboard input
-if (input.keyboard.isKeyDown("ArrowUp")) {
-    // Move player up
-}
-
-if (input.keyboard.wasKeyPressed("Space")) {
-    // Jump (only triggers once when key is first pressed)
-}
-
-if (input.keyboard.wasKeyReleased("E")) {
-    // Interact (triggers once when key is released)
-}
-
-// Check mouse input
-if (input.mouse.isButtonDown(0)) {
-    // Left mouse button is down
-}
-
-let mouseX = input.mouse.getX();
-let mouseY = input.mouse.getY();
-
-// Check gamepad input
-if (input.gamepad.isButtonDown(0, "A")) {
-    // Gamepad 0, button A is down
-}
-
-let leftStickX = input.gamepad.getAxisValue(0, "LeftStickX");
-```
-
-### game.audio
-
-The `game.audio` module provides functionality for game audio.
-
-```tocin
-import game.audio;
-
-// Load audio clips
-let jumpSound = new AudioClip("assets/jump.wav");
-let music = new AudioClip("assets/music.mp3");
-
-// Create audio sources
-let jumpSource = new AudioSource(jumpSound);
-let musicSource = new AudioSource(music);
-
-// Configure audio properties
-jumpSource.volume = 0.5;
-musicSource.loop = true;
-musicSource.volume = 0.3;
-
-// Play sounds
-jumpSource.play();
-musicSource.play();
-
-// Pause and stop
-musicSource.pause();
-musicSource.stop();
-
-// Check if playing
-if (jumpSource.isPlaying()) {
-    println("Jump sound is playing");
-}
-```
-
-## Machine Learning Modules
-
-### ml.model
-
-The `ml.model` module provides functionality for creating and using machine learning models.
-
-```tocin
-import ml.model;
-
-// Create a machine learning model
-let model = new model.Model();
-
-// Load a pre-trained model
-let pretrainedModel = model.load("path/to/model.tocin");
-
-// Make predictions
-let input = new Tensor([1.0, 2.0, 3.0, 4.0]);
-let prediction = pretrainedModel.predict(input);
-
-// Save a model
-model.save("path/to/save/model.tocin");
-```
-
-### ml.nn
-
-The `ml.nn` module provides neural network components for deep learning.
-
-```tocin
-import ml.nn;
-
-// Create a sequential neural network
-let model = new nn.Sequential([
-    new nn.Linear(784, 128),  // Input layer with 784 features, 128 neurons
-    new nn.ReLU(),            // Activation function
-    new nn.Dropout(0.2),      // Dropout for regularization
-    new nn.Linear(128, 64),   // Hidden layer with 64 neurons
-    new nn.ReLU(),            // Activation function
-    new nn.Linear(64, 10)     // Output layer with 10 classes
-]);
-
-// Initialize with specific options
-model.initialize({
-    weightInit: "xavier",
-    biasInit: "zeros"
-});
-
-// Define loss function
-let lossFn = new nn.CrossEntropyLoss();
-
-// Forward pass
-let input = new Tensor([/* input data */]);
-let output = model.forward(input);
-
-// Compute loss
-let target = new Tensor([/* target data */]);
-let loss = lossFn.forward(output, target);
-
-// Backward pass
-loss.backward();
-```
-
-### ml.optimizer
-
-The `ml.optimizer` module provides optimization algorithms for training neural networks.
-
-```tocin
-import ml.optimizer;
-
-// Create an optimizer
-let sgd = new optimizer.SGD(model.parameters(), {
-    learningRate: 0.01,
-    momentum: 0.9
-});
-
-// Create other types of optimizers
-let adam = new optimizer.Adam(model.parameters(), {
-    learningRate: 0.001,
-    beta1: 0.9,
-    beta2: 0.999
-});
-
-// Training loop
-for (let epoch = 0; epoch < 10; epoch++) {
-    // Zero gradients
-    sgd.zeroGrad();
-    
-    // Forward pass, compute loss, backward pass
-    // ...
-    
-    // Update weights
-    sgd.step();
-}
-```
-
-### ml.data
-
-The `ml.data` module provides functionality for loading and processing datasets.
-
-```tocin
-import ml.data;
-
-// Load a dataset
-let mnist = data.loadMNIST();
-
-// Create a dataset from arrays
-let xData = [/* features */];
-let yData = [/* labels */];
-let dataset = new data.Dataset(xData, yData);
-
-// Create a data loader for batch processing
-let dataLoader = new data.DataLoader(dataset, {
-    batchSize: 64,
-    shuffle: true
-});
-
-// Iterate over batches
-for (let batch of dataLoader) {
-    let {inputs, targets} = batch;
-    // Process batch
-}
-
-// Split a dataset
-let {trainData, testData} = dataset.split(0.8);  // 80% train, 20% test
-```
-
-### ml.preprocessing
-
-The `ml.preprocessing` module provides functionality for preprocessing data for machine learning.
-
-```tocin
-import ml.preprocessing;
-
-// Create a preprocessing pipeline
-let transform = preprocessing.Compose([
-    preprocessing.ToTensor(),
-    preprocessing.Normalize([0.5], [0.5])
-]);
-
-// Apply to a dataset
-let transformedDataset = dataset.map(transform);
-
-// One-hot encoding
-let encoder = new preprocessing.OneHotEncoder();
-let encoded = encoder.fit_transform(labels);
-
-// Standardization
-let scaler = new preprocessing.StandardScaler();
-let scaled = scaler.fit_transform(features);
-
-// Image preprocessing for computer vision
-let imageTransform = preprocessing.Compose([
-    preprocessing.Resize(256),
-    preprocessing.CenterCrop(224),
-    preprocessing.ToTensor(),
-    preprocessing.Normalize([0.485, 0.456, 0.406], [0.229, 0.224, 0.225])
-]);
-```
-
-This completes the overview of the Tocin Standard Library. For more detailed information on each module and function, please refer to the API reference documentation. 
+## web and net — HTTP and WebSocket
+
+`web.http` parses request lines (`httpMethod`, `httpPath`, `httpRoute`),
+builds HTTP/1.1 responses, and runs a blocking single-threaded server on the
+`tcp*` builtins where the handler is a `(string) -> string` function value.
+`web.websocket` encodes and decodes WebSocket frames in raw buffers.
+`net.advanced` is the client side: URL parsing and one-shot `httpGet`/
+`httpPost` requests.
+
+| Function | Module | Description |
+|---|---|---|
+| `httpMethod(req)` / `httpPath(req)` | `web.http` | Parse the request line |
+| `httpRoute(req, method, path) -> int` | `web.http` | Does the request match method + path? |
+| `buildResponse(status, contentType, body) -> string` | `web.http` | Build a full HTTP/1.1 response |
+| `ok(body)` / `okJson(body)` / `notFound()` | `web.http` | Response shorthands |
+| `serve(port)` / `serveOnce(listenFd, handler)` / `serveLoop(listenFd, handler, count)` | `web.http` | Blocking server; handler is `(string) -> string` |
+| `writeFrame(dst, opcode, src, len, masked, maskKey)` | `web.websocket` | Encode a WebSocket frame |
+| `frameOpcode(frame)` / `framePayloadLen(frame)` / `framePayloadOffset(frame)` | `web.websocket` | Decode a frame header |
+| `unmaskPayload(frame)` | `web.websocket` | Unmask a client frame in place |
+| `httpGet(url)` / `httpPost(url, contentType, body)` | `net.advanced` | One-shot HTTP client requests |
+| `urlHost(url)` / `urlPort(url)` / `urlPath(url)` | `net.advanced` | URL parsing |
+| `responseStatus(resp)` / `responseBody(resp)` | `net.advanced` | Split a raw HTTP response |
+
+## database — in-memory storage
+
+`database.database` provides a string key/value store over the `map` builtins
+and a typed-row table engine (fixed column count, `int` cells) with insert,
+scan, select, and aggregation — the relational core, with no disk or SQL
+parser. Note: it defines `countWhere(t, col, value)`, which clashes with
+`std.functional`'s `countWhere`; do not import both modules into one program.
+
+| Function | Description |
+|---|---|
+| `kvNew()` / `kvPut(db, key, value)` / `kvGet(db, key, dflt)` / `kvHas(db, key)` | String key/value store |
+| `tableNew(ncols, capacityRows) -> int` | Create a table handle |
+| `tableInsert(t, row: list<int>)` | Append a row |
+| `tableGet(t, row, col)` / `tableSet(t, row, col, value)` | Cell access |
+| `selectWhere(t, col, value, out)` / `selectGreater(t, col, threshold, out)` | Collect matching row indices into a `vector` |
+| `columnSum(t, col)` / `columnMax(t, col)` / `columnMin(t, col)` | Column aggregates |
+| `countWhere(t, col, value) -> int` | Count rows with `row[col] == value` |
+| `tableDelete(t, row)` / `tableFree(t)` | Remove a row / release the table |
+
+## game — entities, framebuffers, shading math
+
+`game.engine` is a small entity world (positions and velocities stored
+fixed-point in one buffer) with spawning, integration steps, forces, and AABB
+collision tests. `game.graphics` draws into a raw RGBA framebuffer:
+rectangles, lines (Bresenham), and circles. `game.shader` collects
+GLSL-style shading math (`smoothstep`, `mix`, reflection, Lambert and
+Blinn-Phong lighting, color packing). `game.shader` reuses the names `step`,
+`mix`, and `fract` — import it separately from `game.engine`, `audio.audio`,
+and `math.basic`.
+
+| Function | Module | Description |
+|---|---|---|
+| `worldNew(cap)` / `spawnEntity(w, x, y, vx, vy)` | `game.engine` | Create a world / add an entity |
+| `step(w, dt)` / `applyForce(w, ax, ay, dt)` | `game.engine` | Integrate positions / accelerate everything |
+| `entitiesCollide(w, e1, e2, size)` / `aabbOverlap(...)` | `game.engine` | Collision tests |
+| `fixedSteps(frameTime, fixedDt) -> int` | `game.engine` | Fixed-timestep step count |
+| `createFramebuffer(width, height) -> int` | `game.graphics` | Allocate an RGBA framebuffer |
+| `setPixel` / `fillRect` / `drawLine` / `fillCircle` / `clear` | `game.graphics` | Drawing primitives |
+| `smoothstep(edge0, edge1, x)` / `mix(a, b, t)` | `game.shader` | Interpolation curves |
+| `lambert(...)` / `blinnPhong(...)` | `game.shader` | Diffuse / specular lighting terms |
+| `packColor(r, g, b, a) -> int` / `unpackChannel(color, c)` | `game.shader` | RGBA8 color packing |
+| `luminance(r, g, b) -> float` | `game.shader` | Perceptual brightness |
+
+## gui — layout and widget math
+
+`gui.core` supplies rectangle tests, a vertical layout cursor, and
+immediate-mode widget state: `buttonState` folds mouse position and button
+into hover/pressed/active flags (`WS_HOVERED`, `WS_PRESSED`, `WS_ACTIVE`),
+and `sliderValue` maps a mouse position onto a value range. `gui.widgets`
+computes text metrics, alignment, progress-bar fill, scrollbar thumb geometry,
+grid cells, and flex item sizes — the math layer a renderer plugs into.
+
+| Function | Module | Description |
+|---|---|---|
+| `rectContains(x, y, w, h, px, py)` / `rectsOverlap(...)` | `gui.core` | Hit tests |
+| `layoutNew(x, y, spacing)` / `layoutRow(l, h)` | `gui.core` | Vertical layout cursor |
+| `buttonState(x, y, w, h, mx, my, mouseDown)` / `buttonClicked(state)` | `gui.core` | Immediate-mode button state |
+| `sliderValue(trackX, trackW, mx, minV, maxV)` / `sliderKnobX(...)` | `gui.core` | Slider position math |
+| `textWidth(n)` / `textHeight()` | `gui.widgets` | Monospace text metrics |
+| `progressFill(trackW, fraction)` | `gui.widgets` | Progress-bar fill width |
+| `scrollThumbLen(...)` / `scrollThumbPos(...)` | `gui.widgets` | Scrollbar thumb geometry |
+| `gridCell(...)` / `flexItemSize(total, n, gap)` / `wrapLines(charCount, widthChars)` | `gui.widgets` | Grid, flex, and wrapping layout |
+
+## audio — synthesis and DSP
+
+`audio.audio` generates and processes sample buffers (`list<float>`):
+oscillators, gain staging, mixing, clipping, attack/release envelopes,
+metering, a one-pole lowpass, and MIDI note conversion.
+
+| Function | Description |
+|---|---|
+| `genSine(buf, freq, sampleRate, amp)` / `genSquare(...)` / `genSaw(...)` | Fill a buffer with an oscillator waveform |
+| `gain(buf, g)` | Scale all samples |
+| `mix(dst, src, level)` | Mix `src` into `dst` at a level |
+| `clip(buf, limit)` | Hard-clip samples to `[-limit, limit]` |
+| `applyEnvelope(buf, attack, release)` | Linear attack/release envelope |
+| `rms(buf)` / `peak(buf)` | Level metering |
+| `normalize(buf, target)` | Scale so the peak hits `target` |
+| `lowpass(buf, a)` | One-pole lowpass filter in place |
+| `midiToFreq(note) -> float` | MIDI note number to frequency |
+
+## embedded — memory-mapped GPIO
+
+`embedded.gpio` drives a memory-mapped GPIO register block through the
+volatile access builtins (`volatileLoad32`/`volatileStore32`/`fence`), so
+reads and writes are never optimized away or reordered — the pattern a
+bare-metal or RTOS driver needs (pair with `--freestanding`). Register
+offsets (`GPIO_DIR`, `GPIO_OUT`, `GPIO_IN`, `GPIO_SET`, `GPIO_CLR`) follow a
+common MMIO layout; adapt `base` to your SoC.
+
+| Function | Description |
+|---|---|
+| `pinMode(base, pin, output)` | Configure a pin as input or output |
+| `digitalWrite(base, pin, high)` | Drive a pin via the atomic set/clear registers |
+| `digitalRead(base, pin) -> int` | Read a pin level |
+| `toggle(base, pin)` | Flip an output pin |
+| `writePort(base, value)` / `readPort(base)` | Whole-port access |
+| `barrier()` | Memory fence between device accesses |
+
+## scripting — text automation
+
+`scripting.automation` is string plumbing for scripts and code generation:
+`{{key}}` template rendering, shell command assembly with quoting,
+environment expansion, and `key=value` config-line parsing. Actual process
+spawning belongs behind FFI.
+
+| Function | Description |
+|---|---|
+| `renderTemplate(tmpl, keys, vals) -> string` | Replace every `{{key}}` placeholder |
+| `buildCommand(program, args) -> string` | Assemble a command line, double-quoting arguments with spaces |
+| `shellQuote(s) -> string` | POSIX single-quote a string for the shell |
+| `expandVar(name) -> string` | Read an environment variable |
+| `repeatStr(s, count) -> string` | Repeat a string |
+| `configKey(line)` / `configValue(line)` | Split a `key=value` line |
+
+## pkg — semantic versioning
+
+`pkg.manager` implements semver parsing and constraint matching for package
+tooling: split versions into fields, compare them, and test caret/tilde
+ranges.
+
+| Function | Description |
+|---|---|
+| `major(v)` / `minor(v)` / `patch(v)` | Extract version fields from `"1.2.3"` |
+| `versionCode(v) -> int` | Encode a version as one comparable integer |
+| `compareVersions(a, b) -> int` | Three-way comparison |
+| `versionEq(a, b)` / `versionGt(a, b)` / `versionLt(a, b)` | Comparison predicates |
+| `satisfiesCaret(version, base)` | `^base` range test (left-most non-zero field fixed) |
+| `satisfiesTilde(version, base)` | `~base` range test (patch-level changes only) |
+| `satisfies(version, base, op)` | Range test by operator code |
+| `bestMatch(candidates, baseCode, op) -> int` | Pick the best matching version code |
+
+## Built-in functions
+
+Everything above is ordinary Tocin source layered on the runtime builtins —
+`print`/`println`, `len`, math (`sqrt`, `sin`, `pow`, ...), strings
+(`strLen`, `substr`, `startsWith`, ...), dynamic collections (`vecNew`,
+`mapNew`, ...), raw memory (`alloc`, `loadInt`, `storeByte`, ...), file I/O,
+and TCP sockets. These need no import and are documented with verified
+signatures in [stdlib-reference.md](stdlib-reference.md).

--- a/docs/05_Advanced_Topics.md
+++ b/docs/05_Advanced_Topics.md
@@ -1,5 +1,7 @@
 # Advanced Topics in Tocin
 
+*Some sections of this document sketch design-intent APIs. For the implemented feature set, see [language-reference.md](language-reference.md).*
+
 This guide delves into the advanced features and techniques in the Tocin programming language. These topics build upon the fundamentals covered in the Language Basics and are designed for developers looking to leverage the full power of Tocin.
 
 ## Table of Contents
@@ -679,7 +681,7 @@ def hotLoop() -> int {
 
 ```tocin
 // Using SIMD (Single Instruction, Multiple Data) operations
-import math.simd;
+// design sketch — no math/simd module ships today
 
 // Create SIMD vectors
 let v1 = new Float32x4(1.0, 2.0, 3.0, 4.0);
@@ -776,7 +778,7 @@ class MathTests {
 ### Property-Based Testing
 
 ```tocin
-import testing.property;
+// design sketch — no testing/property module ships today (only std/testing ships)
 
 // Define a property test
 @PropertyTest

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,607 +1,140 @@
-# Tocin Compiler and Interpreter Architecture
+# Tocin Compiler Architecture
 
-## Overview
+How the Tocin compiler is put together. Tocin is a **statically typed,
+LLVM-compiled** language: programs are either JIT-executed in-process or
+compiled ahead-of-time to native binaries. There is **no tree-walking
+interpreter and no bytecode VM** — LLVM is the single execution substrate.
 
-This document provides a comprehensive overview of the Tocin compiler and interpreter architecture, including detailed information about key components and their interactions.
-
-## System Architecture
+## Pipeline
 
 ```
-┌─────────────────────────────────────────────────────────────────┐
-│                         Tocin Compiler                          │
-├─────────────────────────────────────────────────────────────────┤
-│  Source Code (.to files)                                        │
-│       ↓                                                          │
-│  ┌─────────────────┐                                           │
-│  │     Lexer       │  → Tokens                                 │
-│  └─────────────────┘                                           │
-│       ↓                                                          │
-│  ┌─────────────────┐                                           │
-│  │     Parser      │  → Abstract Syntax Tree (AST)             │
-│  └─────────────────┘                                           │
-│       ↓                                                          │
-│  ┌─────────────────┐                                           │
-│  │  Type Checker   │  → Type-checked AST                       │
-│  └─────────────────┘                                           │
-│       ↓                                                          │
-│  ┌─────────────────┐                                           │
-│  │  IR Generator   │  → LLVM IR                                │
-│  └─────────────────┘                                           │
-│       ↓                                                          │
-│  ┌─────────────────┐      ┌──────────────────┐               │
-│  │  Interpreter    │──────│  JIT Compiler    │               │
-│  │  (Direct Exec)  │      │  (LLVM)          │               │
-│  └─────────────────┘      └──────────────────┘               │
-│       ↓                            ↓                            │
-│  ┌─────────────────┐      ┌──────────────────┐               │
-│  │   Runtime       │      │ Machine Code     │               │
-│  │   System        │      │ Generator        │               │
-│  └─────────────────┘      └──────────────────┘               │
-│       ↓                            ↓                            │
-│  Execution Result          Native Binary (.exe, ELF, etc.)    │
-└─────────────────────────────────────────────────────────────────┘
+Source (.to)
+   → Lexer          src/lexer/         tokens (indentation/brace blocks, literals)
+   → Macro expander                    token-level name!(args) expansion
+   → Parser         src/parser/        recursive descent → AST
+   → Import resolver src/main.cpp      merge imported files (TOCIN_PATH, stdlib/)
+   → Type checker   src/type/          strict two-pass: hoist signatures, then check
+   → IR generator   src/codegen/       LLVM IR (two-pass; DataLayout set up front)
+   → Optimizer      LLVM PassBuilder   -O0..-O3 with a configured TargetMachine
+   → ┬ JIT          ORCv2 LLJIT        --run: execute main() in-process
+     └ AOT          TargetMachine      -o: .ll / .s / .o / linked executable
 ```
 
-## Core Components
-
-### 1. Lexer (Tokenization)
-
-**Location**: `src/lexer/lexer.cpp`, `src/lexer/lexer.h`
-
-**Purpose**: Converts source code into a stream of tokens.
-
-**Key Features**:
-- Indentation-aware tokenization (Python-style)
-- Support for Unicode identifiers
-- Template literal parsing
-- Comprehensive error recovery
-- Line and column tracking for error reporting
-
-**Token Types**:
-```cpp
-enum class TokenType {
-    // Keywords
-    DEF, CLASS, IF, ELSE, WHILE, FOR, RETURN,
-    LET, CONST, IMPORT, ASYNC, AWAIT, GO,
-    
-    // Literals
-    INTEGER, FLOAT, STRING, TRUE, FALSE, NULL,
-    
-    // Operators
-    PLUS, MINUS, STAR, SLASH, PERCENT,
-    EQUAL, NOT_EQUAL, LESS, GREATER,
-    
-    // Special
-    INDENT, DEDENT, NEWLINE, EOF
-};
-```
-
-**Advanced Features**:
-- Automatic semicolon insertion
-- Context-aware keyword recognition
-- String interpolation support
-- Multi-line string handling
-
-### 2. Parser (Syntax Analysis)
-
-**Location**: `src/parser/parser.cpp`, `src/parser/parser.h`
-
-**Purpose**: Constructs an Abstract Syntax Tree (AST) from tokens.
-
-**Parsing Strategy**: Recursive Descent with Pratt Parsing for expressions
-
-**Key Features**:
-- Operator precedence handling
-- Error recovery and synchronization
-- Support for all Tocin language features:
-  - Classes and traits
-  - Pattern matching
-  - Async/await
-  - Goroutines and channels
-  - LINQ-style operations
-
-**AST Node Types**:
-```cpp
-// Statements
-class VarDeclStmt;      // Variable declarations
-class FunctionDeclStmt; // Function definitions
-class ClassDeclStmt;    // Class definitions
-class IfStmt;           // Conditional statements
-class WhileStmt;        // While loops
-class ForStmt;          // For loops
-class ReturnStmt;       // Return statements
-class GoStmt;           // Goroutine launch
-
-// Expressions
-class BinaryExpr;       // Binary operations
-class UnaryExpr;        // Unary operations
-class CallExpr;         // Function calls
-class MemberExpr;       // Member access
-class ArrayExpr;        // Array literals
-class LambdaExpr;       // Lambda functions
-```
-
-### 3. Type Checker
-
-**Location**: `src/type/type_checker.cpp`, `src/type/type_checker.h`
-
-**Purpose**: Performs static type analysis and inference.
-
-**Key Features**:
-- Hindley-Milner type inference
-- Generics and polymorphism support
-- Trait constraint checking
-- Null safety validation
-- Move semantics verification
-
-**Type System**:
-```cpp
-class TypeChecker {
-    // Core type checking
-    void check(ast::StmtPtr stmt);
-    TypePtr inferType(ast::ExprPtr expr);
-    
-    // Advanced features
-    void checkTraitConstraints();
-    void checkNullSafety();
-    void checkMoveSemantics();
-    void checkOwnership();
-};
-```
-
-### 4. IR Generator (Code Generation)
-
-**Location**: `src/codegen/ir_generator.cpp`, `src/codegen/ir_generator.h`
-
-**Purpose**: Converts AST to LLVM Intermediate Representation.
-
-**Key Features**:
-- Complete AST traversal and IR generation
-- Optimization-friendly IR structure
-- Debug information generation
-- Support for all language constructs
-
-**IR Generation Process**:
-
-```cpp
-class IRGenerator {
-public:
-    // Main entry point
-    std::unique_ptr<llvm::Module> generate(ast::StmtPtr ast);
-    
-    // Statement generation
-    void generateStmt(ast::Stmt* stmt);
-    void generateFunctionDecl(ast::FunctionDeclStmt* stmt);
-    void generateClassDecl(ast::ClassDeclStmt* stmt);
-    
-    // Expression generation
-    llvm::Value* generateExpr(ast::Expr* expr);
-    llvm::Value* generateBinaryOp(ast::BinaryExpr* expr);
-    llvm::Value* generateFunctionCall(ast::CallExpr* expr);
-    
-    // Advanced features
-    void generateGoRoutine(ast::GoStmt* stmt);
-    void generateChannel(ast::ChannelExpr* expr);
-    void generateAsyncFunction(ast::FunctionDeclStmt* stmt);
-};
-```
-
-**Supported Node Types**:
-- ✅ All basic statements (if, while, for, return)
-- ✅ Function declarations with parameters and return types
-- ✅ Class declarations with methods and properties
-- ✅ All expression types (binary, unary, call, member access)
-- ✅ Goroutines and concurrent execution
-- ✅ Channels for communication
-- ✅ Async/await constructs
-- ✅ Pattern matching
-- ✅ LINQ-style operations
-
-### 5. Interpreter
-
-**Location**: `interpreter/src/Interpreter.cpp`, `interpreter/include/Interpreter.h`
-
-**Purpose**: Direct execution of AST or JIT-compiled code.
-
-**Architecture**:
-
-```cpp
-class EnhancedInterpreter {
-private:
-    // Core components
-    LLVMJITCompiler* jitCompiler;
-    MemoryManager* memoryManager;
-    GenerationalGC* gc;
-    
-    // Advanced features
-    TypeSystem* typeSystem;
-    NullSafety* nullSafety;
-    StaticAnalyzer* analyzer;
-    Optimizer* optimizer;
-    PerformanceMonitor* perfMonitor;
-    
-public:
-    // Execution modes
-    void interpretDirect(ast::StmtPtr ast);
-    void interpretJIT(ast::StmtPtr ast);
-    
-    // Visitor pattern for AST traversal
-    void visitExpr(ast::Expr* expr) override;
-    void visitStmt(ast::Stmt* stmt) override;
-};
-```
-
-**Features**:
-- **Direct Interpretation**: Fast startup, immediate execution
-- **JIT Compilation**: LLVM-based optimization for hot code paths
-- **Generational GC**: Efficient memory management
-- **Performance Monitoring**: Built-in profiling and statistics
-- **Static Analysis**: Pre-execution optimization
-
-## Advanced Features
-
-### 1. V8 Engine Integration (Planned)
-
-**Purpose**: Full JavaScript interoperability and execution.
-
-**Architecture**:
-
-```cpp
-class V8Integration {
-private:
-    v8::Isolate* isolate;
-    v8::Persistent<v8::Context> context;
-    
-public:
-    // JavaScript execution
-    FFIValue executeJS(const std::string& code);
-my 
-   FFIValue callJSFunction(const std::string& name, 
-                           const std::vector<FFIValue>& args);
-    
-    // Bidirectional type conversion
-    v8::Local<v8::Value> toV8Value(const FFIValue& value);
-    FFIValue fromV8Value(v8::Local<v8::Value> value);
-    
-    // Module management
-    void loadModule(const std::string& name);
-    void registerFunction(const std::string& name, 
-                         std::function<FFIValue(std::vector<FFIValue>)> func);
-};
-```
-
-**Implementation Status**:
-- ✅ FFI infrastructure complete
-- ✅ Type conversion system ready
-- ⏳ V8 engine integration pending
-- 📋 Full JavaScript evaluation requires V8 installation
-
-**Integration Points**:
-1. **FFI Layer**: `src/ffi/ffi_javascript.cpp`
-2. **Value Conversion**: `src/ffi/ffi_value.cpp`
-3. **Module System**: `src/ffi/ffi_javascript.h`
-
-### 2. Complete AST-to-IR Generation
-
-**Current Status**: Core functionality implemented
-
-**Completion Requirements**:
-
-```cpp
-// All AST nodes should generate appropriate IR
-class IRGenerator {
-    // ✅ Implemented
-    llvm::Value* generateBinaryExpr(ast::BinaryExpr* expr);
-    llvm::Value* generateFunctionCall(ast::CallExpr* expr);
-    llvm::Value* generateMemberAccess(ast::MemberExpr* expr);
-    
-    // 🔄 Enhanced implementations needed
-    llvm::Value* generatePatternMatch(ast::MatchExpr* expr);
-    llvm::Value* generateLINQOperation(ast::LINQExpr* expr);
-    llvm::Value* generateTraitMethod(ast::TraitMethodExpr* expr);
-    
-    // 📋 Advanced optimizations planned
-    void optimizeLoopVectorization();
-    void optimizeTailCallElimination();
-    void optimizeInlining();
-};
-```
-
-**Optimization Passes**:
-1. **Dead Code Elimination**: Remove unreachable code
-2. **Constant Folding**: Evaluate constant expressions at compile time
-3. **Function Inlining**: Inline small functions for performance
-4. **Loop Optimization**: Unrolling, vectorization, invariant code motion
-5. **Memory Optimization**: Reduce allocations, reuse objects
-
-### 3. Lightweight Goroutine Scheduler
-
-**Location**: `src/runtime/concurrency.cpp`, `src/runtime/concurrency.h`
-
-**Current Implementation**:
-
-```cpp
-class Scheduler {
-private:
-    std::vector<std::thread> workers;
-    std::queue<Task> taskQueue;
-    std::mutex queueMutex;
-    std::condition_variable queueCondition;
-    
-public:
-    // Task scheduling
-    void schedule(Task task);
-    
-    // Goroutine creation
-    template<typename Func, typename... Args>
-    void go(Func&& func, Args&&... args);
-    
-    // Worker management
-    void startWorkers(size_t count);
-    void stopWorkers();
-};
-```
-
-**Enhancement Plan**:
-
-```cpp
-// Lightweight goroutine implementation
-class LightweightScheduler {
-private:
-    // Fiber-based coroutines instead of OS threads
-    std::vector<Fiber> fibers;
-    
-    // Work-stealing queue for load balancing
-    WorkStealingQueue<Task> globalQueue;
-    std::vector<LocalQueue<Task>> localQueues;
-    
-public:
-    // Lightweight goroutine launch
-    void go(std::function<void()> func) {
-        // Create fiber (much lighter than thread)
-        Fiber fiber = createFiber(func);
-        schedule(fiber);
-    }
-    
-    // Cooperative multitasking
-    void yield() {
-        // Switch to another fiber
-        switchFiber();
-    }
-    
-    // Efficient scheduling
-    void schedule(Fiber fiber) {
-        // Use work-stealing for load balancing
-        localQueues[currentThread()].push(fiber);
-    }
-};
-```
-
-**Benefits**:
-- **Memory Efficiency**: Fibers use ~4KB vs threads using ~1MB
-- **Performance**: Faster context switching
-- **Scalability**: Support millions of concurrent goroutines
-- **Integration**: Seamless with existing code
-
-### 4. Advanced Optimization Passes
-
-**Location**: `src/compiler/compiler.cpp`
-
-**Current Optimizations**:
-
-```cpp
-bool Compiler::optimizeModule(int level) {
-    auto passManager = std::make_unique<llvm::legacy::FunctionPassManager>(module.get());
-    
-    if (level >= 1) {
-        // Basic optimizations
-        passManager->add(llvm::createPromoteMemoryToRegisterPass());
-        passManager->add(llvm::createInstructionCombiningPass());
-        passManager->add(llvm::createReassociatePass());
-    }
-    
-    if (level >= 2) {
-        // Intermediate optimizations
-        passManager->add(llvm::createGVNPass());
-        passManager->add(llvm::createCFGSimplificationPass());
-    }
-    
-    if (level >= 3) {
-        // Aggressive optimizations
-        passManager->add(llvm::createLoopUnrollPass());
-        passManager->add(llvm::createVectorizePass());
-    }
-    
-    return true;
-}
-```
-
-**Planned Enhancements**:
-
-1. **Profile-Guided Optimization (PGO)**
-   - Collect runtime statistics
-   - Optimize based on actual usage patterns
-   - Improve branch prediction
-
-2. **Interprocedural Optimization**
-   - Cross-function optimization
-   - Better inlining decisions
-   - Global value numbering
-
-3. **Whole-Program Optimization**
-   - Link-time optimization (LTO)
-   - Dead function elimination
-   - Better constant propagation
-
-4. **Polyhedral Optimization**
-   - Advanced loop transformations
-   - Automatic parallelization
-   - Cache optimization
-
-## Runtime System
-
-### Memory Management
-
-**Generational Garbage Collector**:
-
-```cpp
-class GenerationalGC {
-private:
-    // Young generation (frequent collections)
-    Heap youngGeneration;
-    
-    // Old generation (infrequent collections)
-    Heap oldGeneration;
-    
-public:
-    void* allocate(size_t size) {
-        // Allocate in young generation
-        void* ptr = youngGeneration.allocate(size);
-        
-        // Trigger minor collection if needed
-        if (youngGeneration.needsCollection()) {
-            minorCollection();
-        }
-        
-        return ptr;
-    }
-    
-    void minorCollection() {
-        // Collect young generation
-        // Promote survivors to old generation
-    }
-    
-    void majorCollection() {
-        // Full heap collection
-    }
-};
-```
-
-### Concurrency Primitives
-
-**Channels**:
-
-```cpp
-template<typename T>
-class Channel {
-private:
-    std::queue<T> buffer;
-    std::mutex mutex;
-    std::condition_variable notEmpty;
-    std::condition_variable notFull;
-    size_t capacity;
-    
-public:
-    void send(const T& value) {
-        std::unique_lock<std::mutex> lock(mutex);
-        notFull.wait(lock, [this] { return buffer.size() < capacity; });
-        buffer.push(value);
-        notEmpty.notify_one();
-    }
-    
-    T receive() {
-        std::unique_lock<std::mutex> lock(mutex);
-        notEmpty.wait(lock, [this] { return !buffer.empty(); });
-        T value = buffer.front();
-        buffer.pop();
-        notFull.notify_one();
-        return value;
-    }
-};
-```
-
-**Select Statement**:
-
-```cpp
-class SelectHandler {
-public:
-    template<typename... Cases>
-    void select(Cases... cases) {
-        // Wait for first available channel operation
-        // Execute corresponding case
-    }
-};
-```
-
-## Build System
-
-### CMake Configuration
-
-**Key Features**:
-- Cross-platform support (Windows, Linux, macOS)
-- Optional feature flags
-- Automatic dependency detection
-- Multiple build configurations
-
-**Build Options**:
-```cmake
-option(WITH_PYTHON "Enable Python FFI" ON)
-option(WITH_V8 "Enable JavaScript FFI" ON)
-option(WITH_ZSTD "Enable compression" ON)
-option(WITH_XML "Enable XML support" ON)
-option(WITH_DEBUGGER "Enable debugger" OFF)
-option(WITH_WASM "Enable WebAssembly target" OFF)
-```
-
-### Installer System
-
-**Windows**: NSIS-based installer
-**Linux**: DEB/RPM packages
-**macOS**: DMG installer
-
-## Testing Infrastructure
-
-### Unit Tests
-- Lexer tests
-- Parser tests
-- Type checker tests
-- IR generation tests
-- Runtime tests
-
-### Integration Tests
-- Full compilation pipeline
-- FFI integration
-- Standard library tests
-- Performance benchmarks
-
-## Performance Characteristics
-
-### Compilation Speed
-- Lexer: ~1M lines/second
-- Parser: ~500K lines/second
-- Type checker: ~300K lines/second
-- IR generation: ~200K lines/second
-
-### Runtime Performance
-- Direct interpretation: ~5-10x slower than native
-- JIT compilation: ~1-2x slower than native
-- Full compilation: Native performance
-
-### Memory Usage
-- Compiler: ~50MB baseline + ~1MB per 1K lines
-- Interpreter: ~20MB baseline
-- Runtime: ~10MB baseline + program data
-
-## Future Enhancements
-
-### Short Term
-1. Complete V8 integration
-2. Enhance IR generation for all AST nodes
-3. Implement lightweight goroutine scheduler
-4. Add more optimization passes
-
-### Medium Term
-1. Language Server Protocol (LSP) support
-2. Interactive debugger
-3. Visual profiler
-4. Package manager
-
-### Long Term
-1. Self-hosting compiler
-2. GPU compute support
-3. Distributed runtime
-4. Formal verification tools
-
-## Conclusion
-
-The Tocin compiler and interpreter architecture provides a solid foundation for a modern, high-performance programming language. The modular design allows for easy extension and optimization, while the comprehensive feature set supports a wide range of programming paradigms and use cases.
+The driver (`src/main.cpp`) orchestrates everything and also implements the
+subcommands: `tocin check` (stop after the type checker), `tocin new`
+(scaffold), `tocin doc` (signatures + `//` doc comments → Markdown).
+
+## Components
+
+### Lexer (`src/lexer/`)
+
+Hand-written tokenizer: indentation- and brace-blocks, `0x`/`0o`/`0b` and `_`
+digit separators, string escapes, line/column tracking on every token.
+Historic log-level keywords (`log`, `warn`, `error`, …) were unreserved so
+they work as ordinary identifiers.
+
+### Parser (`src/parser/`)
+
+Recursive descent producing the AST in `src/ast/`. Notable mechanics: the
+ternary conditional sits between assignment and elvis in the precedence chain;
+`>>` is split when it closes nested generic type annotations; parameters may
+carry default-value expressions; `switch` parses as an alias of `match`.
+
+### Type checker (`src/type/`)
+
+Two-pass (hoist all signatures, then check bodies) and **strict by default**:
+unknown identifiers, wrong arity — including builtins, via the shared registry
+in `src/type/builtin_names.h` — and type mismatches are hard errors;
+`--permissive` downgrades them. Also here: generic monomorphization typing,
+trait-bound enforcement (`T016`), match exhaustiveness (`P001`), `const`
+enforcement (`T013`), and the opt-in borrow checker (`B001`/`B002`).
+
+### Diagnostics (`src/error/`)
+
+Rustc-style rendering: the offending source line with a caret underline,
+ANSI colors gated on TTY detection and `NO_COLOR`, bounded-edit-distance
+"did you mean '…'?" suggestions, and a final `N errors generated.` summary.
+Codegen errors carry source locations threaded through the IR generator.
+
+### IR generator (`src/codegen/`)
+
+Two-pass LLVM IR emission (declaration order doesn't matter). Sets the module
+triple and DataLayout **before** generating IR so layout-sensitive folding is
+correct. Lowers: classes (opaque heap objects), monomorphized generics, trait
+objects (`{ i64 typeId, ptr data }` boxes with virtual dispatch), algebraic
+enums (`[tag][payload…]`), closures (read captures snapshot, write captures
+share a cell), generators (eager collection), exceptions (setjmp/longjmp
+handler stack), `defer`/RAII destructors, and the kernel primitives (volatile
+loads/stores, `fence`, inline `asm` with operands/constraints/clobbers, raw
+memory ops). Emits runtime traps — division/modulo-by-zero and bounds checks —
+as branches to a panic path that reports `panic: <msg> at file:line:col`.
+Math builtins lower to LLVM intrinsics (`sqrt`, `fabs`, `pow`, …) so loops
+vectorize; buffer accesses get `noalias`-style scoped-alias metadata so
+independent buffers optimize as if `restrict`-qualified.
+
+### Optimizer (driver, `src/main.cpp`)
+
+LLVM's **new PassBuilder** pipelines at `-O0`..`-O3` (default `-O2`), built
+with a **configured TargetMachine** so `--native` CPU features (POPCNT, AVX…)
+reach the cost models and vectorizer — not just the backend. For executables
+and JIT runs at `-O3`, non-`main` symbols are **internalized** first
+(whole-program optimization); object/IR/assembly outputs and `--freestanding`
+skip internalization so their symbols stay exported.
+
+### Execution
+
+- **JIT** (`--run`): ORCv2 LLJIT; the runtime is registered in-process, so no
+  external tools are needed.
+- **AOT** (`-o`): TargetMachine emits the object; executables link through the
+  system C compiler **or**, in installed packages, through the **bundled
+  `ld.lld` + static link recipe** (`libexec/link/`), which needs no system
+  toolchain at all — see [native-linking.md](native-linking.md). On Linux the
+  bundled-recipe output is fully static.
+- **Freestanding** (`--freestanding`): a relocatable object with no
+  libc/GC/runtime references, for kernels and bare metal.
+
+### Runtime (`src/runtime/`, linked as `libtocin_runtime`)
+
+C-ABI symbols prefixed `__tocin_`:
+
+- **Memory**: allocation through the **Boehm conservative GC**
+  (`GC_malloc`; `__tocin_alloc_atomic` for pointer-free data like string
+  bytes). `--no-gc` degrades allocation to `malloc`. `free`/`vecFree`/
+  `mapFree` allow eager release.
+- **Concurrency**: `go` spawns **real OS threads** (`__tocin_go`); typed
+  channels and `select` synchronize them. (The fiber-based
+  `lightweight_scheduler.*` M:N substrate exists in-tree but is **not
+  linked** — see [async-scheduler-design.md](async-scheduler-design.md);
+  `async`/`await` run eagerly today.)
+- **Services**: strings (fast `intToStr`, `bufToStr`), vectors/maps (64-bit
+  slots), TCP sockets, time, FNV-1a/splitmix64 hashing, seeded random,
+  env/exit, file I/O.
+- **Failure**: `__tocin_panic`/`__tocin_oob` print the located panic message,
+  flush stdout, and abort.
+
+## Memory model (summary)
+
+Heap values (instances, arrays, strings, closures, Option/Result, channels)
+are opaque pointers allocated via the GC. Channels, Option/Result payloads,
+vector/map elements, and thrown exception payloads move through a uniform
+**64-bit slot** ABI. Strings are immutable NUL-terminated `char*`, compared by
+value with `==`. Full details: [language-reference.md §18](language-reference.md#18-memory-model--abi).
+
+## Testing architecture
+
+| Suite | Runner | What it covers |
+|---|---|---|
+| C++ unit tests (`tests/*.cpp`) | `ctest` | lexer/parser/type-checker/codegen internals |
+| `.to` integration programs (`tests/cases/`) | `scripts/run_to_tests.sh` (compiles to IR, executes under `lli`) | language semantics that need no runtime symbols |
+| JIT runtime + stdlib suites (`tests/jit/`) | `tests/run_stdlib_tests.sh` (runs `tocin --run`) | GC/vectors/maps/strings, traps, kernel primitives, and all 34 stdlib modules (`// expect: N` convention) |
+
+CI (`.github/workflows/ci.yml`): Linux Release+Debug are authoritative;
+macOS/Windows are best-effort; static analysis is advisory.
+
+## Distribution
+
+`installer/` builds self-contained packages per platform — Windows NSIS
+`Setup.exe` + zip, Debian `.deb`, self-extracting `.run`, macOS `.pkg`/`.dmg`,
+and portable tarballs — each bundling the compiler, runtime, stdlib, and the
+`ld.lld` link bundle. See [INSTALLER_GUIDE.md](INSTALLER_GUIDE.md) and
+[../INSTALL.md](../INSTALL.md).

--- a/docs/BUILDING.md
+++ b/docs/BUILDING.md
@@ -5,15 +5,15 @@ This guide covers how to build the Tocin compiler and runtime on all major platf
 ## Prerequisites
 - CMake 3.15+
 - C++17 compatible compiler (GCC 7+, Clang 5+, MSVC 2017+)
-- LLVM 11.0 or newer
+- LLVM 18 (up to LLVM 22 is supported)
 - Python 3.6+ (for Python FFI, optional)
-- Node.js 12+ and V8 (for JavaScript FFI, optional)
+- V8/JavaScript FFI is non-functional and always disabled (`-DWITH_V8=OFF`) — no Node.js/V8 needed
 - zstd, zlib, libffi, libxml2 (optional, for extra features)
 
 ## Basic Build (All Platforms)
 ```bash
-git clone https://github.com/yourusername/tocin-compiler.git
-cd tocin-compiler
+git clone https://github.com/tafolabi009/TocinLang.git
+cd TocinLang
 mkdir build && cd build
 cmake ..
 cmake --build .
@@ -25,7 +25,7 @@ You can enable or disable optional features using CMake flags:
 cmake -DWITH_PYTHON=ON -DWITH_V8=OFF -DWITH_ZSTD=ON -DWITH_XML=OFF ..
 ```
 - `WITH_PYTHON`: Enable Python FFI (default ON)
-- `WITH_V8`: Enable JavaScript (V8) FFI (default ON)
+- `WITH_V8`: JavaScript (V8) FFI — non-functional; always disabled (`-DWITH_V8=OFF`)
 - `WITH_ZSTD`: Enable zstd compression (default ON)
 - `WITH_XML`: Enable XML support (default ON)
 
@@ -100,4 +100,4 @@ cmake --install --preset=default
 - If the IDE does not detect presets, ensure you are using CMake 3.19+ and the latest IDE version.
 - You can always fall back to manual `cmake ..` configuration if needed.
 
-See also: [README.md](../README.md), [BENCHMARKS.md](../BENCHMARKS.md) 
+See also: [README.md](../README.md), [PERFORMANCE.md](PERFORMANCE.md) 

--- a/docs/CONCURRENCY.md
+++ b/docs/CONCURRENCY.md
@@ -12,17 +12,18 @@ To start a function in a new goroutine, use the `go` keyword:
 
 ```tocin
 // Define a function
-fn sayHello(name: string) {
+def sayHello(name: string) {
     println("Hello, " + name);
 }
 
 // Run it in a goroutine
 go sayHello("World");
 
-// Anonymous function in a goroutine
-go func() {
+// Any named function can be spawned
+def announce() {
     println("Running in a goroutine");
-}();
+}
+go announce();
 ```
 
 Goroutines are multiplexed onto a small number of OS threads, similar to Go's approach. This allows thousands of goroutines to run efficiently.
@@ -112,7 +113,7 @@ select {
 ### Fan-Out (Distribution)
 
 ```tocin
-fn fanOut() {
+def fanOut() {
     let work = Channel<int>(100);
     
     // Create 5 workers
@@ -129,7 +130,7 @@ fn fanOut() {
     work.close();
 }
 
-fn worker(id: int, work: Channel<int>) {
+def worker(id: int, work: Channel<int>) {
     for {
         match work.tryReceive() {
             Some(task) => println("Worker " + id.toString() + " processing " + task.toString()),
@@ -142,28 +143,23 @@ fn worker(id: int, work: Channel<int>) {
 ### Fan-In (Collection)
 
 ```tocin
-fn fanIn(input1: Channel<int>, input2: Channel<int>) -> Channel<int> {
+def collect(input: Channel<int>, merged: Channel<int>) {
+    for {
+        match input.tryReceive() {
+            Some(v) => merged.send(v),
+            None => break
+        }
+    }
+}
+
+def fanIn(input1: Channel<int>, input2: Channel<int>) -> Channel<int> {
     let merged = Channel<int>();
     
     // Start goroutine to collect from input1
-    go func() {
-        for {
-            match input1.tryReceive() {
-                Some(v) => merged.send(v),
-                None => break
-            }
-        }
-    }();
+    go collect(input1, merged);
     
     // Start goroutine to collect from input2
-    go func() {
-        for {
-            match input2.tryReceive() {
-                Some(v) => merged.send(v),
-                None => break
-            }
-        }
-    }();
+    go collect(input2, merged);
     
     return merged;
 }

--- a/docs/ERROR_HANDLING.md
+++ b/docs/ERROR_HANDLING.md
@@ -1,34 +1,102 @@
 # Error Handling in Tocin
 
-Tocin provides robust error handling at compile time and runtime, with clear diagnostics and actionable messages.
+Tocin reports errors at three levels: **compile-time diagnostics** (strict by
+default), **runtime traps** (panics with source locations), and **language
+error handling** (`try`/`catch`/`finally` and `Option`/`Result`).
 
-## Error Types
-- **Compile-time errors:** Type errors, undefined variables, trait violations, etc.
-- **Runtime errors:** Null dereference, FFI failures, assertion failures, etc.
+## Compile-time diagnostics (strict by default)
 
-## Reporting Errors
-- Errors are reported with file, line, column, and error code.
-- Use `errorHandler.reportError` in custom codegen or extensions.
+The type checker is strict: unknown identifiers, wrong argument counts
+(builtins included), type mismatches, assigning to a `const`, non-exhaustive
+`match`es on algebraic enums, and (under `--borrow-check`) move/borrow
+violations are **hard errors**. Diagnostics are rendered rustc-style — the
+offending source line, a caret underline, colors on terminals (respects
+`NO_COLOR`), and a `did you mean '…'?` suggestion when a similarly-spelled
+name exists — ending with an `N errors generated.` summary:
 
-## Example: Compile-Time Error
-```to
-let x: int = "hello"; // Type error: cannot assign string to int
+```text
+app.to:3:8: error [T013]: Cannot assign to constant 'X' (declared with `const`). Use `let` for a mutable binding.
+    3 |     X = 6;
+      |        ^
+1 error generated.
 ```
 
-## Example: Runtime Error
-```to
-let s: string? = null;
-let len = s!.length; // Runtime error: not-null assertion failed
+Common error codes: `T002` unknown identifier, `T013` assignment to `const`,
+`T016` unsatisfied generic trait bound, `P001` non-exhaustive `match`,
+`B001`/`B002` move / borrow violations (opt-in `--borrow-check`).
+
+- `tocin check file.to` runs just the checker (no codegen) and exits 0 when
+  clean — a fast pre-commit / CI gate.
+- `--permissive` downgrades type errors to warnings and compiles anyway (not
+  recommended; strict is the supported mode).
+
+## Runtime traps (panics)
+
+Operations that would otherwise be undefined behavior abort with a **located
+panic** instead of corrupting state:
+
+```text
+panic: integer division by zero at app.to:4:16
 ```
 
-## Best Practices
-- Fix all compile-time errors before running your program.
-- Use null safety and type annotations to prevent runtime errors.
-- Handle FFI errors gracefully and check for backend availability.
+- Integer division or modulo by zero.
+- Out-of-bounds array/string indexing (bounds checks are on by default;
+  `--freestanding` omits them for systems code).
+- Force-unwrapping a null reference with `x!!`.
 
-## Troubleshooting
-- **Unclear error message:** Check the error code and docs for more info.
-- **FFI error:** Ensure the backend (Python, JS, C++) is available and enabled.
-- **Trait error:** Ensure all required methods are implemented.
+A panic flushes pending output and aborts the process (exit code 134).
 
-See also: [Language Basics](03_Language_Basics.md), [Advanced Topics](05_Advanced_Topics.md) 
+## Exceptions: `throw` / `try` / `catch` / `finally`
+
+```tocin
+def divide(a: int, b: int) -> int {
+    if b == 0 { throw 1; }        // unwinds to the nearest catch
+    return a / b;
+}
+
+def main() {
+    try {
+        println("{}", divide(10, 0));
+    } catch (e) {
+        println("error code {}", e);   // error code 1
+    } finally {
+        println("done");               // runs on every path
+    }
+    return 0;
+}
+```
+
+Exceptions unwind across function calls in both JIT and native builds, and
+`finally` runs on every path — including early `return`. The payload is an
+**integer error code** (there is no exception type hierarchy or typed
+`catch`). See the full semantics in
+[language-reference.md §11](language-reference.md#11-error-handling).
+
+## Recoverable errors: `Option` / `Result`
+
+For expected failures, prefer returning `Option`/`Result` and destructuring
+with `match` — no unwinding involved:
+
+```tocin
+def safeDiv(a: int, b: int) -> Result {
+    if b == 0 { return Err(1); }
+    return Ok(a / b);
+}
+
+match safeDiv(100, n) {
+    case Ok(v):  { println("ok: {}", v); }
+    case Err(e): { println("error code {}", e); }
+}
+```
+
+## Best practices
+
+- Keep the strict checker on; fix errors rather than reaching for
+  `--permissive`.
+- Use `Option`/`Result` for expected failures, exceptions for exceptional
+  ones, and let traps catch genuine bugs loudly.
+- Note that only the **C** FFI path is functional today — treat Python/JS FFI
+  errors as "feature not available", not something to handle at runtime.
+
+See also: [language-reference.md](language-reference.md) §11 (exceptions),
+§13 (Option/Result), §19 (diagnostics and traps).

--- a/docs/INSTALLER_GUIDE.md
+++ b/docs/INSTALLER_GUIDE.md
@@ -1,690 +1,79 @@
-# Tocin Installer Guide
-
-## Overview
-
-The Tocin compiler provides professional, cross-platform installers similar to Go, Python, and Adobe installers. This guide explains how to build and use installers for Windows, Linux, and macOS.
-
-## Installer Features
-
-### Windows Installer
-- **Technology**: NSIS (Nullsoft Scriptable Install System)
-- **Format**: .exe installer
-- **Features**:
-  - GUI installation wizard
-  - Custom installation directory
-  - PATH environment variable configuration
-  - Start menu shortcuts
-  - Uninstall support
-  - Version detection and upgrade handling
-
-### Linux Installer
-- **Formats**: 
-  - DEB (Debian/Ubuntu)
-  - RPM (Red Hat/Fedora)
-  - AppImage (Universal)
-  - Snap package
-- **Features**:
-  - System-wide or user installation
-  - Automatic dependency resolution
-  - Desktop integration
-  - Man page installation
-  - Clean uninstallation
-
-### macOS Installer
-- **Formats**:
-  - DMG disk image
-  - PKG installer
-  - Homebrew formula
-- **Features**:
-  - Drag-and-drop installation
-  - Code signing support
-  - Gatekeeper compatibility
-  - Automatic PATH configuration
-  - Native uninstaller
-
-## Building Installers
-
-### Prerequisites
-
-#### Windows
-```powershell
-# Install NSIS
-choco install nsis
-
-# Or download from: https://nsis.sourceforge.io/
-
-# Install CMake
-choco install cmake
-
-# Install LLVM
-choco install llvm
-```
-
-#### Linux
-```bash
-# Debian/Ubuntu
-sudo apt-get install build-essential cmake llvm-dev nsis
-
-# Fedora/RHEL
-sudo dnf install gcc-c++ cmake llvm-devel nsis
-
-# For package building
-sudo apt-get install dpkg-dev rpm alien
-```
-
-#### macOS
-```bash
-# Install Homebrew
-/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
-
-# Install dependencies
-brew install cmake llvm create-dmg
-```
-
-### Building Windows Installer
-
-#### Method 1: Using PowerShell Script
-
-```powershell
-# Navigate to repository root
-cd tocin-compiler
-
-# Run the installer build script
-.\installer\build_installer.ps1 -Platform windows -Version "1.0.0"
-
-# Installer will be created in: build\TocingCompiler-1.0.0-Setup.exe
-```
-
-#### Method 2: Manual Build
-
-```powershell
-# Step 1: Build the compiler
-mkdir build
-cd build
-cmake -G "Visual Studio 17 2022" -A x64 ..
-cmake --build . --config Release
-
-# Step 2: Create staging directory
-mkdir installer_staging
-mkdir installer_staging\bin
-mkdir installer_staging\lib
-mkdir installer_staging\doc
-
-# Step 3: Copy files
-copy Release\tocin.exe installer_staging\bin\
-copy ..\README.md installer_staging\doc\
-copy ..\LICENSE installer_staging\doc\
-
-# Step 4: Build installer
-cd ..\installer\windows
-makensis installer.nsi
-```
-
-### Building Linux Installer
-
-#### DEB Package
-
-```bash
-# Navigate to repository root
-cd tocin-compiler
-
-# Run the installer build script
-./installer/build_installer.sh --platform linux --format deb --version "1.0.0"
-
-# Package will be created in: build/tocin-compiler_1.0.0_amd64.deb
-```
-
-#### Manual DEB Build
-
-```bash
-# Step 1: Build the compiler
-mkdir build && cd build
-cmake -DCMAKE_BUILD_TYPE=Release ..
-make -j$(nproc)
-
-# Step 2: Create package directory structure
-mkdir -p tocin-compiler-1.0.0/DEBIAN
-mkdir -p tocin-compiler-1.0.0/usr/bin
-mkdir -p tocin-compiler-1.0.0/usr/share/doc/tocin-compiler
-mkdir -p tocin-compiler-1.0.0/usr/share/man/man1
-
-# Step 3: Copy files
-cp tocin tocin-compiler-1.0.0/usr/bin/
-cp ../README.md tocin-compiler-1.0.0/usr/share/doc/tocin-compiler/
-cp ../LICENSE tocin-compiler-1.0.0/usr/share/doc/tocin-compiler/
-
-# Step 4: Create control file
-cat > tocin-compiler-1.0.0/DEBIAN/control << EOF
-Package: tocin-compiler
-Version: 1.0.0
-Section: devel
-Priority: optional
-Architecture: amd64
-Depends: llvm-11 | llvm-12 | llvm-13 | llvm-14, libc6 (>= 2.31)
-Maintainer: Tocin Team <team@tocin.dev>
-Description: Tocin Programming Language Compiler
- A modern, statically-typed programming language with advanced features
- including traits, LINQ, null safety, and async/await support.
-EOF
-
-# Step 5: Build package
-dpkg-deb --build tocin-compiler-1.0.0
-```
-
-#### RPM Package
-
-```bash
-# Create RPM spec file and build
-./installer/build_installer.sh --platform linux --format rpm --version "1.0.0"
-```
-
-#### AppImage (Universal Linux Package)
-
-```bash
-# Download AppImage tools
-wget https://github.com/linuxdeploy/linuxdeploy/releases/download/continuous/linuxdeploy-x86_64.AppImage
-chmod +x linuxdeploy-x86_64.AppImage
-
-# Build AppImage
-./installer/build_installer.sh --platform linux --format appimage --version "1.0.0"
-```
-
-### Building macOS Installer
-
-#### DMG Installer
-
-```bash
-# Navigate to repository root
-cd tocin-compiler
-
-# Run the installer build script
-./installer/build_installer.sh --platform macos --format dmg --version "1.0.0"
-
-# DMG will be created in: build/Tocin-1.0.0.dmg
-```
-
-#### Manual DMG Build
-
-```bash
-# Step 1: Build the compiler
-mkdir build && cd build
-cmake -DCMAKE_BUILD_TYPE=Release ..
-make -j$(sysctl -n hw.ncpu)
-
-# Step 2: Create application bundle
-mkdir -p Tocin.app/Contents/MacOS
-mkdir -p Tocin.app/Contents/Resources
-
-cp tocin Tocin.app/Contents/MacOS/
-cp ../installer/macos/Info.plist Tocin.app/Contents/
-cp ../Tocin_Logo.icns Tocin.app/Contents/Resources/
-
-# Step 3: Create DMG
-create-dmg \
-  --volname "Tocin Compiler" \
-  --volicon "../Tocin_Logo.icns" \
-  --window-pos 200 120 \
-  --window-size 800 400 \
-  --icon-size 100 \
-  --icon "Tocin.app" 200 190 \
-  --hide-extension "Tocin.app" \
-  --app-drop-link 600 185 \
-  "Tocin-1.0.0.dmg" \
-  "Tocin.app"
-```
-
-#### Homebrew Formula
-
-```bash
-# Create Homebrew tap
-brew tap tocin/tap
-
-# Install via Homebrew
-brew install tocin
-```
-
-## Installation
-
-### Windows
-
-#### GUI Installation
-
-1. Download `TocingCompiler-1.0.0-Setup.exe`
-2. Double-click to run the installer
-3. Follow the installation wizard:
-   - Accept license agreement
-   - Choose installation directory (default: `C:\Program Files\Tocin`)
-   - Select components to install
-   - Choose whether to add to PATH
-4. Click Install
-5. Installation complete!
-
-#### Silent Installation
-
-```powershell
-# Install silently with default options
-TocingCompiler-1.0.0-Setup.exe /S
-
-# Install to custom directory
-TocingCompiler-1.0.0-Setup.exe /S /D=C:\MyPrograms\Tocin
-```
-
-#### Verification
-
-```powershell
-# Open new terminal
-tocin --version
-# Output: Tocin Compiler v1.0.0
-
-# Test compilation
-tocin test.to
-```
-
-### Linux
-
-#### DEB Package (Debian/Ubuntu)
-
-```bash
-# Download the DEB package
-wget https://github.com/tocin/releases/download/v1.0.0/tocin-compiler_1.0.0_amd64.deb
-
-# Install
-sudo dpkg -i tocin-compiler_1.0.0_amd64.deb
-
-# Fix dependencies if needed
-sudo apt-get install -f
-
-# Verify installation
-tocin --version
-```
-
-#### RPM Package (Fedora/RHEL)
-
-```bash
-# Download the RPM package
-wget https://github.com/tocin/releases/download/v1.0.0/tocin-compiler-1.0.0.x86_64.rpm
-
-# Install
-sudo rpm -i tocin-compiler-1.0.0.x86_64.rpm
-
-# Or using dnf
-sudo dnf install tocin-compiler-1.0.0.x86_64.rpm
-
-# Verify installation
-tocin --version
-```
-
-#### AppImage (Universal)
-
-```bash
-# Download AppImage
-wget https://github.com/tocin/releases/download/v1.0.0/Tocin-1.0.0-x86_64.AppImage
-
-# Make executable
-chmod +x Tocin-1.0.0-x86_64.AppImage
-
-# Run (no installation needed!)
-./Tocin-1.0.0-x86_64.AppImage --version
-
-# Optional: Integrate with system
-./Tocin-1.0.0-x86_64.AppImage --appimage-integrate
-```
-
-#### Snap Package
-
-```bash
-# Install from Snap Store
-sudo snap install tocin-compiler
-
-# Verify installation
-tocin --version
-```
-
-### macOS
-
-#### DMG Installation
-
-1. Download `Tocin-1.0.0.dmg`
-2. Double-click to mount the disk image
-3. Drag `Tocin.app` to the Applications folder
-4. Eject the disk image
-5. Open Terminal and add to PATH:
-
-```bash
-echo 'export PATH="/Applications/Tocin.app/Contents/MacOS:$PATH"' >> ~/.zshrc
-source ~/.zshrc
-
-# Verify
-tocin --version
-```
-
-#### Homebrew Installation
-
-```bash
-# Add Tocin tap
-brew tap tocin/tap
-
-# Install
-brew install tocin
-
-# Verify
-tocin --version
-```
-
-## Uninstallation
-
-### Windows
-
-#### Using Uninstaller
-
-1. Open Settings → Apps → Apps & features
-2. Search for "Tocin Compiler"
-3. Click Uninstall
-4. Follow the uninstall wizard
-
-#### Silent Uninstall
-
-```powershell
-# Find uninstaller
-$uninstaller = "C:\Program Files\Tocin\Uninstall.exe"
-
-# Run silently
-& $uninstaller /S
-```
-
-### Linux
-
-#### DEB Package
-
-```bash
-# Remove package
-sudo dpkg -r tocin-compiler
-
-# Remove package and configuration
-sudo dpkg -P tocin-compiler
-
-# Or using apt
-sudo apt-get remove tocin-compiler
-```
-
-#### RPM Package
-
-```bash
-# Remove package
-sudo rpm -e tocin-compiler
-
-# Or using dnf
-sudo dnf remove tocin-compiler
-```
-
-#### AppImage
-
-```bash
-# Simply delete the file
-rm Tocin-1.0.0-x86_64.AppImage
-
-# If integrated with system
-./Tocin-1.0.0-x86_64.AppImage --appimage-unintegrate
-```
-
-### macOS
-
-#### Manual Uninstall
-
-```bash
-# Remove application
-rm -rf /Applications/Tocin.app
-
-# Remove from PATH (if manually added)
-# Edit ~/.zshrc and remove the PATH line
-```
-
-#### Homebrew Uninstall
-
-```bash
-brew uninstall tocin
-```
-
-## Upgrade/Update
-
-### Windows
-
-1. Download new installer
-2. Run installer (will detect existing installation)
-3. Choose "Upgrade" option
-4. Previous version will be replaced
+# Building the Tocin Installers
+
+How to produce the native, self-contained Tocin installers. **If you just want
+to install Tocin, read [../INSTALL.md](../INSTALL.md) instead** — this page is
+for maintainers building the packages.
+
+Every artifact is self-contained: it bundles the compiler, runtime, standard
+library, docs/examples, an uninstaller, and the **`ld.lld` link bundle** that
+lets `tocin file.to -o app` produce native binaries with **no system C
+compiler** on the target machine ([native-linking.md](native-linking.md)).
+
+## What gets built
+
+| Platform | Artifact | Built by |
+|---|---|---|
+| Windows | `Tocin-<ver>-Setup.exe` — NSIS GUI wizard (welcome → license → components → PATH + `.to` association, Add/Remove Programs uninstaller) | `installer\windows\Build-TocinInstaller.ps1` + `installer\windows\installer.nsi` |
+| Windows | `tocin-<ver>-windows-x86_64.zip` — portable zip with `install.ps1` | `installer\windows\Build-TocinInstaller.ps1` |
+| Debian/Ubuntu | `tocin_<ver>_amd64.deb` — installs to `/opt/tocin`, `Depends: libc6` only | `installer/linux/make-deb.sh` |
+| Any Linux | `tocin-<ver>-linux-<arch>.run` — self-extracting installer (zenity/kdialog GUI or terminal prompt), installs to `~/.tocin`, no root | `installer/linux/make-run.sh` |
+| Linux/macOS | `tocin-<ver>-<os>-<arch>.tar.gz` — portable tarball with `install.sh` | `installer/package.sh --bundle-libs` |
+| macOS | `tocin-<ver>-macos-<arch>.pkg` / `.dmg` — native Installer GUI, installs to `/usr/local/tocin` | `installer/macos/make-pkg.sh` |
+
+## One command per platform
 
 ### Linux
 
 ```bash
-# DEB
-sudo dpkg -i tocin-compiler_NEW_VERSION_amd64.deb
-
-# RPM
-sudo rpm -U tocin-compiler-NEW_VERSION.x86_64.rpm
+installer/build-all.sh      # -> dist/: .tar.gz + .run + .deb
 ```
 
 ### macOS
 
 ```bash
-# Homebrew
-brew upgrade tocin
-
-# Manual: Install new DMG (overwrites old version)
+installer/build-all.sh      # -> dist/: .tar.gz + .pkg + .dmg
 ```
 
-## Configuration
-
-### Post-Installation Setup
-
-#### Set Default Editor
-
-```bash
-# Bash
-echo 'export EDITOR=tocin' >> ~/.bashrc
-
-# Zsh
-echo 'export EDITOR=tocin' >> ~/.zshrc
-```
-
-#### Configure Environment
-
-```bash
-# Set Tocin home directory
-export TOCIN_HOME=/usr/local/tocin
-
-# Set standard library path
-export TOCIN_STDLIB=$TOCIN_HOME/stdlib
-
-# Enable JIT by default
-export TOCIN_JIT=1
-```
-
-## Troubleshooting
-
-### Common Issues
-
-#### Windows: "tocin is not recognized"
-
-**Solution**: Add to PATH manually
-```powershell
-$env:Path += ";C:\Program Files\Tocin\bin"
-[Environment]::SetEnvironmentVariable("Path", $env:Path, [EnvironmentVariableTarget]::User)
-```
-
-#### Linux: Missing dependencies
-
-**Solution**: Install LLVM
-```bash
-# Ubuntu
-sudo apt-get install llvm-14
-
-# Fedora
-sudo dnf install llvm
-```
-
-#### macOS: "tocin cannot be opened because it is from an unidentified developer"
-
-**Solution**: Allow in System Preferences
-```bash
-# Or use command line
-xattr -d com.apple.quarantine /Applications/Tocin.app
-```
-
-### Verification
-
-```bash
-# Check installation
-tocin --version
-
-# Check system integration
-which tocin
-
-# Test compilation
-echo 'print("Hello, World!");' > test.to
-tocin test.to
-```
-
-## Advanced Installation Options
-
-### Custom Installation Location
-
-#### Windows
-```powershell
-TocingCompiler-Setup.exe /D=C:\MyPath\Tocin
-```
-
-#### Linux
-```bash
-# Extract DEB and install manually
-dpkg -x tocin-compiler.deb ~/tocin
-export PATH="$HOME/tocin/usr/bin:$PATH"
-```
-
-### Minimal Installation
-
-Install only core components without optional features:
-
-```bash
-# During build
-cmake -DWITH_PYTHON=OFF -DWITH_V8=OFF -DWITH_DEBUGGER=OFF ..
-
-# Or use minimal installer variant
-./TocingCompiler-1.0.0-Minimal-Setup.exe
-```
-
-### Development Installation
-
-Install additional development tools:
-
-```bash
-# Include headers and libraries
-cmake -DINSTALL_HEADERS=ON -DINSTALL_LIBS=ON ..
-
-# Or install dev package
-sudo apt-get install tocin-compiler-dev
-```
-
-## System Requirements
+(Run **on** macOS — Mach-O binaries and `pkgbuild`/`productbuild`/`hdiutil`
+are not cross-produced.)
 
 ### Windows
-- Windows 10 or later (64-bit)
-- 2 GB RAM minimum, 4 GB recommended
-- 500 MB disk space
-- Visual C++ Redistributable 2017 or later
 
-### Linux
-- glibc 2.31 or later
-- 2 GB RAM minimum, 4 GB recommended
-- 500 MB disk space
-- LLVM 11 or later
-
-### macOS
-- macOS 10.15 (Catalina) or later
-- 2 GB RAM minimum, 4 GB recommended
-- 500 MB disk space
-- Xcode Command Line Tools
-
-## Building Custom Installers
-
-### Customizing Windows Installer
-
-Edit `installer/windows/installer.nsi`:
-
-```nsis
-; Custom branding
-!define PRODUCT_NAME "My Custom Tocin"
-!define PRODUCT_VERSION "1.0.0"
-!define PRODUCT_PUBLISHER "My Company"
-
-; Custom installation directory
-InstallDir "$PROGRAMFILES64\MyTocin"
-
-; Add custom shortcuts
-CreateShortCut "$DESKTOP\Tocin.lnk" "$INSTDIR\bin\tocin.exe"
+```powershell
+powershell -ExecutionPolicy Bypass -File installer\windows\Build-TocinInstaller.ps1
 ```
 
-### Customizing Linux Packages
+This is turnkey on a clean machine: it installs MSYS2 (winget), pacman-installs
+the mingw64 toolchain (LLVM, GCC, CMake, Ninja, Boehm GC), builds the compiler,
+stages a self-contained tree (bundling every dependent DLL next to
+`tocin.exe`), zips it, and — if `makensis` is on `PATH` — emits the GUI
+`Setup.exe`. Useful extras:
 
-Edit `installer/linux/control` (for DEB) or `installer/linux/tocin.spec` (for RPM).
-
-### Customizing macOS Installer
-
-Edit `installer/macos/Info.plist` for app bundle configuration.
-
-## CI/CD Integration
-
-### Automated Installer Building
-
-```yaml
-# GitHub Actions example
-name: Build Installers
-
-on: [push, pull_request]
-
-jobs:
-  build-windows:
-    runs-on: windows-latest
-    steps:
-      - uses: actions/checkout@v2
-      - name: Build Windows Installer
-        run: |
-          .\installer\build_installer.ps1 -Platform windows
-      - name: Upload Artifact
-        uses: actions/upload-artifact@v2
-        with:
-          name: windows-installer
-          path: build/*.exe
-
-  build-linux:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - name: Build Linux Packages
-        run: |
-          ./installer/build_installer.sh --platform linux --format all
-      - name: Upload Artifacts
-        uses: actions/upload-artifact@v2
-        with:
-          name: linux-packages
-          path: build/*.deb build/*.rpm build/*.AppImage
-
-  build-macos:
-    runs-on: macos-latest
-    steps:
-      - uses: actions/checkout@v2
-      - name: Build macOS Installer
-        run: |
-          ./installer/build_installer.sh --platform macos
-      - name: Upload Artifact
-        uses: actions/upload-artifact@v2
-        with:
-          name: macos-installer
-          path: build/*.dmg
+```powershell
+winget install --id NSIS.NSIS -e                 # once: enables the Setup.exe step
+C:\msys64\usr\bin\bash.exe -lc "pacman -S --needed --noconfirm mingw-w64-x86_64-lld"
+                                                 # once: ld.lld for the no-compiler link bundle
+powershell -ExecutionPolicy Bypass -File installer\windows\Build-TocinInstaller.ps1 -SkipDeps
+                                                 # repeat builds: skip the toolchain step
 ```
 
-## Conclusion
+Outputs land in `dist\tocin-<ver>-windows-x86_64.zip` and
+`installer\windows\Tocin-<ver>-Setup.exe`.
 
-The Tocin installer system provides professional, cross-platform installation experience comparable to major programming languages and commercial software. The installers handle all aspects of installation, configuration, and maintenance automatically.
+## Package flavors
 
-For issues or questions, visit: https://github.com/tocin/tocin-compiler/issues
+| Flavor | Size | Needs on the target machine |
+|---|---|---|
+| **Portable** (`--bundle-libs`, the default for `build-all.sh`) | ~60 MB | nothing but a libc — no compiler, no LLVM, no GC package |
+| **Standard** (`package.sh` without `--bundle-libs`) | <1 MB | system LLVM 18 + libgc already installed |
+
+The portable flavor also vendors the static link recipe
+(`installer/make-link-recipe.sh --static`), so on Linux the executables that
+`tocin -o` produces are **fully static** — they run on any distro, like Go
+binaries.
+
+## Publishing
+
+Upload the artifacts to a GitHub Release tagged `v<ver>`; the quick-install
+scripts (`installer/get-tocin.sh`, `installer/install.ps1`) download the
+matching release asset. Details: [../installer/README.md](../installer/README.md).

--- a/docs/INTEGRATION_GUIDE.md
+++ b/docs/INTEGRATION_GUIDE.md
@@ -1,469 +1,57 @@
-# Integration Guide for Advanced Features
+# Integration & Interop Status
 
-This document explains how to integrate and use the newly implemented advanced features in your Tocin projects.
+What is actually wired into the shipped `tocin` binary versus what exists as
+scaffolding in the tree. This page replaces an older guide that described
+unbuilt subsystems as if they were live.
 
-## Table of Contents
-1. [Building with Advanced Features](#building-with-advanced-features)
-2. [V8 JavaScript Integration](#v8-javascript-integration)
-3. [Advanced Optimizations](#advanced-optimizations)
-4. [Lightweight Goroutine Scheduler](#lightweight-goroutine-scheduler)
-5. [Examples](#examples)
-6. [Performance Tuning](#performance-tuning)
+## Interop matrix
 
-## Building with Advanced Features
+| Integration | Status | Notes |
+|---|---|---|
+| **C FFI** | ✅ **Works** (JIT + native) | `extern def name(...) -> T;` then call like any function. Under `--run` symbols resolve from the process (libc/libm available out of the box); native builds link them normally. See [ffi.md](ffi.md). |
+| **Python FFI** | ⚠️ Experimental scaffold | Behind the `WITH_PYTHON` CMake option (embeds CPython). Off by default in release packages; not a supported surface yet. |
+| **JavaScript / V8** | ❌ Not functional | All real builds configure `-DWITH_V8=OFF`. The `src/v8_integration/` sources exist but are not part of a working feature. |
+| **WebAssembly target** | ⚠️ Parsed, not a supported path | `--target wasm` exists; native is the supported target. |
 
-### Prerequisites
+## Concurrency runtime (what `go` really does)
 
-#### V8 JavaScript Engine
-**Linux (Debian/Ubuntu):**
-```bash
-sudo apt-get install libv8-dev
-```
+`go f(args)` spawns a **real OS thread** via the `__tocin_go` runtime
+(1:1 threading), and channels/`select` synchronize threads. The fiber-based
+`src/runtime/lightweight_scheduler.*` ("millions of goroutines" M:N substrate)
+is **not linked into the runtime** — it is design scaffolding; the plan for
+wiring it under `async`/`await` is written up in
+[async-scheduler-design.md](async-scheduler-design.md). `async def`/`await`
+run today with eager semantics (correct results, no suspension).
 
-**macOS:**
-```bash
-brew install v8
-```
+## Optimization pipeline (what `-O3` really runs)
 
-**Windows (vcpkg):**
-```bash
-vcpkg install v8
-```
+The driver uses LLVM's **new PassBuilder** pipeline with a configured
+TargetMachine (so `--native` CPU features reach the vectorizer), plus
+whole-program internalization at `-O3` for executables and JIT runs. The
+separate `src/compiler/advanced_optimizations.cpp` (PGO/polyhedral
+scaffolding) is **not on the default path**.
 
-### CMake Configuration
+## Embedding the compiler
 
-Update your `CMakeLists.txt` to include the new features:
+The build produces reusable pieces:
 
-```cmake
-# Enable advanced features
-option(WITH_V8 "Enable V8 JavaScript Engine" ON)
-option(WITH_ADVANCED_OPT "Enable advanced optimizations" ON)
-option(WITH_LIGHTWEIGHT_SCHEDULER "Enable lightweight goroutine scheduler" ON)
+- `tocin` — the CLI (JIT, AOT, `check`/`new`/`doc`).
+- `libtocin_runtime.a` / `tocin_runtime_shared` — the runtime (GC allocator,
+  goroutines/channels, strings/vectors/maps, TCP/time/hash/random), linkable
+  from C/C++; every entry point is a C symbol prefixed `__tocin_`.
+- The C++ compiler libraries (lexer/parser/type/codegen) that `tocin` itself
+  is built from — usable in-tree (e.g. the unit tests link them), though the
+  C++ API is not a stability-guaranteed surface.
 
-# Add source directories
-add_subdirectory(src/v8_integration)
-add_subdirectory(src/compiler)
-add_subdirectory(src/runtime)
+## Calling Tocin from other languages
 
-# Link libraries
-target_link_libraries(tocin PRIVATE 
-    v8_integration
-    advanced_optimizations
-    lightweight_scheduler
-)
-```
-
-### Build Commands
+Compile to an object file and link it like C:
 
 ```bash
-mkdir build
-cd build
-
-# Build with all features
-cmake -DWITH_V8=ON -DWITH_ADVANCED_OPT=ON -DWITH_LIGHTWEIGHT_SCHEDULER=ON ..
-make -j$(nproc)
-
-# Or build without V8 (if not available)
-cmake -DWITH_V8=OFF -DWITH_ADVANCED_OPT=ON -DWITH_LIGHTWEIGHT_SCHEDULER=ON ..
-make -j$(nproc)
+tocin lib.to -o lib.o
+cc main.c lib.o -o app        # Tocin functions are plain C symbols
 ```
 
-## V8 JavaScript Integration
-
-### Basic Usage in Tocin
-
-```to
-// Import JavaScript FFI module
-import ffi.javascript;
-
-// Execute JavaScript code
-let result = ffi.javascript.eval("2 + 3 * 4");
-print("Result: " + result);
-
-// Define JavaScript function
-ffi.javascript.eval("""
-    function factorial(n) {
-        return n <= 1 ? 1 : n * factorial(n - 1);
-    }
-""");
-
-// Call JavaScript function from Tocin
-let fact = ffi.javascript.call("factorial", [10]);
-print("Factorial(10) = " + fact);
-```
-
-### Advanced V8 Usage in C++
-
-```cpp
-#include "v8_integration/v8_runtime.h"
-
-using namespace tocin::v8_integration;
-
-void useV8Runtime() {
-    V8Runtime runtime;
-    
-    if (!runtime.initialize()) {
-        std::cerr << "Failed to initialize V8: " 
-                  << runtime.getLastError() << "\n";
-        return;
-    }
-    
-    // Execute JavaScript
-    auto result = runtime.executeCode(R"(
-        const arr = [1, 2, 3, 4, 5];
-        arr.map(x => x * 2).reduce((a, b) => a + b, 0);
-    )");
-    
-    if (runtime.hasError()) {
-        std::cerr << "Error: " << runtime.getLastError() << "\n";
-    } else {
-        std::cout << "Result: " << result.asInt32() << "\n";
-    }
-    
-    // Register Tocin function for JavaScript
-    runtime.registerFunction("tocinFunction", 
-        [](const std::vector<ffi::FFIValue>& args) {
-            // Your Tocin logic here
-            return ffi::FFIValue(42);
-        }
-    );
-    
-    runtime.shutdown();
-}
-```
-
-## Advanced Optimizations
-
-### Using the Optimization Pipeline
-
-```cpp
-#include "compiler/advanced_optimizations.h"
-
-using namespace tocin::optimization;
-
-void optimizeModule(llvm::Module* module) {
-    // Create optimization pipeline
-    AdvancedOptimizationPipeline pipeline;
-    
-    // Configure optimizations
-    pipeline.setOptimizationLevel(3);  // 0-3
-    pipeline.enablePGO(false);         // Profile-guided optimization
-    pipeline.enableIPO(true);          // Interprocedural optimization
-    pipeline.enablePolyhedral(true);   // Loop optimizations
-    pipeline.enableLTO(true);          // Link-time optimization
-    
-    // Run optimization
-    pipeline.optimize(module);
-    
-    // Get statistics
-    auto stats = pipeline.getStats();
-    std::cout << "Optimization completed in " 
-              << stats.optimizationTimeMs << "ms\n";
-    std::cout << "Functions inlined: " 
-              << stats.ipoStats.inlinedFunctions << "\n";
-    std::cout << "Loops vectorized: " 
-              << stats.loopStats.vectorizedLoops << "\n";
-}
-```
-
-### Compiler Integration
-
-Add to your compiler class:
-
-```cpp
-#include "compiler/advanced_optimizations.h"
-
-class Compiler {
-private:
-    std::unique_ptr<optimization::AdvancedOptimizationPipeline> optimizer_;
-    
-public:
-    Compiler() {
-        optimizer_ = std::make_unique<optimization::AdvancedOptimizationPipeline>();
-    }
-    
-    void compile(const std::string& source, int optLevel) {
-        // ... parse and generate IR ...
-        
-        // Apply advanced optimizations
-        optimizer_->setOptimizationLevel(optLevel);
-        optimizer_->optimize(module.get());
-        
-        // ... generate code ...
-    }
-};
-```
-
-## Lightweight Goroutine Scheduler
-
-### Basic Usage in Tocin
-
-```to
-// Import concurrency module
-import runtime.concurrency;
-
-// Launch goroutines
-go {
-    print("Goroutine 1");
-}
-
-go {
-    print("Goroutine 2");
-}
-
-// Launch goroutine with parameters
-func processData(id: int, data: string) {
-    print("Processing " + data + " in goroutine " + id);
-}
-
-for i in 0..1000 {
-    go processData(i, "data" + i);
-}
-```
-
-### Advanced Usage in C++
-
-```cpp
-#include "runtime/lightweight_scheduler.h"
-
-using namespace tocin::runtime;
-
-void useLightweightScheduler() {
-    // Create scheduler with 8 worker threads
-    LightweightScheduler scheduler(8);
-    
-    // Configure scheduler
-    scheduler.setFiberStackSize(8192);  // 8KB per fiber
-    scheduler.start();
-    
-    // Launch goroutines
-    std::atomic<int> counter{0};
-    
-    for (int i = 0; i < 1000000; i++) {
-        scheduler.go([&counter, i]() {
-            counter++;
-            // Do work
-        });
-    }
-    
-    // Or use singleton
-    auto& globalScheduler = LightweightScheduler::instance();
-    globalScheduler.go([]() {
-        // Work
-    });
-    
-    // Wait for completion
-    std::this_thread::sleep_for(std::chrono::seconds(5));
-    
-    // Get statistics
-    auto stats = scheduler.getStats();
-    std::cout << "Completed: " << stats.completedFibers << "\n";
-    std::cout << "Average time: " << stats.averageFiberTimeMs << "ms\n";
-    
-    scheduler.stop();
-}
-```
-
-### Integration with Existing Runtime
-
-```cpp
-// In your runtime initialization
-void Runtime::initialize() {
-    // Start global scheduler
-    auto& scheduler = LightweightScheduler::instance();
-    scheduler.setMaxWorkers(std::thread::hardware_concurrency());
-    scheduler.start();
-}
-
-// In your go statement handler
-void Runtime::executeGoStatement(ast::GoStatement* stmt) {
-    auto& scheduler = LightweightScheduler::instance();
-    
-    scheduler.go([stmt, this]() {
-        // Execute the statement in a fiber
-        this->execute(stmt->body);
-    });
-}
-```
-
-## Examples
-
-### Complete Integration Example
-
-```cpp
-#include "v8_integration/v8_runtime.h"
-#include "compiler/advanced_optimizations.h"
-#include "runtime/lightweight_scheduler.h"
-
-class AdvancedTocinRuntime {
-private:
-    std::unique_ptr<v8_integration::V8Runtime> v8_;
-    std::unique_ptr<optimization::AdvancedOptimizationPipeline> optimizer_;
-    LightweightScheduler& scheduler_;
-    
-public:
-    AdvancedTocinRuntime() 
-        : scheduler_(LightweightScheduler::instance()) {
-        
-        // Initialize V8
-        v8_ = std::make_unique<v8_integration::V8Runtime>();
-        v8_->initialize();
-        
-        // Initialize optimizer
-        optimizer_ = std::make_unique<optimization::AdvancedOptimizationPipeline>();
-        optimizer_->setOptimizationLevel(3);
-        
-        // Start scheduler
-        scheduler_.start();
-    }
-    
-    void executeJavaScript(const std::string& code) {
-        // Execute in a goroutine
-        scheduler_.go([this, code]() {
-            auto result = v8_->executeCode(code);
-            if (v8_->hasError()) {
-                std::cerr << "JS Error: " << v8_->getLastError() << "\n";
-            }
-        });
-    }
-    
-    void compileOptimized(llvm::Module* module) {
-        optimizer_->optimize(module);
-    }
-    
-    ~AdvancedTocinRuntime() {
-        scheduler_.stop();
-        v8_->shutdown();
-    }
-};
-```
-
-### Tocin Language Example
-
-```to
-// Complete example using all advanced features
-
-import ffi.javascript;
-import runtime.concurrency;
-
-// Use JavaScript for complex calculations
-ffi.javascript.eval("""
-    function complexCalculation(data) {
-        return data.map(x => Math.sin(x) * Math.cos(x))
-                   .reduce((a, b) => a + b, 0);
-    }
-""");
-
-// Process data concurrently
-func processDataset(dataset: []float) -> float {
-    let results: []float = [];
-    
-    // Launch goroutine for each chunk
-    for chunk in dataset.chunks(1000) {
-        go {
-            let jsResult = ffi.javascript.call("complexCalculation", [chunk]);
-            results.append(jsResult);
-        }
-    }
-    
-    // Wait for all results
-    sleep(1000);
-    
-    return results.sum();
-}
-
-// Main program
-func main() {
-    let data = generate_random_data(1000000);
-    let result = processDataset(data);
-    print("Final result: " + result);
-}
-```
-
-## Performance Tuning
-
-### V8 Optimization Tips
-
-1. **Warm up the V8 engine**: Execute code multiple times for JIT optimization
-2. **Reuse contexts**: Don't create new contexts frequently
-3. **Minimize type conversions**: Batch operations when possible
-
-### Compiler Optimization Tips
-
-1. **Use PGO for production**: Profile your application and rebuild with PGO
-2. **Enable LTO**: For final release builds
-3. **Tune optimization level**: Start with -O2, use -O3 for performance-critical code
-
-### Scheduler Optimization Tips
-
-1. **Match workers to CPU cores**: Use `std::thread::hardware_concurrency()`
-2. **Tune fiber stack size**: Larger stacks for deep recursion, smaller for many fibers
-3. **Batch small operations**: Don't create goroutines for tiny tasks
-
-### Memory Optimization
-
-```cpp
-// Configure for high concurrency
-scheduler.setMaxWorkers(16);
-scheduler.setFiberStackSize(4096);  // 4KB - can support millions of fibers
-
-// For lower concurrency but more stack space
-scheduler.setMaxWorkers(4);
-scheduler.setFiberStackSize(16384);  // 16KB
-```
-
-## Troubleshooting
-
-### V8 Not Found
-```
-CMake Error: Could not find V8
-```
-**Solution**: Install V8 or build with `-DWITH_V8=OFF`
-
-### Scheduler Crashes
-**Issue**: Stack overflow in fibers
-**Solution**: Increase fiber stack size:
-```cpp
-scheduler.setFiberStackSize(8192);  // 8KB or more
-```
-
-### Optimization Failures
-**Issue**: Module corruption during optimization
-**Solution**: Reduce optimization level or disable specific passes:
-```cpp
-pipeline.setOptimizationLevel(2);  // Instead of 3
-pipeline.enablePolyhedral(false);  // If polyhedral causes issues
-```
-
-## Testing
-
-Run comprehensive tests:
-```bash
-cd build
-
-# V8 tests
-./tests/v8_integration/test_v8
-
-# Optimization tests
-./tests/optimization/test_optimizations
-
-# Scheduler tests
-./tests/scheduler/test_scheduler
-
-# Benchmarks
-./benchmarks/advanced_features_bench
-```
-
-## Further Reading
-
-- [V8 Integration Roadmap](V8_INTEGRATION_ROADMAP.md)
-- [Advanced Features Documentation](ADVANCED_FEATURES.md)
-- [Architecture Overview](ARCHITECTURE.md)
-- [Performance Guide](PERFORMANCE.md)
-
-## Support
-
-For issues, questions, or contributions:
-- Open an issue on GitHub
-- Check documentation in `docs/`
-- Review test files for examples
+Exported Tocin functions use the C ABI for `int`/`float`/pointer parameters
+(see [language-reference.md §17–18](language-reference.md#17-ffi)); pair with
+`--freestanding` for runtime-free objects in kernels or embedded targets.

--- a/docs/INTERPRETER_GUIDE.md
+++ b/docs/INTERPRETER_GUIDE.md
@@ -1,337 +1,93 @@
-# Tocin Interpreter Guide
+# Running Tocin Programs
 
-## Overview
+Tocin is a **compiled** language with two execution paths — an in-process JIT
+for fast iteration and ahead-of-time native builds for deployment. (There is no
+tree-walking interpreter; this guide replaces an older document that described
+one.)
 
-The Tocin interpreter provides a powerful, Python-like experience with advanced features including JIT compilation, concurrent execution, and comprehensive error handling. This guide explains how to use the interpreter effectively and how it compares to other popular interpreters.
-
-## Interpreter Features
-
-### 1. Interactive REPL Mode
-
-Start the interpreter in REPL mode for interactive development:
+## JIT: run it now
 
 ```bash
-./tocin
+tocin app.to --run          # compile in memory and execute immediately
+echo $?                     # the exit code is main()'s return value
 ```
 
-The REPL supports:
-- Multi-line input with automatic indentation detection
-- Command history and editing
-- Tab completion (if supported by terminal)
-- Inline documentation with `help(function_name)`
-- Expression evaluation with automatic result printing
+`--run` (alias `--jit`) lowers the program to LLVM IR, JIT-compiles it with
+ORCv2, and calls `main` in-process. The runtime (GC, goroutines, channels,
+TCP/time/hash builtins) is registered automatically — no external tools are
+involved.
 
-### 2. Script Execution
-
-Execute Tocin scripts directly:
+## AOT: build a native executable
 
 ```bash
-./tocin script.to
+tocin app.to -o app         # native executable
+./app
+
+tocin app.to -o app.ll      # LLVM IR (text)
+tocin app.to -o app.s       # assembly
+tocin app.to -o app.o       # object file
 ```
 
-Options:
-- `-O0`, `-O1`, `-O2`, `-O3`: Optimization levels
-- `--jit`: Enable JIT compilation for performance
-- `--ast`: Print AST for debugging
-- `--ir`: Print LLVM IR for inspection
-- `--time`: Show execution time statistics
+The `-o` extension selects the output format. Executables link through the
+system C compiler when one is present — or through the **bundled `ld.lld` +
+static link recipe** in installed packages, which needs **no system toolchain
+at all** (see [native-linking.md](native-linking.md)).
 
-### 3. Output Format
+## Optimization
 
-The Tocin interpreter provides clear, informative output similar to Python but with enhancements:
-
-#### Expression Results
-```to
-# Tocin REPL
-> 2 + 3
-5
-
-> "Hello, " + "World!"
-"Hello, World!"
-
-> [1, 2, 3].map(x => x * 2)
-[2, 4, 6]
-```
-
-#### Function Definitions
-```to
-> def greet(name: string) -> string {
-    return "Hello, " + name;
-  }
-Function 'greet' defined successfully
-
-> greet("Alice")
-"Hello, Alice"
-```
-
-#### Error Messages
-```to
-> 1 / 0
-RuntimeError: Division by zero
-  at <stdin>:1:3
-  
-> nonexistent_var
-NameError: Variable 'nonexistent_var' is not defined
-  at <stdin>:1:1
-```
-
-## Comparison with Python Interpreter
-
-### Similarities
-- Interactive REPL with immediate feedback
-- Clear error messages with line numbers
-- Expression evaluation and auto-printing
-- Multi-line input support
-
-### Enhancements Over Python
-
-#### 1. **Built-in JIT Compilation**
 ```bash
-# Tocin with JIT
-./tocin --jit compute_heavy.to
-
-# Python (requires PyPy or manual optimization)
-python compute_heavy.py
+tocin app.to -o app -O3 --native
 ```
 
-The Tocin JIT compiler automatically optimizes hot code paths using LLVM, providing performance comparable to compiled languages.
+- `-O0`/`-O1`/`-O2`/`-O3` — LLVM's standard pipelines; the default is `-O2`.
+- `--native` — tune for the build machine's CPU (POPCNT/AVX reach the
+  vectorizer). The binary is not portable to older CPUs.
+- At `-O3`, executables and JIT runs get whole-program internalization
+  (non-`main` symbols become internal, unlocking cross-function optimization).
 
-#### 2. **Static Type Safety with Inference**
-```to
-# Tocin - Type errors caught before execution
-let x: int = 42;
-x = "hello";  // Compile-time error: Type mismatch
+## Checking without running
 
-# Python - Type errors only at runtime
-x = 42
-x = "hello"  # No error until variable is used
-```
-
-#### 3. **Built-in Concurrency Primitives**
-```to
-# Tocin - Native goroutines
-go {
-    print("Running concurrently");
-}
-
-# Python - Requires threading/asyncio
-import threading
-threading.Thread(target=lambda: print("Running concurrently")).start()
-```
-
-#### 4. **Enhanced Error Messages**
-Tocin provides detailed stack traces with context:
-
-```
-Error: Type mismatch in function call
-  Expected: int
-  Received: string
-  at main.to:15:8
-  in function 'calculate'
-  called from main.to:23:5
-  
-Suggestion: Convert the string to int using int.parse()
-```
-
-#### 5. **Performance Monitoring**
 ```bash
-./tocin --time script.to
-
-# Output includes:
-Performance Statistics:
-  Total execution time: 1.234s
-  JIT compilation time: 0.123s
-  Function calls: 1,523
-  Memory allocations: 45,678
+tocin check app.to          # typecheck only; exit 0 if clean
 ```
 
-## Advanced Features
+Fast pre-commit/CI gate: full strict diagnostics (caret underlines,
+`did you mean …?` suggestions, `N errors generated.`), no code generation.
+See [ERROR_HANDLING.md](ERROR_HANDLING.md).
 
-### Memory Management
+## Project scaffolding and docs
 
-The interpreter includes a generational garbage collector:
-
-```to
-// Objects are automatically managed
-let large_array = Array.new(1000000);
-// Memory is reclaimed when no longer needed
-```
-
-### Optimization Passes
-
-Multiple optimization levels are available:
-
-- **-O0**: No optimization (fastest compilation, useful for debugging)
-- **-O1**: Basic optimizations (constant folding, dead code elimination)
-- **-O2**: Advanced optimizations (function inlining, loop unrolling)
-- **-O3**: Aggressive optimizations (all of the above plus profile-guided optimization)
-
-### Static Analysis
-
-The interpreter performs static analysis before execution:
-
-```to
-// Detects unreachable code
-def example() {
-    return 42;
-    print("This will never execute");  // Warning: Unreachable code
-}
-
-// Detects potential null pointer dereferences
-let x: string? = null;
-print(x.length);  // Error: Possible null reference
-```
-
-## Integration with Compiler
-
-The interpreter seamlessly works with the compiler:
-
-### Compile and Execute
 ```bash
-# Compile to binary
-./tocin -o myapp myapp.to
-
-# Execute directly
-./myapp
+tocin new myapp             # creates myapp/ (main.to, README.md, .gitignore)
+tocin doc app.to > API.md   # Markdown API docs from signatures + // comments
 ```
 
-### Mixed Mode
-```bash
-# Interpret with JIT for testing
-./tocin --jit myapp.to
+## The REPL (experimental)
 
-# Then compile for production
-./tocin -O3 -o myapp myapp.to
+Running `tocin` with **no arguments** starts an experimental REPL:
+
+```text
+Tocin Enhanced REPL (type 'exit' to quit, 'clear' to reset)
+Commands: debug, package, async, macro
+>
 ```
 
-## Best Practices
+Today it **compiles each line and prints the resulting LLVM IR** — useful for
+inspecting codegen, but it does *not* evaluate expressions or print their
+values, and it has no history or completion. For interactive experimentation,
+prefer editing a file and re-running `tocin file.to --run` (the JIT makes this
+near-instant).
 
-### 1. Use Type Annotations
-```to
-// Good: Clear types for better performance and error detection
-def calculate(x: int, y: int) -> int {
-    return x + y;
-}
+## Environment
 
-// Avoid: Type inference works but is slower
-def calculate(x, y) {
-    return x + y;
-}
-```
+| Variable | Effect |
+|---|---|
+| `TOCIN_PATH` | Root directory searched for `import` resolution (installers set it to the bundled `stdlib/`). |
+| `NO_COLOR` | Disable ANSI colors in diagnostics. |
+| `CC` | Choose the C-compiler driver for `-o` linking when the system path is used. |
 
-### 2. Enable JIT for Long-Running Scripts
-```bash
-# For scripts with loops or recursive functions
-./tocin --jit -O2 script.to
-```
+## See also
 
-### 3. Use Concurrency for I/O-Bound Tasks
-```to
-// Good: Non-blocking I/O
-async def fetch_data(url: string) -> string {
-    return await http.get(url);
-}
-
-// Use goroutines for CPU-bound parallel work
-def process_large_dataset(data: Array<int>) {
-    let chunks = data.chunk(1000);
-    for chunk in chunks {
-        go {
-            process_chunk(chunk);
-        }
-    }
-}
-```
-
-### 4. Profile Before Optimizing
-```bash
-./tocin --time --profile script.to
-```
-
-## Debugging
-
-### Interactive Debugging
-```to
-// Set breakpoints in code
-debug.breakpoint();
-
-// Inspect variables
-debug.print_locals();
-
-// Step through execution
-debug.step();
-```
-
-### Verbose Error Mode
-```bash
-./tocin --verbose --stack-trace script.to
-```
-
-## Performance Tips
-
-### 1. **Leverage JIT Compilation**
-The JIT compiler optimizes frequently executed code paths automatically.
-
-### 2. **Use Appropriate Data Structures**
-```to
-// Fast: Specialized collections
-let numbers = IntArray.new(1000);
-
-// Slower: Generic arrays
-let numbers = Array.new(1000);
-```
-
-### 3. **Minimize Allocations**
-```to
-// Good: Reuse objects
-let buffer = String.with_capacity(1000);
-for item in items {
-    buffer.clear();
-    buffer.append(item.to_string());
-    process(buffer);
-}
-
-// Avoid: Creating new strings in loop
-for item in items {
-    process(item.to_string());  // Allocates each iteration
-}
-```
-
-### 4. **Use Parallel Processing**
-```to
-// Process data in parallel
-let results = data
-    .parallel()
-    .map(x => expensive_computation(x))
-    .collect();
-```
-
-## Troubleshooting
-
-### Common Issues
-
-#### 1. "JIT compilation failed"
-- Check LLVM installation
-- Ensure sufficient memory
-- Try lower optimization level
-
-#### 2. "Stack overflow"
-- Check for infinite recursion
-- Increase stack size if needed: `--stack-size=16M`
-
-#### 3. "Type inference failed"
-- Add explicit type annotations
-- Check for circular type dependencies
-
-## Future Enhancements
-
-The interpreter will continue to evolve with:
-- **Language Server Protocol (LSP)**: IDE integration with autocomplete and refactoring
-- **Interactive Debugger**: Step-through debugging with breakpoints
-- **Profiler Integration**: Visual performance profiling tools
-- **Remote Execution**: Run interpreter on remote machines
-- **Notebook Support**: Jupyter-style notebook interface
-
-## Conclusion
-
-The Tocin interpreter combines the ease of use of Python with the performance of compiled languages, providing a superior development experience for modern applications. Its advanced features like JIT compilation, built-in concurrency, and comprehensive error handling make it ideal for both rapid prototyping and production deployment.
+- [language-reference.md §19](language-reference.md#19-compilation--execution) — the full CLI table.
+- [ERROR_HANDLING.md](ERROR_HANDLING.md) — diagnostics and runtime traps.
+- [../INSTALL.md](../INSTALL.md) — installing a released Tocin.

--- a/docs/LANGUAGE_FEATURES.md
+++ b/docs/LANGUAGE_FEATURES.md
@@ -38,7 +38,7 @@ let failure: Result<int, string> = Err("Something went wrong");
 Tocin supports generic types and functions:
 
 ```tocin
-fn identity<T>(value: T) -> T {
+def identity<T>(value: T) -> T {
     return value;
 }
 
@@ -55,11 +55,11 @@ Traits define behavior that types can implement:
 
 ```tocin
 trait ToString {
-    fn toString() -> string;
+    def toString() -> string;
 }
 
 impl ToString for int {
-    fn toString() -> string {
+    def toString() -> string {
         // Implementation
     }
 }
@@ -95,7 +95,7 @@ match point {
 Lightweight threads for concurrent execution:
 
 ```tocin
-fn computeValue() -> int {
+def computeValue() -> int {
     // Some computation
     return 42;
 }
@@ -141,7 +141,7 @@ select {
 Tocin uses the Result type for explicit error handling without exceptions:
 
 ```tocin
-fn divide(a: float, b: float) -> Result<float, string> {
+def divide(a: float, b: float) -> Result<float, string> {
     if b == 0.0 {
         return Err("Division by zero");
     }
@@ -149,7 +149,7 @@ fn divide(a: float, b: float) -> Result<float, string> {
 }
 
 // Using the ? operator for error propagation
-fn calculate(a: float, b: float) -> Result<float, string> {
+def calculate(a: float, b: float) -> Result<float, string> {
     let result = divide(a, b)?;  // Returns Err if divide returns Err
     return Ok(result * 2);
 }
@@ -175,7 +175,7 @@ match optionalName {
 }
 
 // Safe access using the ? operator
-fn greet(optionalName: Option<string>) -> Option<string> {
+def greet(optionalName: Option<string>) -> Option<string> {
     let name = optionalName?;  // Returns None if optionalName is None
     return Some("Hello, " + name);
 }
@@ -186,7 +186,7 @@ fn greet(optionalName: Option<string>) -> Option<string> {
 The `defer` statement ensures that a function call is performed when the current function returns:
 
 ```tocin
-fn processFile(path: string) -> Result<string, string> {
+def processFile(path: string) -> Result<string, string> {
     let file = open(path)?;
     defer file.close();  // Will be called when function returns
 
@@ -231,7 +231,7 @@ Add methods to existing types without inheritance:
 ```tocin
 // Add a method to the string type
 extension string {
-    fn capitalize() -> string {
+    def capitalize() -> string {
         if self.length() == 0 {
             return self;
         }
@@ -254,12 +254,12 @@ struct Buffer {
     data: Array<byte>;
     
     // Move constructor
-    fn move(self) -> Buffer {
+    def move(self) -> Buffer {
         return Buffer { data: self.data.move() };
     }
     
     // Access after move is a compile error
-    fn use() {
+    def use() {
         let buf1 = Buffer { data: [1, 2, 3] };
         let buf2 = buf1.move();
         
@@ -284,17 +284,17 @@ struct Buffer {
 ```tocin
 // Call C functions
 extern "C" {
-    fn printf(format: string, ...): int;
+    def printf(format: string, ...): int;
 }
 
 // Call JavaScript (through V8)
 extern "js" {
-    fn alert(message: string): void;
+    def alert(message: string): void;
 }
 
 // Call Python (through Python C API)
 extern "python" {
-    fn numpy_array(data: Array<float>): PyObject;
+    def numpy_array(data: Array<float>): PyObject;
 }
 ```
 
@@ -302,7 +302,7 @@ extern "python" {
 
 See the `examples/` directory for demonstration programs showing these features in action:
 
-- `option_result_demo.tc`: Shows Option and Result types
-- `traits_demo.tc`: Demonstrates the trait system
-- `concurrency_demo.tc`: Shows goroutines and channels
-- `pattern_matching_demo.tc`: Shows pattern matching capabilities 
+- `option_result_demo.to`: Shows Option and Result types
+- `traits_demo.to`: Demonstrates the trait system
+- `concurrency_demo.to`: Shows goroutines and channels
+- `pattern_matching_demo.to`: Shows pattern matching capabilities 

--- a/docs/LINQ.md
+++ b/docs/LINQ.md
@@ -1,42 +1,106 @@
-# LINQ in Tocin
+# Query-Style Operations (LINQ)
 
-LINQ (Language Integrated Query) in Tocin provides expressive, chainable operations for working with collections. Inspired by C# and functional languages, LINQ makes data transformation and querying concise and readable.
+Tocin's query facilities are ordinary functions, not extension methods:
+**method-style chaining (`xs.where(...).select(...)`) is not part of the
+language.** Two modules cover the same ground over `list<int>`:
 
-## Basic Usage
-```to
-let numbers = [1, 2, 3, 4, 5];
-let evens = numbers.where(x => x % 2 == 0);
-let squares = numbers.select(x => x * x);
+- `std.linq` — reductions/aggregations and `*Into` transforms that take plain
+  parameters (thresholds, scale factors, operation codes);
+- `std.functional` — higher-order `map`/`filter`/`fold` functions that take
+  function values (named functions or lambdas).
+
+Both follow the stdlib conventions: predicates return `int` `1`/`0`, and
+imported names are called bare (no namespacing).
+
+## std.linq
+
+| Function | Description |
+|---|---|
+| `reduceSum(xs: list<int>) -> int` | Sum of the elements |
+| `reduceProduct(xs: list<int>) -> int` | Product of the elements |
+| `aggregate(xs: list<int>, seed: int, op: int) -> int` | Fold with a seed and an op code: `0` add, `1` multiply, `2` max, `3` min |
+| `count(xs: list<int>) -> int` | Element count (`len`) |
+| `countGreater(xs: list<int>, threshold: int) -> int` | How many elements exceed `threshold` |
+| `indexOf(xs: list<int>, target: int) -> int` | First index of `target`, `-1` if absent |
+| `allGreater(xs: list<int>, threshold: int) -> int` | `1` if every element exceeds `threshold` |
+| `anyGreater(xs: list<int>, threshold: int) -> int` | `1` if any element exceeds `threshold` |
+| `mapScaleInto(dst, src: list<int>, k: int) -> int` | Write `src[i] * k` into `dst`; returns the count |
+| `mapAddInto(dst, src: list<int>, k: int) -> int` | Write `src[i] + k` into `dst`; returns the count |
+| `filterGreaterInto(dst, src: list<int>, threshold: int) -> int` | Copy elements `> threshold` into `dst`; returns how many were written |
+
+The `*Into` transforms write into a caller-allocated destination list at least
+as long as the source, instead of returning a fresh list. Verified example:
+
+```tocin
+import std.linq;
+
+def main() {
+    let xs = [3, 1, 4, 1, 5, 9, 2, 6];
+    println("sum {}  product {}", reduceSum(xs), reduceProduct(xs));
+    println("max {}  over3 {}", aggregate(xs, xs[0], 2), countGreater(xs, 3));
+    let dst = [0, 0, 0, 0, 0, 0, 0, 0];
+    let n = filterGreaterInto(dst, xs, 3);
+    println("kept {}  first {}", n, dst[0]);
+    return 0;
+}
 ```
 
-## Supported Operations
-- `where(predicate)`: Filter elements
-- `select(selector)`: Transform elements
-- `order_by(key_selector)`: Sort elements
-- `first()`, `last()`: Get first/last element
-- `count()`: Number of elements
-- `any(predicate)`, `all(predicate)`: Boolean checks
-- `sum()`, `avg()`, `min()`, `max()`: Aggregates
-
-## Chaining
-LINQ operations can be chained for complex queries:
-```to
-let result = numbers.where(x => x > 2).select(x => x * 10).order_by(x => -x);
+```text
+sum 31  product 6480
+max 9  over3 4
+kept 4  first 4
 ```
 
-## Type Inference
-- The type of each operation is inferred automatically.
-- `select` infers the result type from the selector function.
-- Aggregates return the appropriate type (e.g., `sum()` returns the element type).
+## std.functional
 
-## Best Practices
-- Use LINQ for readable, declarative data processing.
-- Avoid deeply nested or overly complex chains—break into steps if needed.
-- Use type annotations for clarity in complex queries.
+These take function-typed parameters, so the transformation itself is an
+argument — a top-level `def` or a `lambda` (which captures enclosing locals
+by value):
 
-## Troubleshooting
-- **Type errors:** Ensure selector/predicate functions have the correct signature.
-- **Operation not supported:** Check that the collection type supports LINQ (e.g., list, array).
-- **Null values:** Use null safety features to avoid runtime errors.
+| Function | Description |
+|---|---|
+| `mapInts(xs: list<int>, f: (int) -> int) -> list<int>` | New list of `f(x)` for each element |
+| `filterInts(xs: list<int>, pred: (int) -> int) -> list<int>` | New list of elements where `pred(x) != 0` |
+| `foldInts(xs: list<int>, init: int, f: (int, int) -> int) -> int` | Left fold: `f(acc, x)` |
+| `zipWith(a: list<int>, b: list<int>, f: (int, int) -> int) -> list<int>` | Element-wise combine of two lists |
+| `anyInt(xs, pred)` / `allInt(xs, pred)` | `1` if any / every element satisfies `pred` |
+| `countWhere(xs: list<int>, pred: (int) -> int) -> int` | How many elements satisfy `pred` |
+| `findFirst(xs: list<int>, pred: (int) -> int, dflt: int) -> int` | First matching element, or `dflt` |
+| `takeWhile(xs, pred)` / `dropWhile(xs, pred)` | Longest matching prefix / everything after it |
+| `rangeList(start: int, end: int) -> list<int>` | Half-open integer range `[start, end)` |
+| `reversed(xs: list<int>) -> list<int>` | Reversed copy |
+| `concatInts(a: list<int>, b: list<int>) -> list<int>` | Concatenated copy |
 
-See also: [Language Basics](03_Language_Basics.md), [Standard Library](04_Standard_Library.md) 
+Verified example with lambdas:
+
+```tocin
+import std.functional;
+
+def main() {
+    let xs = rangeList(1, 6);                                   // [1, 2, 3, 4, 5]
+    let sq = mapInts(xs, lambda (x: int) -> int x * x);
+    println("{} {} {}", sq[0], sq[4], len(sq));
+    let odd = filterInts(xs, lambda (x: int) -> int x % 2);
+    println("{}", foldInts(odd, 0, lambda (a: int, b: int) -> int a + b));
+    return 0;
+}
+```
+
+```text
+1 25 5
+9
+```
+
+## Limitations
+
+- Both modules operate on `list<int>` today. For float data use the
+  `list<float>` functions in `math.stats` (`mean`, `median`, ...) and
+  `math.stats_advanced`.
+- There is no chaining and no lazy evaluation: compose by nesting calls or
+  binding intermediate `let`s, as above.
+- `std.functional`'s `countWhere` clashes with a same-named function in
+  `database.database`; do not import both modules into one program.
+
+See also: [language-reference.md](language-reference.md) (lambdas and function
+types), [stdlib-reference.md](stdlib-reference.md) (builtins and the
+`std.linq` walkthrough), [04_Standard_Library.md](04_Standard_Library.md).

--- a/docs/NULL_SAFETY.md
+++ b/docs/NULL_SAFETY.md
@@ -21,10 +21,10 @@ Provide a default value if null:
 let value = s ?: "default";
 ```
 
-## Not-Null Assertion (`!`)
+## Not-Null Assertion (`!!`)
 Assert that a value is not null (throws if null):
 ```to
-let force_len = s!.length; // Throws if s is null
+let force_len = s!!.length; // Throws if s is null
 ```
 
 ## Best Practices
@@ -34,7 +34,7 @@ let force_len = s!.length; // Throws if s is null
 
 ## Troubleshooting
 - **Safe call on non-nullable:** Only use `?.` on nullable types.
-- **Not-null assertion failed:** Ensure the value is not null before using `!`.
+- **Not-null assertion failed:** Ensure the value is not null before using `!!`.
 - **Type mismatch:** Assigning null to a non-nullable type is an error.
 
 See also: [Language Basics](03_Language_Basics.md), [Advanced Topics](05_Advanced_Topics.md) 

--- a/docs/OPTION_RESULT_TYPES.md
+++ b/docs/OPTION_RESULT_TYPES.md
@@ -31,7 +31,7 @@ match name {
 The `?` operator provides a convenient way to propagate `None` values:
 
 ```tocin
-fn process_name(name: Option<string>) -> Option<string> {
+def process_name(name: Option<string>) -> Option<string> {
     // If name is None, the function returns None immediately
     // If name is Some(value), value is extracted and assigned to x
     let x = name?;
@@ -68,7 +68,7 @@ match divide(10.0, 2.0) {
 The `?` operator works with Result types to propagate errors:
 
 ```tocin
-fn calculate(a: float, b: float) -> Result<float, string> {
+def calculate(a: float, b: float) -> Result<float, string> {
     // If divide returns Err, the function returns that error immediately
     // If divide returns Ok(value), value is extracted and assigned to result
     let result = divide(a, b)?;
@@ -94,7 +94,7 @@ You can convert between Option and Result types:
 
 ```tocin
 // Convert an Option to a Result
-fn option_to_result<T>(opt: Option<T>, error: E) -> Result<T, E> {
+def option_to_result<T>(opt: Option<T>, error: E) -> Result<T, E> {
     match opt {
         Some(value) => Ok(value),
         None => Err(error)
@@ -102,7 +102,7 @@ fn option_to_result<T>(opt: Option<T>, error: E) -> Result<T, E> {
 }
 
 // Convert a Result to an Option
-fn result_to_option<T, E>(res: Result<T, E>) -> Option<T> {
+def result_to_option<T, E>(res: Result<T, E>) -> Option<T> {
     match res {
         Ok(value) => Some(value),
         Err(_) => None

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -6,7 +6,7 @@ Writing fast, efficient Tocin code is easy with the right techniques. Here are s
 - **Prefer immutable data** where possible for easier reasoning and optimization.
 - **Use built-in types and stdlib functions**—they are highly optimized.
 - **Minimize allocations** in tight loops (reuse objects, use preallocated lists).
-- **Avoid deep recursion** unless tail call optimization is guaranteed.
+- **Avoid deep recursion**—Tocin does not guarantee tail-call optimization, so prefer iteration for unbounded depth.
 
 ## Collections and LINQ
 - **Chain LINQ operations** efficiently; avoid unnecessary intermediate collections.
@@ -38,4 +38,4 @@ Writing fast, efficient Tocin code is easy with the right techniques. Here are s
 - **High memory usage:** Check for unnecessary allocations or large data structures.
 - **FFI slowdowns:** Minimize cross-language calls in performance-critical code.
 
-See also: [BENCHMARKS.md](../../BENCHMARKS.md) 
+See also: [Building](BUILDING.md), [Advanced Topics](05_Advanced_Topics.md) 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,251 +1,64 @@
-# Tocin Compiler Documentation
+# Tocin Documentation
 
-## Overview
+The documentation set for the Tocin language and compiler. Start here.
 
-This directory contains comprehensive documentation for the Tocin programming language compiler and interpreter.
+## Start here
 
-## Documentation Index
+| Doc | What it is |
+|---|---|
+| [tutorial.md](tutorial.md) | **The from-scratch walkthrough** — install, first program, then every feature with runnable code. The best way to learn Tocin. |
+| [02_Getting_Started.md](02_Getting_Started.md) | Install the toolchain and run/compile your first programs (`--run`, `-o`, `check`, `new`, `doc`). |
+| [01_Introduction.md](01_Introduction.md) | What Tocin is and its design goals. |
+| [../INSTALL.md](../INSTALL.md) | **Installing a released Tocin** — native installers (Windows Setup.exe, .deb, .run, macOS .pkg/.dmg), quick-install one-liners, and manual installs. |
 
-### Getting Started
-- **[README.md](../README.md)** - Main project README with quick start guide
-- **[QUICK_START.md](../QUICK_START.md)** - Quick start guide for new users
-- **[CONTRIBUTING.md](../CONTRIBUTING.md)** - How to contribute to the project
+## Reference
 
-### Architecture & Design
-- **[ARCHITECTURE.md](ARCHITECTURE.md)** - Complete compiler and interpreter architecture
-  - System overview with diagrams
-  - Component descriptions (Lexer, Parser, Type Checker, IR Generator)
-  - V8 engine integration architecture
-  - Goroutine scheduler design
-  - Runtime system details
-  - Performance characteristics
+| Doc | What it is |
+|---|---|
+| [language-reference.md](language-reference.md) | **The authoritative reference** — grammar, types, operators & precedence, every statement and feature, diagnostics, CLI, memory model, and the built-in function reference. Every snippet verified against the in-tree compiler. |
+| [stdlib-reference.md](stdlib-reference.md) | Every built-in (no-import) function with signatures and examples. |
+| [04_Standard_Library.md](04_Standard_Library.md) | Guided tour of the 34 standard-library modules (`std`, `data`, `math`, `ml`, `web`, `game`, `gui`, …). |
+| [STDLIB_GUIDE.md](STDLIB_GUIDE.md) | Practical stdlib guide — imports, `TOCIN_PATH`, writing tests with `std.testing`. |
+| [tocin-for-ai.md](tocin-for-ai.md) | A dense, exact spec of the implemented language for LLMs/tooling — write correct Tocin on the first try. |
 
-- **[LEXER_PARSER_ENHANCEMENTS.md](LEXER_PARSER_ENHANCEMENTS.md)** - Lexer and parser implementation details
-  - Advanced features (indentation, string interpolation, error recovery)
-  - AST structure and transformations
-  - IR generation roadmap
-  - Testing strategies
+## Language topics
 
-### User Guides
-- **[INTERPRETER_GUIDE.md](INTERPRETER_GUIDE.md)** - Interpreter usage guide
-  - Interactive REPL mode
-  - Output format (comparison with Python)
-  - JIT compilation
-  - Performance tips
-  - Debugging techniques
+| Doc | What it is |
+|---|---|
+| [03_Language_Basics.md](03_Language_Basics.md) | Variables, control flow, functions, classes. |
+| [ERROR_HANDLING.md](ERROR_HANDLING.md) | Strict diagnostics, runtime panics/traps, exceptions, `Option`/`Result`. |
+| [NULL_SAFETY.md](NULL_SAFETY.md) | `?.`, `?:`, `!!` over nullable references. |
+| [OPTION_RESULT_TYPES.md](OPTION_RESULT_TYPES.md) | `Some`/`None`/`Ok`/`Err` and pattern matching. |
+| [TRAITS.md](TRAITS.md) | Traits, `impl` blocks, trait objects. |
+| [CONCURRENCY.md](CONCURRENCY.md) | Goroutines, channels, `select`. |
+| [LINQ.md](LINQ.md) | Query-style collection operations (`std.linq`, `std.functional`). |
+| [LANGUAGE_FEATURES.md](LANGUAGE_FEATURES.md) | Feature survey with examples. |
+| [05_Advanced_Topics.md](05_Advanced_Topics.md) | Ownership, advanced generics, FFI, WASM (partly design-intent — see the note at its top). |
+| [ffi.md](ffi.md) | Calling C from Tocin (`extern def`); Python/JS FFI status. |
 
-- **[INSTALLER_GUIDE.md](INSTALLER_GUIDE.md)** - Installing Tocin
-  - Windows installer (NSIS)
-  - Linux packages (DEB/RPM/AppImage)
-  - macOS installer (DMG/Homebrew)
-  - Building custom installers
-  - Troubleshooting
+## Building, running, performance
 
-- **[STDLIB_GUIDE.md](STDLIB_GUIDE.md)** - Standard Library documentation
-  - All stdlib modules with examples
-  - Math, Data Structures, Web, Database, ML, Game Dev, etc.
-  - Usage patterns
-  - Performance considerations
+| Doc | What it is |
+|---|---|
+| [BUILDING.md](BUILDING.md) | Building the compiler from source (CMake + LLVM 18–22). |
+| [INTERPRETER_GUIDE.md](INTERPRETER_GUIDE.md) | Running programs: the JIT (`--run`), native builds (`-o`), and what the REPL actually does. |
+| [INSTALLER_GUIDE.md](INSTALLER_GUIDE.md) | Building the native installers (points at the real `installer/` scripts). |
+| [native-linking.md](native-linking.md) | How `tocin file.to -o app` links with **no system compiler** (bundled `ld.lld` + static recipe). |
+| [PERFORMANCE.md](PERFORMANCE.md) | Performance practices. |
+| [capability-report.md](capability-report.md) | **Honest assessment** of what Tocin can build today, with measurements. |
 
-### Implementation Reports
-- **[INTERPRETER_COMPLETION.md](../INTERPRETER_COMPLETION.md)** - Interpreter completion report
-- **[FINAL_REPORT.md](../FINAL_REPORT.md)** - Final implementation report
-- **[COMPLETION_SUMMARY.md](../COMPLETION_SUMMARY.md)** - Completion summary
+## Compiler internals
 
-## Documentation by Topic
+| Doc | What it is |
+|---|---|
+| [ARCHITECTURE.md](ARCHITECTURE.md) | The compiler pipeline: lexer → parser → type checker → LLVM IR → JIT/AOT. |
+| [ADVANCED_FEATURES.md](ADVANCED_FEATURES.md) | Notes on optional/experimental C++ subsystems. |
+| [async-scheduler-design.md](async-scheduler-design.md) | Design for the M:N async scheduler (eager async ships today). |
+| [INTEGRATION_GUIDE.md](INTEGRATION_GUIDE.md) | Embedding/interop status: what is wired in and what is scaffolding. |
 
-### For Users
+## Contributing
 
-**I want to learn Tocin:**
-1. Start with [QUICK_START.md](../QUICK_START.md)
-2. Read [INTERPRETER_GUIDE.md](INTERPRETER_GUIDE.md)
-3. Explore [STDLIB_GUIDE.md](STDLIB_GUIDE.md)
-
-**I want to install Tocin:**
-- Follow [INSTALLER_GUIDE.md](INSTALLER_GUIDE.md)
-
-**I want to understand how things work:**
-- Read [ARCHITECTURE.md](ARCHITECTURE.md)
-- Check [LEXER_PARSER_ENHANCEMENTS.md](LEXER_PARSER_ENHANCEMENTS.md)
-
-### For Contributors
-
-**I want to contribute:**
-1. Read [CONTRIBUTING.md](../CONTRIBUTING.md)
-2. Understand [ARCHITECTURE.md](ARCHITECTURE.md)
-3. Review [LEXER_PARSER_ENHANCEMENTS.md](LEXER_PARSER_ENHANCEMENTS.md)
-
-**I want to understand the implementation:**
-- [ARCHITECTURE.md](ARCHITECTURE.md) - Overall design
-- [INTERPRETER_COMPLETION.md](../INTERPRETER_COMPLETION.md) - Implementation details
-- [FINAL_REPORT.md](../FINAL_REPORT.md) - Features and status
-
-### For Maintainers
-
-**I need to build installers:**
-- [INSTALLER_GUIDE.md](INSTALLER_GUIDE.md) - Installer building process
-
-**I need to understand the codebase:**
-- [ARCHITECTURE.md](ARCHITECTURE.md) - High-level architecture
-- [LEXER_PARSER_ENHANCEMENTS.md](LEXER_PARSER_ENHANCEMENTS.md) - Compiler internals
-
-## Quick Reference
-
-### Language Features
-
-| Feature | Status | Documentation |
-|---------|--------|---------------|
-| Strong Static Typing | ✅ Complete | [ARCHITECTURE.md](ARCHITECTURE.md#type-checker) |
-| Type Inference | ✅ Complete | [ARCHITECTURE.md](ARCHITECTURE.md#type-system) |
-| Traits | ✅ Complete | [STDLIB_GUIDE.md](STDLIB_GUIDE.md) |
-| LINQ Operations | ✅ Complete | [STDLIB_GUIDE.md](STDLIB_GUIDE.md#data-structures--algorithms) |
-| Null Safety | ✅ Complete | [ARCHITECTURE.md](ARCHITECTURE.md#type-checker) |
-| Pattern Matching | ✅ Complete | [LEXER_PARSER_ENHANCEMENTS.md](LEXER_PARSER_ENHANCEMENTS.md#pattern-matching) |
-| Async/Await | ✅ Complete | [ARCHITECTURE.md](ARCHITECTURE.md#runtime-system) |
-| Goroutines | ✅ Complete | [ARCHITECTURE.md](ARCHITECTURE.md#goroutine-scheduler) |
-| Channels | ✅ Complete | [ARCHITECTURE.md](ARCHITECTURE.md#concurrency-primitives) |
-| FFI (C/Python/JS) | ✅ Complete | [ARCHITECTURE.md](ARCHITECTURE.md#v8-integration) |
-| JIT Compilation | ✅ Complete | [INTERPRETER_GUIDE.md](INTERPRETER_GUIDE.md#jit-compilation) |
-| Binary Generation | ✅ Complete | [INSTALLER_GUIDE.md](INSTALLER_GUIDE.md) |
-
-### Compilation Pipeline
-
-```
-Source Code (.to)
-    ↓
-Lexer (Tokenization)
-    ↓
-Parser (AST Construction)
-    ↓
-Type Checker (Semantic Analysis)
-    ↓
-IR Generator (LLVM IR)
-    ↓
-Optimizer (Multiple Passes)
-    ↓
-Either:
-  → Interpreter (Direct Execution or JIT)
-  → Code Generator (Native Binary)
-```
-
-See [ARCHITECTURE.md](ARCHITECTURE.md) for detailed pipeline documentation.
-
-### Standard Library Modules
-
-| Module | Description | Documentation |
-|--------|-------------|---------------|
-| `math/*` | Mathematical operations | [STDLIB_GUIDE.md](STDLIB_GUIDE.md#math) |
-| `data/*` | Data structures & algorithms | [STDLIB_GUIDE.md](STDLIB_GUIDE.md#data-structures--algorithms) |
-| `web/*` | HTTP, WebSocket | [STDLIB_GUIDE.md](STDLIB_GUIDE.md#web--networking) |
-| `database/*` | Database connectivity | [STDLIB_GUIDE.md](STDLIB_GUIDE.md#database) |
-| `ml/*` | Machine learning | [STDLIB_GUIDE.md](STDLIB_GUIDE.md#machine-learning) |
-| `game/*` | Game engine | [STDLIB_GUIDE.md](STDLIB_GUIDE.md#game-development) |
-| `gui/*` | GUI framework | [STDLIB_GUIDE.md](STDLIB_GUIDE.md#gui) |
-| `audio/*` | Audio processing | [STDLIB_GUIDE.md](STDLIB_GUIDE.md#audio) |
-| `embedded/*` | GPIO, embedded systems | [STDLIB_GUIDE.md](STDLIB_GUIDE.md#embedded-systems) |
-| `pkg/*` | Package management | [STDLIB_GUIDE.md](STDLIB_GUIDE.md#package-management) |
-| `scripting/*` | Automation | [STDLIB_GUIDE.md](STDLIB_GUIDE.md#scripting--automation) |
-
-### Build Configurations
-
-| Configuration | Description | Use Case |
-|---------------|-------------|----------|
-| `-O0` | No optimization | Debugging |
-| `-O1` | Basic optimization | Development |
-| `-O2` | Standard optimization | Production |
-| `-O3` | Aggressive optimization | Performance-critical |
-| `--jit` | JIT compilation | Interactive/Testing |
-| `--ast` | Print AST | Debugging |
-| `--ir` | Print LLVM IR | Optimization analysis |
-
-See [INTERPRETER_GUIDE.md](INTERPRETER_GUIDE.md#optimization-passes) for details.
-
-## Additional Resources
-
-### Examples
-- **[../examples/](../examples/)** - Example programs demonstrating features
-  - `concurrency_demo.to` - Goroutines and channels
-  - `traits_demo.to` - Trait usage
-  - `web_demo.to` - Web server example
-  - `ml_demo.to` - Machine learning example
-  - `game_demo.to` - Game development example
-
-### Tests
-- **[../tests/](../tests/)** - Test suite for compiler and runtime
-- **[../test_interpreter_completion.py](../test_interpreter_completion.py)** - Interpreter tests
-
-### Standard Library
-- **[../stdlib/](../stdlib/)** - Complete standard library implementation
-
-## Documentation Conventions
-
-### Code Examples
-
-Tocin code examples use the `.to` extension:
-
-```to
-// This is Tocin code
-def greet(name: string) -> string {
-    return f"Hello, {name}!";
-}
-```
-
-C++ implementation examples are marked:
-
-```cpp
-// This is C++ implementation code
-void IRGenerator::generate(ast::StmtPtr stmt) {
-    stmt->accept(*this);
-}
-```
-
-### Status Indicators
-
-- ✅ Complete - Feature is implemented and tested
-- 🔄 In Progress - Feature is being implemented
-- 📋 Planned - Feature is planned but not started
-- ⏳ Pending - Feature depends on other work
-
-### File Structure
-
-Documentation files follow this structure:
-1. **Overview** - Brief description
-2. **Table of Contents** - Navigation
-3. **Main Content** - Detailed information
-4. **Examples** - Code examples
-5. **References** - Links to related docs
-
-## Contributing to Documentation
-
-To improve documentation:
-
-1. **Fix Errors**: Submit PR with corrections
-2. **Add Examples**: Provide clear, working examples
-3. **Clarify**: Improve unclear sections
-4. **Expand**: Add missing information
-5. **Maintain**: Keep documentation in sync with code
-
-### Documentation Style Guide
-
-- Use **clear, concise language**
-- Include **code examples** for concepts
-- Provide **both simple and advanced examples**
-- Link to **related documentation**
-- Keep **consistent formatting**
-- Update **index and TOC** when adding content
-
-## Getting Help
-
-- **Issues**: https://github.com/tafolabi009/tocin-compiler/issues
-- **Discussions**: https://github.com/tafolabi009/tocin-compiler/discussions
-- **Email**: dev@tocin.dev (if available)
-
-## License
-
-Documentation is licensed under the MIT License, same as the compiler.
-
----
-
-**Last Updated**: 2024
-**Compiler Version**: 1.0.0
-**Documentation Version**: 1.0.0
+See [../CONTRIBUTING.md](../CONTRIBUTING.md). When adding a language feature,
+include a `.to` test under `tests/` (JIT/runtime tests go in `tests/jit/`,
+lli-compatible ones in `tests/cases/`) and update
+[language-reference.md](language-reference.md).

--- a/docs/STDLIB_GUIDE.md
+++ b/docs/STDLIB_GUIDE.md
@@ -1,658 +1,190 @@
-# Tocin Standard Library Documentation
+# Tocin Standard Library Guide
 
-## Overview
+A practical guide to finding, importing, and testing against the standard
+library. For a module-by-module tour with function tables see
+[04_Standard_Library.md](04_Standard_Library.md); for the built-in functions
+that need no import see [stdlib-reference.md](stdlib-reference.md).
 
-The Tocin standard library provides a comprehensive set of modules for various programming domains. All modules are written in pure Tocin and demonstrate the language's advanced features.
+## Finding modules
 
-## Table of Contents
+The library is plain Tocin source under `stdlib/`, organized into domain
+directories. The import path is the file path: `import data.algorithms;`
+loads `data/algorithms.to`.
 
-1. [Math](#math)
-2. [Data Structures & Algorithms](#data-structures--algorithms)
-3. [Web & Networking](#web--networking)
-4. [Database](#database)
-5. [Machine Learning](#machine-learning)
-6. [Game Development](#game-development)
-7. [GUI](#gui)
-8. [Audio](#audio)
-9. [Embedded Systems](#embedded-systems)
-10. [Package Management](#package-management)
-11. [Scripting & Automation](#scripting--automation)
-
-## Math
-
-### Module: `math/basic.to`
-
-Provides fundamental mathematical operations and constants.
-
-**Constants:**
-```to
-const PI: float = 3.14159265358979323846;
-const E: float = 2.71828182845904523536;
-const SQRT2: float = 1.41421356237309504880;
-const INFINITY: float = 1.0 / 0.0;
-const NAN: float = 0.0 / 0.0;
+```text
+stdlib/
+├── std/          math.to  list.to  functional.to  linq.to  strings.to
+│                 strseq.to  json.to  testing.to
+├── data/         algorithms.to  structures.to  collections.to
+├── math/         basic.to  linear.to  geometry.to  stats.to
+│                 stats_advanced.to  differential.to
+├── ml/           neural_network.to  deep_learning.to  computer_vision.to  ten.to
+├── web/          http.to  websocket.to
+├── net/          advanced.to
+├── database/     database.to
+├── game/         engine.to  graphics.to  shader.to
+├── gui/          core.to  widgets.to
+├── audio/        audio.to
+├── embedded/     gpio.to
+├── scripting/    automation.to
+└── pkg/          manager.to
 ```
 
-**Functions:**
-- `abs(x: number) -> number` - Absolute value
-- `sign(x: number) -> int` - Sign of number (-1, 0, 1)
-- `floor(x: float) -> int` - Floor function
-- `ceil(x: float) -> int` - Ceiling function
-- `round(x: float) -> int` - Round to nearest integer
-- `min(...args: Array<number>) -> number` - Minimum value
-- `max(...args: Array<number>) -> number` - Maximum value
-- `clamp(x, min_val, max_val: number) -> number` - Clamp value to range
-- `sqrt(x: number) -> float` - Square root
-- `pow(x, y: number) -> number` - Power function
-- `log(x: number) -> float` - Natural logarithm
-- `exp(x: number) -> float` - Exponential function
-- `sin(x: number) -> float` - Sine function
-- `cos(x: number) -> float` - Cosine function
-- `tan(x: number) -> float` - Tangent function
+Each file opens with a comment describing its scope, and every public function
+carries a doc comment — `grep "^def " stdlib/std/strings.to` is a quick way to
+see a module's API.
 
-**Example:**
-```to
-import math.basic;
+## Import mechanics
 
-let angle = math.basic.PI / 4;
-let sine = math.basic.sin(angle);
-let cosine = math.basic.cos(angle);
-
-print(f"sin(π/4) = {sine}");  // 0.707...
-print(f"cos(π/4) = {cosine}"); // 0.707...
+```tocin
+import std.testing;        // dotted path  -> std/testing.to
+import "std/testing";      // string path, same file
 ```
 
-### Module: `math/linear.to`
+For each import the compiler searches, in order:
 
-Linear algebra operations including vectors and matrices.
+1. the directory of the importing file,
+2. `$TOCIN_PATH`, if set,
+3. the compiled-in standard-library path.
 
-**Types:**
-- `Vector2`, `Vector3`, `Vector4` - Vector types
-- `Matrix2x2`, `Matrix3x3`, `Matrix4x4` - Matrix types
+The installers generate a `tocin` launcher that points `TOCIN_PATH` at the
+installed `stdlib/`, so imports work out of the box. From a source checkout,
+set it explicitly:
 
-**Operations:**
-- Vector addition, subtraction, scaling
-- Dot product, cross product
-- Matrix multiplication
-- Matrix determinant, inverse, transpose
+```sh
+TOCIN_PATH=/path/to/TocinLang/stdlib ./build/tocin program.to --run
+```
 
-### Module: `math/geometry.to`
+An import merges the file's top-level declarations into the program (each file
+is loaded at most once, and a module's own imports load first). **There is no
+namespacing and no selective import**: after `import std.math;` you call
+`gcd(12, 18)` — never `std.math.gcd(...)` or `math.gcd(...)`.
 
-Geometric computations and shapes.
+### The naming rule
 
-**Features:**
-- Point, Line, Circle, Rectangle classes
-- Distance calculations
-- Intersection tests
-- Area and perimeter computations
+Because every imported name lands in one global scope, stdlib functions are
+named to be globally unique, usually with a module or structure prefix:
+`listSum`, `strTrim`, `jsonParse`, `heapPush`, `matMul`, `tenScan`. Constants
+follow the same rule (`PI`, `GEO_PI`, `JSON_ARRAY`, `WS_HOVERED`).
 
-### Module: `math/stats.to`
+A few short names do repeat across unrelated domains:
 
-Statistical functions and distributions.
+| Name | Defined in |
+|---|---|
+| `countWhere` | `std/functional.to` and `database/database.to` |
+| `mix` | `audio/audio.to` and `game/shader.to` |
+| `step` | `game/engine.to` and `game/shader.to` |
+| `fract` | `math/basic.to` and `game/shader.to` (identical definitions) |
 
-**Functions:**
-- `mean(data: Array<number>) -> float`
-- `median(data: Array<number>) -> float`
-- `mode(data: Array<number>) -> number`
-- `variance(data: Array<number>) -> float`
-- `stddev(data: Array<number>) -> float`
-- `correlation(x, y: Array<number>) -> float`
+Importing two modules that define the same name with different signatures
+into one program is not supported — it typically fails to compile. Keep such
+pairs in separate programs.
 
-### Module: `math/differential.to`
+### API conventions
 
-Differential calculus and numerical analysis.
+- **Booleans are `int`**: predicates return `1`/`0` (`isPrime(13)` returns
+  `1`), and boolean parameters take `1`/`0`.
+- **Handles are `int`**: raw-buffer structures (`heapNew`, `tableNew`,
+  `worldNew`, `layoutNew`, ...) return an address; pass it to the module's
+  functions and release it with the matching `*Free`.
+- Bulk float APIs write into **caller-allocated `list<float>` buffers**
+  instead of returning fresh lists (`softmax(src, dst)`,
+  `linearRegression(x, y, out)`).
 
-**Features:**
-- Numerical differentiation
-- Numerical integration
-- Differential equation solvers
+## Writing tests with std.testing
 
-## Data Structures & Algorithms
+`std.testing` is a minimal test harness written in Tocin. It keeps global
+pass/fail counters so checks read naturally, and `testSummary()` returns the
+process exit code (`0` if every check passed, `1` otherwise):
 
-### Module: `data/structures.to`
+| Function | Description |
+|---|---|
+| `testBegin() -> int` | Reset the pass/fail counters |
+| `check(name: string, cond: int) -> int` | Assert a condition (`1`/`0` or any comparison) |
+| `checkEq(name: string, got: int, want: int) -> int` | Assert integer equality; prints both values on mismatch |
+| `checkStrEq(name: string, got: string, want: string) -> int` | Assert string equality (by value) |
+| `testSummary() -> int` | Print the summary line; return `0` if all passed, else `1` |
 
-Advanced data structures beyond built-in types.
+A complete test file:
 
-**Structures:**
-- `Stack<T>` - LIFO stack
-- `Queue<T>` - FIFO queue
-- `PriorityQueue<T>` - Priority-based queue
-- `LinkedList<T>` - Doubly-linked list
-- `BinaryTree<T>` - Binary tree
-- `BinarySearchTree<T>` - BST
-- `AVLTree<T>` - Self-balancing BST
-- `HashMap<K, V>` - Hash table
-- `Trie` - Prefix tree
-- `Graph<T>` - Graph structure
+```tocin
+import std.testing;
+import std.math;
 
-**Example:**
-```to
-import data.structures;
-
-let stack = Stack<int>.new();
-stack.push(1);
-stack.push(2);
-stack.push(3);
-
-while (!stack.is_empty()) {
-    print(stack.pop()); // 3, 2, 1
+def main() -> int {
+    testBegin();
+    check("13 is prime", isPrime(13));
+    checkEq("gcd", gcd(12, 18), 6);
+    checkStrEq("strings", "to" + "cin", "tocin");
+    return testSummary();     // exit 0 if all checks passed, 1 otherwise
 }
 ```
 
-### Module: `data/algorithms.to`
-
-Common algorithms for sorting, searching, and more.
-
-**Sorting:**
-- `quicksort<T>(arr: Array<T>, compare: fn(T, T) -> int)`
-- `mergesort<T>(arr: Array<T>, compare: fn(T, T) -> int)`
-- `heapsort<T>(arr: Array<T>, compare: fn(T, T) -> int)`
-
-**Searching:**
-- `binary_search<T>(arr: Array<T>, target: T) -> int?`
-- `linear_search<T>(arr: Array<T>, target: T) -> int?`
-
-**Graph Algorithms:**
-- `dijkstra(graph: Graph, start: int) -> Array<int>`
-- `bellman_ford(graph: Graph, start: int) -> Array<int>`
-- `floyd_warshall(graph: Graph) -> Matrix`
-- `kruskal(graph: Graph) -> Graph`
-- `prim(graph: Graph) -> Graph`
-
-## Web & Networking
-
-### Module: `web/http.to`
-
-HTTP client and server functionality.
-
-**Classes:**
-- `Request` - HTTP request representation
-- `Response` - HTTP response representation
-- `Client` - HTTP client for making requests
-- `Server` - HTTP server for handling requests
-
-**Client Example:**
-```to
-import web.http;
-
-async def fetch_data() {
-    let client = http.Client.new();
-    let response = await client.get("https://api.example.com/data");
-    
-    if (response.statusCode == 200) {
-        let data = JSON.parse(response.body);
-        return data;
-    }
-    
-    throw Error(f"HTTP {response.statusCode}: {response.statusMessage}");
-}
+```text
+$ TOCIN_PATH=stdlib ./build/tocin my_test.to --run
+  ok   13 is prime
+  ok   gcd
+  ok   strings
+3 passed, 0 failed
 ```
 
-**Server Example:**
-```to
-import web.http;
+Because `main`'s return value is the process exit code, any script or CI job
+can treat a nonzero exit as failure with no extra plumbing.
 
-let server = http.Server.new();
+## How the stdlib test suite runs
 
-server.get("/", (req, res) => {
-    return res.html("<h1>Welcome to Tocin!</h1>");
-});
+Tests that need the full runtime (vectors, maps, strings, `alloc`, module
+imports, `std.testing`) live in `tests/jit/` and run under the JIT via
+`tests/run_stdlib_tests.sh`:
 
-server.get("/api/users/:id", (req, res) => {
-    let userId = req.params["id"];
-    // Fetch user from database
-    return res.json({ id: userId, name: "John Doe" });
-});
-
-await server.listen(8080);
-print("Server running on http://localhost:8080");
+```sh
+./tests/run_stdlib_tests.sh              # runs every tests/jit/*.to
+./tests/run_stdlib_tests.sh some/dir     # or another directory of .to files
 ```
 
-### Module: `web/websocket.to`
+The runner executes each file with `tocin FILE.to --run`, defaulting
+`TOCIN_PATH` to the repository's `stdlib/`. A file **passes when it exits 0**
+— unless it declares an expected exit code in a comment:
 
-WebSocket client and server for real-time communication.
-
-**Features:**
-- Full-duplex communication
-- Binary and text message support
-- Connection state management
-- Automatic reconnection
-
-**Example:**
-```to
-import web.websocket;
-
-let ws = websocket.Client.new("ws://localhost:8080");
-
-ws.on_message((message) => {
-    print(f"Received: {message}");
-});
-
-ws.on_connect(() => {
-    ws.send("Hello, server!");
-});
-
-await ws.connect();
+```tocin
+// expect: 7
 ```
 
-### Module: `net/advanced.to`
-
-Advanced networking features including TCP/UDP sockets, TLS, and protocols.
-
-## Database
-
-### Module: `database/database.to`
-
-Database connectivity and ORM functionality.
-
-**Features:**
-- SQL query builder
-- Connection pooling
-- Transaction support
-- ORM (Object-Relational Mapping)
-- Support for PostgreSQL, MySQL, SQLite
-
-**Example:**
-```to
-import database.database;
-
-let db = database.connect("postgresql://localhost/mydb");
-
-// Raw SQL
-let users = await db.query("SELECT * FROM users WHERE age > $1", [18]);
-
-// Query builder
-let adults = await db.table("users")
-    .where("age", ">", 18)
-    .order_by("name")
-    .get();
-
-// ORM
-class User {
-    property id: int;
-    property name: string;
-    property email: string;
-    property age: int;
-}
-
-let user = User.find(1);
-user.age = 30;
-await user.save();
-```
-
-## Machine Learning
-
-### Module: `ml/neural_network.to`
-
-Neural network implementation with training and inference.
-
-**Features:**
-- Layer types: Dense, Conv2D, MaxPool, Dropout, BatchNorm
-- Activation functions: ReLU, Sigmoid, Tanh, Softmax
-- Loss functions: MSE, CrossEntropy
-- Optimizers: SGD, Adam, RMSprop
-- Training utilities
-
-**Example:**
-```to
-import ml.neural_network as nn;
-
-let model = nn.Sequential([
-    nn.Dense(784, 128, activation: "relu"),
-    nn.Dropout(0.2),
-    nn.Dense(128, 64, activation: "relu"),
-    nn.Dense(64, 10, activation: "softmax")
-]);
-
-let optimizer = nn.Adam(learning_rate: 0.001);
-let loss_fn = nn.CrossEntropyLoss();
-
-// Training loop
-for epoch in 1..100 {
-    for (x_batch, y_batch) in train_loader {
-        let predictions = model.forward(x_batch);
-        let loss = loss_fn(predictions, y_batch);
-        
-        model.backward(loss);
-        optimizer.step();
-    }
-    
-    print(f"Epoch {epoch}: loss = {loss}");
-}
-```
-
-### Module: `ml/deep_learning.to`
-
-Advanced deep learning architectures and techniques.
-
-**Features:**
-- Pre-trained models (ResNet, VGG, etc.)
-- Transfer learning utilities
-- Data augmentation
-- Model serialization
-
-### Module: `ml/computer_vision.to`
-
-Computer vision algorithms and utilities.
-
-**Features:**
-- Image processing (filters, transformations)
-- Object detection
-- Face recognition
-- Feature extraction
-
-## Game Development
-
-### Module: `game/engine.to`
-
-2D/3D game engine functionality.
-
-**Features:**
-- Entity-Component-System (ECS) architecture
-- Scene management
-- Input handling
-- Physics simulation
-- Collision detection
-
-**Example:**
-```to
-import game.engine;
-
-class Player {
-    property position: Vector2;
-    property velocity: Vector2;
-    property sprite: Sprite;
-    
-    def update(delta_time: float) {
-        self.position += self.velocity * delta_time;
-        
-        // Collision detection
-        if (collides_with_enemy(self)) {
-            self.health -= 10;
-        }
-    }
-    
-    def render(renderer: Renderer) {
-        renderer.draw_sprite(self.sprite, self.position);
-    }
-}
-
-let game = engine.Game.new(width: 800, height: 600);
-let player = Player.new();
-
-game.add_entity(player);
-game.run(); // Start game loop
-```
-
-### Module: `game/graphics.to`
-
-Graphics rendering utilities.
-
-**Features:**
-- 2D sprite rendering
-- 3D mesh rendering
-- Particle systems
-- Lighting and shadows
-
-### Module: `game/shader.to`
-
-Shader programming support.
-
-## GUI
-
-### Module: `gui/core.to`
-
-GUI framework core functionality.
-
-**Features:**
-- Window management
-- Event handling
-- Layout system
-- Theme support
-
-### Module: `gui/widgets.to`
-
-Standard GUI widgets.
-
-**Widgets:**
-- Button, Label, TextBox, CheckBox, RadioButton
-- ComboBox, ListBox, TreeView
-- TabControl, Panel, GroupBox
-- ProgressBar, Slider, ScrollBar
-
-**Example:**
-```to
-import gui.core;
-import gui.widgets;
-
-let app = gui.Application.new();
-let window = gui.Window.new(title: "My App", width: 400, height: 300);
-
-let button = gui.widgets.Button.new(text: "Click Me");
-button.on_click(() => {
-    print("Button clicked!");
-});
-
-window.add(button);
-app.run();
-```
-
-## Audio
-
-### Module: `audio/audio.to`
-
-Audio playback and processing.
-
-**Features:**
-- Audio file loading (WAV, MP3, OGG)
-- Playback control
-- Volume and pan control
-- Audio effects (reverb, echo, etc.)
-- Audio synthesis
-
-**Example:**
-```to
-import audio.audio;
-
-let music = audio.load("background_music.mp3");
-music.set_volume(0.8);
-music.set_loop(true);
-music.play();
-
-// Audio synthesis
-let synth = audio.Synthesizer.new();
-synth.set_waveform("sine");
-synth.set_frequency(440); // A4 note
-synth.play_for(1.0); // Play for 1 second
-```
-
-## Embedded Systems
-
-### Module: `embedded/gpio.to`
-
-GPIO (General Purpose Input/Output) control for embedded systems.
-
-**Features:**
-- Pin configuration (input/output, pull-up/down)
-- Digital read/write
-- PWM (Pulse Width Modulation)
-- Interrupts
-
-**Example:**
-```to
-import embedded.gpio;
-
-// Configure LED pin
-let led_pin = gpio.Pin.new(17, mode: gpio.OUTPUT);
-
-// Blink LED
-for i in 1..10 {
-    led_pin.write(gpio.HIGH);
-    sleep(500); // milliseconds
-    led_pin.write(gpio.LOW);
-    sleep(500);
-}
-
-// Read button with interrupt
-let button_pin = gpio.Pin.new(27, mode: gpio.INPUT, pull: gpio.PULL_UP);
-button_pin.on_interrupt(gpio.FALLING_EDGE, () => {
-    print("Button pressed!");
-});
-```
-
-## Package Management
-
-### Module: `pkg/manager.to`
-
-Package management functionality.
-
-**Features:**
-- Package installation
-- Dependency resolution
-- Version management
-- Package registry integration
-
-**Example:**
-```to
-import pkg.manager;
-
-let pm = pkg.Manager.new();
-
-// Install package
-await pm.install("http_client", version: "^1.0.0");
-
-// Update packages
-await pm.update();
-
-// List installed packages
-let packages = pm.list();
-for pkg in packages {
-    print(f"{pkg.name} v{pkg.version}");
-}
-```
-
-## Scripting & Automation
-
-### Module: `scripting/automation.to`
-
-Scripting and task automation utilities.
-
-**Features:**
-- File system operations
-- Process execution
-- System information
-- Task scheduling
-
-**Example:**
-```to
-import scripting.automation;
-
-// File operations
-let files = automation.list_files(".", pattern: "*.to");
-for file in files {
-    let content = automation.read_file(file);
-    let lines = content.count("\n");
-    print(f"{file}: {lines} lines");
-}
-
-// Process execution
-let result = await automation.execute("ls", ["-la"]);
-print(result.stdout);
-
-// Task scheduling
-automation.schedule_task(
-    name: "backup",
-    interval: automation.DAILY,
-    at: "02:00",
-    action: () => {
-        automation.execute("backup.sh");
-    }
-);
-```
-
-## Usage Notes
-
-### Importing Modules
-
-```to
-// Import entire module
-import math.basic;
-let result = math.basic.sqrt(16);
-
-// Import with alias
-import web.http as http;
-let server = http.Server.new();
-
-// Import specific items
-from math.basic import sin, cos, PI;
-let x = sin(PI / 2);
-```
-
-### Module Organization
-
-All standard library modules follow the same structure:
-1. Module documentation at the top
-2. Type definitions
-3. Constants
-4. Functions and classes
-5. Helper functions (usually private)
-
-### Error Handling
-
-All standard library functions use Tocin's error handling mechanisms:
-- Throwing exceptions for exceptional conditions
-- Returning `Option<T>` for operations that may fail
-- Returning `Result<T, E>` for operations with typed errors
-
-**Example:**
-```to
-import data.structures;
-
-let tree = BinarySearchTree<int>.new();
-
-// find() returns Option<int>
-match tree.find(42) {
-    Some(value) => print(f"Found: {value}"),
-    None => print("Not found")
-}
-
-// This throws an exception if invalid
-let result = tree.remove(42); // May throw if tree is empty
-```
-
-### Thread Safety
-
-Most standard library types are thread-safe by default. Exceptions are documented in their respective modules.
-
-### Performance Considerations
-
-- Collection operations are optimized for common use cases
-- Lazy evaluation is used where appropriate (LINQ operations)
-- Memory allocation is minimized through object pooling
-- JIT compilation optimizes hot paths automatically
-
-## Contributing to Standard Library
-
-To add a new module to the standard library:
-
-1. Create the module file in the appropriate directory
-2. Follow naming conventions (snake_case for files, PascalCase for types)
-3. Add comprehensive documentation
-4. Include usage examples
-5. Write unit tests
-6. Submit a pull request
-
-## Future Additions
-
-Planned standard library modules:
-- Cryptography (`crypto/`)
-- Compression (`compression/`)
-- Regular expressions (`regex/`)
-- JSON/XML parsing (`parsing/`)
-- Logging (`logging/`)
-- Testing framework (`testing/`)
-- Benchmarking (`bench/`)
-
-## License
-
-The Tocin standard library is licensed under the MIT License, same as the compiler.
+in which case the exit code must equal that number. Files built on
+`std.testing` need no annotation: `return testSummary();` already exits
+nonzero when any check fails, so they self-report. The existing
+`tests/jit/stdlib_*.to` files are good templates for new module tests.
+
+## Which module do I need?
+
+| Task | Import | Key functions |
+|---|---|---|
+| Integer math (gcd, primes, factorial) | `std.math` | `gcd`, `lcm`, `factorial`, `isPrime` |
+| Sum / min / max of an int list | `std.list` | `listSum`, `listMin`, `listMax`, `listContains` |
+| Map / filter / fold with lambdas | `std.functional` | `mapInts`, `filterInts`, `foldInts`, `rangeList` |
+| Query-style reductions | `std.linq` | `reduceSum`, `aggregate`, `countGreater` |
+| Trim, pad, parse strings | `std.strings` | `strTrim`, `strPadLeft`, `strParseIntOr` |
+| Split / join / replace strings | `std.strseq` | `splitChar`, `joinStr`, `replaceAll` |
+| Parse or emit JSON | `std.json` | `jsonParse`, `jsonGetString`, `jsonStringify` |
+| Assert and report in tests | `std.testing` | `check`, `checkEq`, `testSummary` |
+| Sort and search int lists | `data.algorithms` | `sort`, `binarySearch`, `argMax` |
+| Stack, queue, set, counter | `data.structures` | `stackPush`, `enqueue`, `setAdd`, `countAdd` |
+| Heap, union-find, BST, deque, bitset | `data.collections` | `heapPush`, `ufUnion`, `bstPut`, `pushBack` |
+| Float helpers and constants | `math.basic` | `lerp`, `clampf`, `hypot`, `PI` |
+| Matrices and vectors | `math.linear` | `matMul`, `vecDot`, `vecNorm` |
+| 2-D/3-D geometry | `math.geometry` | `dist2`, `cross2`, `circleArea` |
+| Statistics and regression | `math.stats`, `math.stats_advanced` | `mean`, `stddev`, `correlation`, `linearRegression` |
+| Derivatives, integrals, roots | `math.differential` | `derivative`, `integrateSimpson`, `newtonRoot` |
+| Neural-network numerics | `ml.neural_network`, `ml.deep_learning` | `denseForward`, `trainStep`, `argmax`, `accuracy` |
+| Image processing | `ml.computer_vision` | `threshold`, `boxBlur`, `sobel`, `resize` |
+| Sequence models (TEN) | `ml.ten` | `tenEigenInit`, `tenScan`, `tenLayerForward` |
+| Serve HTTP / build responses | `web.http` | `httpRoute`, `buildResponse`, `serveLoop` |
+| Make HTTP requests | `net.advanced` | `httpGet`, `httpPost`, `responseBody` |
+| WebSocket frames | `web.websocket` | `writeFrame`, `frameOpcode`, `unmaskPayload` |
+| In-memory KV store / tables | `database.database` | `kvPut`, `tableInsert`, `selectWhere`, `columnSum` |
+| Entities, framebuffers, shading | `game.engine`, `game.graphics`, `game.shader` | `spawnEntity`, `drawLine`, `smoothstep` |
+| Widget layout math | `gui.core`, `gui.widgets` | `buttonState`, `layoutRow`, `progressFill` |
+| Audio synthesis / DSP | `audio.audio` | `genSine`, `applyEnvelope`, `lowpass`, `midiToFreq` |
+| Memory-mapped GPIO | `embedded.gpio` | `pinMode`, `digitalWrite`, `digitalRead` |
+| Templating and shell strings | `scripting.automation` | `renderTemplate`, `buildCommand`, `shellQuote` |
+| Semantic versioning | `pkg.manager` | `compareVersions`, `satisfiesCaret`, `bestMatch` |

--- a/docs/TRAITS.md
+++ b/docs/TRAITS.md
@@ -5,7 +5,7 @@ Traits are a powerful feature in Tocin, inspired by Rust and Swift protocols. Th
 ## Defining a Trait
 ```to
 trait Printable {
-    fn print(self);
+    def print(self);
 }
 ```
 
@@ -13,7 +13,7 @@ trait Printable {
 ```to
 struct Point { x: int, y: int }
 impl Printable for Point {
-    fn print(self) {
+    def print(self) {
         print("Point(" + self.x + ", " + self.y + ")");
     }
 }
@@ -29,7 +29,7 @@ p.print();
 Traits can provide default implementations:
 ```to
 trait Describable {
-    fn describe(self) -> string {
+    def describe(self) -> string {
         return "[no description]";
     }
 }
@@ -39,13 +39,13 @@ trait Describable {
 A trait can require other traits:
 ```to
 trait Drawable: Printable {
-    fn draw(self);
+    def draw(self);
 }
 ```
 
 ## Trait Bounds in Generics
 ```to
-fn print_all<T: Printable>(items: list<T>) {
+def print_all<T: Printable>(items: list<T>) {
     for item in items { item.print(); }
 }
 ```

--- a/docs/capability-report.md
+++ b/docs/capability-report.md
@@ -20,7 +20,7 @@ opt-in borrow-check — move + `&`/`&mut` borrows (12/12), match-exhaustiveness
 | Write a long-running microservice / server? | **Yes now** — a garbage collector (Boehm GC) reclaims unreachable memory, so long-lived processes no longer grow without bound (2M allocations that would leak >128 MB peak at ~8 MB). Networking still goes through C FFI. |
 | OS / kernel / bare-metal work? | **Yes** — `--freestanding` emits a relocatable object with NO libc/GC/runtime (a pure arithmetic/raw-memory/asm program has zero undefined symbols; one using `alloc` references only the user-provided `__tocin_alloc`). Inline assembly and raw pointer/memory builtins give CPU and layout control. Verified end-to-end with a `-nostdlib` static binary. |
 | Self-host (write the Tocin compiler in Tocin)? | **A subset is achievable now** (a Tocin→C or Tocin→LLVM-text backend); a full LLVM-API self-host is a large project blocked by tooling (LLVM bindings), not by language gaps. Memory is no longer a blocker. |
-| C++-level optimizations? | **Yes for compute.** Native code runs LLVM's full `-O2`/`-O3` pipeline (same optimizer as clang). A compute benchmark (recursive fib + 100M-iteration loop) runs in **0.149 s vs C `-O2` at 0.137 s — within ~9 %**. Allocation-bound code now pays GC cost rather than leaking. |
+| C++-level optimizations? | **Yes for compute.** Native code runs LLVM's full `-O2`/`-O3` pipeline (same optimizer as clang), plus `--native` CPU tuning, whole-program internalization, and alias-aware buffer optimization. On a 12-kernel C/C++/Rust comparison the geomean **ties Rust** (~1.4× of C overall), with Tocin outright fastest on 5 of 12 kernels (`sqrtsum` ~2× faster than C); `matmul` and `levenshtein` are the known gaps. Allocation-bound code pays GC cost rather than leaking. |
 
 ---
 
@@ -213,9 +213,13 @@ binaries) — the *same optimizer clang uses*. Tight arithmetic and control-flow
 code is genuinely competitive with C++: inlining, constant folding,
 vectorization, register allocation, and instruction selection are all LLVM's.
 
-Measured: a compute benchmark — recursive `fib(34)` plus a 100-million-iteration
-accumulation loop — compiled with Tocin `-O2` runs in **0.149 s** versus the
-equivalent C at `-O2` in **0.137 s**: within ~9 %.
+Measured on a 12-kernel comparison against C, C++, and Rust (same machine,
+each language's `-O3`-equivalent, Tocin at `-O3 --native`): Tocin's geomean
+**ties Rust** at roughly 1.4× of C overall, and Tocin is outright fastest of
+the four on 5 of the 12 kernels — e.g. `sqrtsum` runs ~2× faster than the C
+version because `sqrt` lowers to the LLVM intrinsic and vectorizes. The known
+gaps are `matmul` (the reduction pattern blocks loop interchange — it limits
+Rust too) and `levenshtein`.
 
 **Frontend (what IR we hand to LLVM): B.** The emitted IR is still
 allocation-happy — arrays, string concatenations, closures, and Option/Result
@@ -237,8 +241,9 @@ correct and bounded, paying GC cost where C++ would pay none.**
 
 Tocin is a real, compiled, statically-typed language that today can build
 compilers, interpreters, CLI tools, parsers, long-running services, and
-low-level/systems programs, with a world-class optimizing backend (measured
-within ~9 % of C on compute) and a garbage-collected heap. Self-hosting runs
+low-level/systems programs, with a world-class optimizing backend (geomean
+ties Rust on a 12-kernel C/C++/Rust comparison; outright fastest on 5 of 12)
+and a garbage-collected heap. Self-hosting runs
 through a Tocin-emitting backend — concrete, scoped work, not blocked by a
 fundamental language deficiency. The keystone gaps called out in earlier
 revisions — memory management and missing operators/control-flow — are closed.

--- a/docs/language-reference.md
+++ b/docs/language-reference.md
@@ -2,8 +2,8 @@
 
 This is the authoritative reference for the Tocin programming language as
 implemented by the compiler in this repository. Tocin is a **statically typed,
-compiled** language that lowers to **LLVM 18** IR and can either be JIT-executed
-or compiled to a native object/executable.
+compiled** language that lowers to **LLVM IR (LLVM 18–22)** and can either be
+JIT-executed or compiled to a native object/executable.
 
 Every nontrivial construct documented here has been verified by compiling and
 running a snippet with the in-tree compiler. Where a feature is lexed but not
@@ -110,18 +110,24 @@ let const def async await class struct enum trait impl
 if elif else while for in return match case default
 import lambda new delete try catch finally throw
 go select channel and or true false None void self
-extern break continue
+extern break continue switch defer yield
 ```
 
 `break` and `continue` are fully implemented and work in every loop form (see
-[§4](#4-statements)).
+[§4](#4-statements)). `switch` is an alias of `match`, `defer` schedules a
+statement to run at function return, and `yield` defines generator functions
+([§5](#5-functions)).
 
 The following are reserved by the lexer but **not** wired into the grammar/
-codegen and are best avoided as identifiers: `from switch interface pub priv
+codegen and are best avoided as identifiers: `from interface pub priv
 static final abstract virtual override super null undefined typeof instanceof
-as is where yield generator coroutine spawn join mutex lock unlock atomic
+as is where generator coroutine spawn join mutex lock unlock atomic
 volatile move borrow constexpr inline export module package namespace using
-with defer panic recover assert debug trace log warn error fatal`.
+with panic recover assert`.
+
+> `debug`, `trace`, `log`, `warn`, `error`, and `fatal` are **ordinary
+> identifiers** — they were unreserved so that names like the `log(x)` math
+> builtin and user-defined `error(...)` helpers work.
 
 `macro` is **not** a reserved keyword — it is recognized as an ordinary
 identifier by a token-level preprocessing pass (see [§15](#15-macros)).
@@ -187,8 +193,9 @@ Rules (verified):
 * `let x: int = 5;` annotates explicitly. An initializer whose type does not
   match the annotation is an error unless it is a numeric widen/narrow that the
   compiler can cast (int↔int, float↔float).
-* `const` is parsed and behaves like `let` for codegen (no enforced
-  immutability today).
+* `const` declares an **immutable binding** — assigning to it later is a
+  compile error:
+  `error [T013]: Cannot assign to constant 'X' (declared with `const`)`.
 
 There is a special rule for **function-typed locals initialized from a call** —
 see [§5](#5-functions).
@@ -208,6 +215,7 @@ see [§5](#5-functions).
 | Logical | `and` / `&&`, `or` / `\|\|` | `and`/`&&` are the same operator; `or`/`\|\|` likewise. |
 | Unary | `-x`, `!x`, `~x` | Numeric negation; boolean (and integer) logical-not; integer bitwise-not. |
 | Compound assignment | `+=` `-=` `*=` `/=` `%=` | `x op= e` is shorthand for `x = x op e`. Valid on variables, array elements (`arr[i] += e`), and strings (`s += t` concatenates). |
+| Conditional (ternary) | `cond ? a : b` | Evaluates `a` if `cond` is true, else `b`; only the taken branch is evaluated. Right-associative: `c1 ? x : c2 ? y : z` is `c1 ? x : (c2 ? y : z)`. |
 | Null safety | `?.`, `?:`, `!!` | Safe navigation, elvis/coalesce, force-unwrap. See [§12](#12-null-safety). |
 | Coalesce | `??` | Synonym for `?:`. |
 | Channel | `<-` | `ch <- v` sends; `<-ch` receives. See [§14](#14-concurrency). |
@@ -229,19 +237,27 @@ This is the precedence as implemented by the recursive-descent parser
 | Level | Operators | Associativity |
 |---|---|---|
 | 1 (loosest) | `=` and compound `+= -= *= /= %=` (assignment) | right |
-| 2 | `?:`, `??` (elvis / coalesce) | left |
-| 3 | `or` / `\|\|` | left |
-| 4 | `and` / `&&` | left |
-| 5 | `\|` (bitwise OR) | left |
-| 6 | `^` (bitwise XOR) | left |
-| 7 | `&` (bitwise AND) | left |
-| 8 | `==`, `!=` | left |
-| 9 | `<`, `<=`, `>`, `>=` | left |
-| 10 | `<<`, `>>` (shifts) | left |
-| 11 | `+`, `-` | left |
-| 12 | `*`, `/`, `%` | left |
-| 13 (prefix) | unary `-`, `!`, `~`, `<-` (receive), `await`, `new`, `delete` | right |
-| 14 (tightest) | call `f()`, member `.`, safe member `?.`, index `[]`, force-unwrap `!!` | left (postfix) |
+| 2 | `cond ? a : b` (ternary conditional) | right |
+| 3 | `?:`, `??` (elvis / coalesce) | left |
+| 4 | `or` / `\|\|` | left |
+| 5 | `and` / `&&` | left |
+| 6 | `\|` (bitwise OR) | left |
+| 7 | `^` (bitwise XOR) | left |
+| 8 | `&` (bitwise AND) | left |
+| 9 | `==`, `!=` | left |
+| 10 | `<`, `<=`, `>`, `>=` | left |
+| 11 | `<<`, `>>` (shifts) | left |
+| 12 | `+`, `-` | left |
+| 13 | `*`, `/`, `%` | left |
+| 14 (prefix) | unary `-`, `!`, `~`, `<-` (receive), `await`, `new`, `delete` | right |
+| 15 (tightest) | call `f()`, member `.`, safe member `?.`, index `[]`, force-unwrap `!!` | left (postfix) |
+
+The ternary is right-associative — `1 ? 2 : 0 ? 3 : 4` parses as
+`1 ? 2 : (0 ? 3 : 4)` and yields `2` — and only the taken branch is evaluated:
+
+```tocin
+let m = a > b ? a : b;     // max
+```
 
 This is the standard C-style ordering: the bitwise operators bind looser than
 comparison, the shifts bind between comparison and `+`/`-`, and unary `~` binds
@@ -475,6 +491,24 @@ def add(a: int, b: int) {   // inferred -> int
 }
 ```
 
+### Default parameter values
+
+A trailing parameter may declare a default with `= expr` after its type (the
+type annotation is **required** on a defaulted parameter). Call sites that omit
+the trailing arguments get the defaults filled in:
+
+```tocin
+def f(a: int, b: int = 10) -> int { return a + b; }
+
+def main() {
+    println("{} {}", f(1), f(1, 2));   // 11 3
+    return 0;
+}
+```
+
+`def g(a: int, b = 7)` — a default without a type — is a compile error.
+Defaulted parameters must come after all non-defaulted ones.
+
 ### Recursion & forward references
 
 Functions may call themselves and may call functions declared later in the file
@@ -529,10 +563,25 @@ println("{}", apply(lambda (x: int) -> int x * x, 9));  // 81
 
 ### Capturing closures
 
-A lambda **closes over the enclosing locals it references, capturing them by
-value** (a snapshot taken when the lambda is created). Because the capture is a
-copy, later mutations of the original variable do not change what the lambda
-sees, and the lambda cannot write back to the original:
+A lambda closes over the enclosing locals it references. Capture is
+**by value for reads and by reference for writes**:
+
+* a closure that only **reads** a captured local takes a snapshot at creation
+  time — later mutations of the original do not change what it sees;
+* a closure that **assigns** to a captured local shares the underlying cell —
+  the write is visible in the enclosing scope after the closure runs:
+
+```tocin
+def main() -> int {
+    let count = 0;
+    let inc = lambda () -> int count = count + 1;   // writes `count`
+    inc(); inc(); inc();
+    println("{}", count);      // 3 — the mutation is visible outside
+    return count;
+}
+```
+
+The read-only (snapshot) behavior:
 
 ```tocin
 def main() -> int {
@@ -561,9 +610,11 @@ def main() -> int {
 }
 ```
 
-> Capture is **by value only** — there is no capture by reference. See
-> [§20](#20-limitations--not-yet-supported). If you need a non-capturing helper,
-> a nested `def` (below) is also available.
+> Read-only captures are snapshots; written captures share the cell (see
+> `examples/byref_closures.to`). The remaining gap is an **escaping** written
+> capture — a write-capturing closure that outlives its defining frame — see
+> [§20](#20-limitations--not-yet-supported). If you need a non-capturing
+> helper, a nested `def` (below) is also available.
 
 ### Function-typed locals
 
@@ -597,6 +648,27 @@ capture.
 def main() -> int {
     def dbl(x: int) -> int { return x * 2; }
     return dbl(21);   // 42
+}
+```
+
+### Generator functions (`yield`)
+
+A function whose body contains `yield` is a **generator**: calling it runs the
+body and collects every yielded value into a sequence, which `for` then walks.
+Collection is **eager** (finite sequences — the generator runs to completion
+when called; truly lazy/infinite generators are future work). The declared
+return type is the **element** type:
+
+```tocin
+def counter(n: int) -> int {
+    for i in 0..n { yield i; }
+}
+
+def main() -> int {
+    let s = 0;
+    for v in counter(5) { s = s + v; }
+    println("{}", s);      // 10  (0+1+2+3+4)
+    return s;
 }
 ```
 
@@ -677,12 +749,16 @@ def main() {
 
 Notes / current behavior:
 
-* Traits are essentially a way to declare and group method signatures. `impl`
-  blocks attach concrete methods to the named type; calls are resolved
-  statically by receiver type.
-* Trait *bounds* on generics are parsed (`<T: SomeTrait>`) but **ignored** —
-  there is no constraint checking or dynamic dispatch through trait objects.
-  See [TRAITS.md](TRAITS.md) for the broader design intent.
+* `impl` blocks attach concrete methods to the named type; when the receiver's
+  concrete type is known, calls resolve statically.
+* **Trait bounds are enforced.** `def f<T: Bound>(...)` rejects, at compile
+  time, a type argument that does not implement `Bound`, and trait methods
+  called on the bounded parameter dispatch to the concrete type.
+* **Trait objects (dynamic dispatch) work.** A value typed as a trait — a
+  parameter, a `let`, or an element of `list<Trait>` — carries its concrete
+  type and dispatches method calls virtually, so one collection can hold many
+  concrete types: `let xs: list<Shape> = [Circle(5), Rect(2, 3)];`. See
+  `examples/trait_objects.to`.
 
 ---
 
@@ -1184,6 +1260,35 @@ Each receive case is `case v = <-ch: { … }` (the `v =` binding is optional).
 The values moved through channels are 64-bit slots (see
 [§18](#18-memory-model--abi)). See [CONCURRENCY.md](CONCURRENCY.md) for more.
 
+### `async` / `await`
+
+`async def` declares an asynchronous function and `await` retrieves its
+result. The semantics today are **eager**: the async body executes on the
+calling path, and `await f` evaluates to the completed result — correct
+composition in expressions and across async calls, without true suspension.
+(The cooperative M:N scheduler that would suspend a pending `await` and run
+other tasks on a worker pool is designed but not yet wired in — see
+[async-scheduler-design.md](async-scheduler-design.md). Use goroutines +
+channels for actual parallelism.)
+
+```tocin
+async def slow(n: int) -> int {
+    sleepMs(5);
+    return n * 2;
+}
+
+def main() -> int {
+    let f = slow(21);     // starts the async computation
+    let v = await f;      // suspends until it completes
+    println("{}", v);     // 42
+    return v;
+}
+```
+
+`await` is a prefix operator (it binds with the other unary operators — see
+[§3](#3-operators--precedence)). Async composes with goroutines and channels;
+`--no-async` disables the feature.
+
 ---
 
 ## 15. Macros
@@ -1331,14 +1436,17 @@ x86-64 SysV ABI — use `-> i32` if you need an exact C `int`.
 ## 18. Memory model & ABI
 
 * **Heap allocation.** Class instances, `Option`/`Result` records, array/list
-  literals, channels, and dynamic collections live on the heap (via `malloc` /
-  runtime allocators). Class/array/channel values are passed around as **opaque
-  pointers**.
-* **No automatic memory management.** There is no garbage collector and no
-  automatic destruction; heap allocations are **leaked** for the program
-  lifetime unless an explicit free builtin is called (`vecFree`, `mapFree`).
-  `new`/`delete` are parsed but allocate stack-locally and are not a general
-  heap-management facility. For typical short-lived programs the leak is benign.
+  literals, channels, and dynamic collections live on the heap, allocated
+  through the GC-backed runtime allocator. Class/array/channel values are
+  passed around as **opaque pointers**.
+* **Garbage collection.** Heap memory — instances, strings, closures, arrays,
+  `Option`/`Result` records, vectors, maps — is reclaimed automatically by the
+  **Boehm conservative collector**, so long-running programs don't leak.
+  `free` / `vecFree` / `mapFree` remain for eager release; `--no-gc` maps
+  allocation to plain `malloc` with no collection (for freestanding or
+  externally-managed environments). RAII destructors (`__del__`) and `defer`
+  give deterministic cleanup on top of the GC. `new`/`delete` are parsed but
+  are not the general heap-management facility.
 * **Arrays.** An array literal `[a, b, c]` is a flat heap block laid out as
   `[i64 length][elem 0][elem 1]…`. `len(arr)` reads the length word; `arr[i]`
   computes `base + 8 + i*sizeof(elem)`. The element type is tracked from the
@@ -1365,6 +1473,9 @@ x86-64 SysV ABI — use `-> i32` if you need an exact C `int`.
 
 ```text
 tocin [options] FILE.to
+tocin check FILE.to        # typecheck only (no codegen); exit 0 if clean
+tocin new NAME             # scaffold a new project directory
+tocin doc FILE.to          # generate Markdown API docs to stdout
 ```
 
 | Option | Effect |
@@ -1372,10 +1483,43 @@ tocin [options] FILE.to
 | `--run` (alias `--jit`) | JIT-compile and run immediately. The program's exit code is `main`'s return value. |
 | `-o <file>` | Write output. The extension selects the format: `.ll` = LLVM IR, `.s` = assembly, `.o` = object file, anything else = **native executable**. |
 | `-O0` / `-O1` / `-O2` / `-O3` | Optimization level. **Default is `-O2`.** |
+| `--native` | Tune output for the build machine's CPU (POPCNT/AVX reach the vectorizer); the binary is not portable to older CPUs. |
+| `--permissive` | Downgrade type errors to warnings and compile anyway. Not recommended — strict is the supported mode. |
+| `--freestanding` | Emit a no-libc/no-GC relocatable object for kernel / bare-metal work (link with `-nostdlib`). |
+| `--no-gc` | Link without the garbage collector (allocation falls back to `malloc`). |
+| `--borrow-check` | Enable the opt-in move / use-after-move checker. |
 | `--dump-ir` | Print the generated LLVM IR to stdout. |
 | `--target <native\|wasm>` | Compilation target (native is the supported path). |
 | `--no-ffi`, `--no-concurrency`, `--no-advanced`, `--no-macros`, `--no-async` | Disable the corresponding feature/pass. |
+| `--version` / `-V` | Print the compiler version. |
 | `--help` | Show usage. |
+
+### Diagnostics
+
+Type checking is **strict by default**: unknown identifiers, wrong argument
+counts (builtins included), and type mismatches are hard errors, rendered
+rustc-style — the offending source line, a caret underline, colors on
+terminals (respects `NO_COLOR`), and a `did you mean '…'?` suggestion when a
+similarly-spelled name exists — followed by an `N errors generated.` summary:
+
+```text
+app.to:3:8: error [T013]: Cannot assign to constant 'X' (declared with `const`). Use `let` for a mutable binding.
+    3 |     X = 6;
+      |        ^
+1 error generated.
+```
+
+`--permissive` downgrades type errors to warnings; `tocin check file.to` runs
+just the checker (no codegen) and exits 0 on a clean file.
+
+### Runtime traps
+
+Integer division/modulo by zero and out-of-bounds indexing abort with a
+located panic instead of silently corrupting state:
+
+```text
+panic: integer division by zero at app.to:4:16
+```
 
 Examples:
 
@@ -1397,13 +1541,11 @@ Known gaps in the current implementation (verified against the compiler):
 
 * **No power operator `**` and no increment/decrement `++` / `--`.** Use the
   `pow()` builtin and `x += 1` / `x -= 1`. ([§3](#3-operators--precedence))
-* **`switch` aliases `match`; `defer` runs cleanup at function return.** Prefer `match` / `case` for
-  multi-way branching ([§10](#10-pattern-matching)); there is no `defer`
-  facility (use `try`/`finally` for cleanup). ([§11](#11-error-handling))
-* **Closures capture by value (snapshot), not by reference.** Mutating the
-  original after capture does not change the captured copy, and the lambda
-  cannot write back to the original. Lambda bodies are a **single expression**
-  (no block). ([§5](#5-functions))
+* **Closure capture is by value for reads, by reference for writes.** A
+  read-only capture is a snapshot (mutating the original afterward doesn't
+  change it); a written capture shares the cell. An **escaping** written
+  capture (outliving its defining frame) is not supported yet. Lambda bodies
+  are a **single expression** (no block). ([§5](#5-functions))
 * **Nested `def` functions are non-capturing** — they are lifted to module
   scope and cannot see the enclosing function's locals; use a lambda to
   capture. ([§5](#5-functions))
@@ -1413,23 +1555,18 @@ Known gaps in the current implementation (verified against the compiler):
 * **Exceptions carry an integer payload only**; there is no exception type
   hierarchy, no typed `catch`, and no bare `throw;` rethrow.
   ([§11](#11-error-handling))
-* **Trait bounds on generics are ignored**; there is no constraint checking and
-  no trait-object dynamic dispatch. Generics have **no explicit type-argument
-  syntax** (turbofish) — types are inferred. ([§7](#7-traits--impl),
-  [§8](#8-generics))
-* **No garbage collection**; heap allocations (strings from concatenation,
-  closures, array/list literals, `Option`/`Result`, vectors, maps, channels)
-  are **not freed automatically** and leak for the process lifetime. Manual
-  `vecFree` / `mapFree` exist for the dynamic collections. ([§18](#18-memory-model--abi))
-* **`const` is not enforced** (behaves like `let`). ([§2](#2-types))
+* **No explicit generic type arguments** (turbofish) — type arguments are
+  always inferred from the call/constructor site. A generic class whose type
+  argument is itself a generic class (e.g. `Box<Box<int>>`) is **not supported
+  yet**; generics over plain classes (`Box<W>`) work. ([§8](#8-generics))
 * **Dictionary literals** construct a value, but there is no rich, ergonomic
   dict API at the language level; the `map*` builtins are the practical
   key/value store. ([§21](#21-built-in-function-reference))
 * **Python / JavaScript FFI are not functional** — only the C path works.
   ([§17](#17-ffi))
-* Many lexer keywords (`interface`, `yield`, `async`/`await` beyond parsing,
-  etc.) are reserved but not implemented end-to-end; avoid them as identifiers
-  and don't rely on them.
+* A few lexer keywords (`interface`, `spawn`, `mutex`, `atomic`, `volatile`,
+  `move`, `borrow`, …) remain reserved but unimplemented; avoid them as
+  identifiers.
 
 ---
 
@@ -1469,6 +1606,10 @@ print("a"); print("b"); println("c");  // abc
 | `abs(x)` | numeric → same type | Absolute value (int or float). |
 | `min(a, b)` / `max(a, b)` | numeric → same type | Two-argument min/max. |
 
+> `sqrt`, `fabs`, `floor`, `ceil`, `round`, and `pow` lower to LLVM intrinsics,
+> so loops over them vectorize at `-O2`/`-O3` (this is why the `sqrtsum`
+> benchmark kernel beats its libm-calling C equivalent).
+
 ```tocin
 println("{}", pow(2.0, 10.0));  // 1024
 println("{}", sqrt(16.0));      // 4
@@ -1486,7 +1627,7 @@ Arrays also support `arr[i]` (read) and `arr[i] = v` (write).
 ### Dynamic vector (heap, 64-bit slots)
 
 `vecNew()`, `vecPush(v, x)`, `vecGet(v, i)`, `vecSet(v, i, x)`, `vecLen(v)`,
-`vecPop(v)`, `vecFree(v)`.
+`vecPop(v)`, `vecToArray(v)`, `vecFree(v)`.
 
 ```tocin
 let v = vecNew();
@@ -1509,8 +1650,12 @@ println("{} {}", mapGet(m, 2), mapHas(m, 3));  // 200 0
 ### Strings
 
 `strLen(s)`, `charAt(s, i)`, `substring(s, a, b)`, `strEq(a, b)`,
-`strCmp(a, b)`, `indexOfChar(s, c)`, `intToStr(n)`, `strToInt(s)`,
-`charToStr(c)`. String concatenation uses `+`.
+`strCmp(a, b)`, `indexOfChar(s, c)`, `strIndexOf(s, sub)`,
+`strContains(s, sub)`, `startsWith(s, p)`, `endsWith(s, p)`, `toUpper(s)`,
+`toLower(s)`, `intToStr(n)`, `strToInt(s)`, `charToStr(c)`,
+`bufToStr(buf, n)` (copy `n` bytes from a raw buffer into a new string),
+`strFromAddr(p)` (view a raw address as a NUL-terminated string).
+String concatenation uses `+`.
 
 ```tocin
 let s = "hello";
@@ -1521,6 +1666,36 @@ println("{} {} {}", strLen(s), charAt(s, 1), strEq("a", "a"));  // 5 101 1
 
 `readFile(path)` → string, `writeFile(path, content)`, `appendFile(path, content)`,
 `readLine()` → string (reads a line from stdin).
+
+### Networking, time, hashing, random (runtime services)
+
+| Group | Builtins |
+|---|---|
+| TCP sockets | `tcpListen`, `tcpAccept`, `tcpConnect`, `tcpSend`, `tcpRecv`, `tcpClose` — clients and concurrent servers; see `examples/tcp_echo.to`. |
+| Time | `timeSec()`, `timeMs()` (wall clock), `monoNanos()` (monotonic), `sleepMs(n)`. |
+| Hashing | `hashStr(s)`, `hashBytes(p, n)` (FNV-1a), `hashInt(x)` (splitmix64). |
+| Random | `randSeed(s)`, `randInt()`, `randRange(lo, hi)` — seeded, reproducible. |
+| Process / env | `envGet(name)`, `sysExit(code)`, `input()`. |
+
+### Raw memory & kernel primitives
+
+`alloc(n)`, `free(p)`, `memcpy(dst, src, n)`, `memset(p, b, n)`,
+`ptrAdd(p, off)`, `loadByte`/`storeByte`/`loadInt`/`storeInt` for raw buffers;
+volatile MMIO accessors `volatileLoad8/16/32/64(p, off)` and
+`volatileStore8/16/32/64(p, off, v)` (never elided or merged, even at `-O3`);
+a full memory `fence()`; and inline assembly:
+
+```tocin
+asm("nop");                                  // template-only
+let fortytwo = asm("mov $$42, $0", "=r");    // one output
+let sum = asm("lea 100($1), $0", "=r,r", x); // output + input
+let tsc = asm("rdtsc", "={ax},~{dx}");       // register constraint + clobber
+```
+
+At most one `=`-output constraint is allowed; templates use AT&T syntax with
+`$0`, `$1`, … operands. Combined with `--freestanding` these are the
+primitives for MMIO device registers and kernel work — see
+`tests/jit/kernel_primitives.to` for a runnable tour.
 
 ### LINQ-style collection ops (require `import std.linq;`)
 
@@ -1538,5 +1713,10 @@ def main() {
 }
 ```
 
-See [LINQ.md](LINQ.md) and [STDLIB_GUIDE.md](STDLIB_GUIDE.md) for the broader
-standard library.
+For higher-order `map`/`filter`/`fold`/`zip` with function-value (lambda)
+callbacks, `import std.functional;` (`mapInts`, `filterInts`, …).
+
+See [LINQ.md](LINQ.md), [04_Standard_Library.md](04_Standard_Library.md), and
+[STDLIB_GUIDE.md](STDLIB_GUIDE.md) for the broader standard library — 34
+modules spanning math, data structures, ML (including `ml.ten` — Temporal
+Eigenstate Networks), web, game, GUI, audio, embedded, and more.

--- a/docs/stdlib-reference.md
+++ b/docs/stdlib-reference.md
@@ -58,18 +58,20 @@ These properties recur throughout and are not repeated in every entry:
   `Option`/`Result` payloads are all stored as a single 64-bit slot. Integers go
   in directly; doubles are bit-cast into the slot; pointers/strings are stored as
   their address (an `i64`). There is no per-slot type tag.
-- **Storing a pointer/string in a vector or map is limited.** The address
-  round-trips as an `i64`, so reading it back gives you an integer, not a usable
-  string — the language exposes no way to cast that integer back to a pointer.
-  Use these collections for integer data (and booleans-as-int).
+- **Storing a pointer/string in a vector or map round-trips as an `i64`.**
+  Reading it back gives you the address as an integer; use `strFromAddr(p)` to
+  view that address as a string again (strings are the safe case — the GC
+  keeps the bytes alive). These collections remain simplest with integer data
+  (and booleans-as-int).
 - **Strings are NUL-terminated `char*`.** Every string-returning builtin returns
-  a *fresh* `malloc`'d buffer that never aliases its input.
-- **Leaks.** There is no garbage collector. String results (`substring`,
-  `intToStr`, `charToStr`, `toUpper`, `toLower`, `+` concatenation, `readFile`,
-  `readLine`, ...) and collection handles (`vecNew`, `mapNew`) are heap-allocated
-  and leak unless you free them. Vectors/maps have explicit `vecFree`/`mapFree`;
-  any heap pointer (including a malloc'd string) can be released with
-  `free(p)`. Only free a buffer you own and never use it afterward.
+  a *fresh* heap buffer that never aliases its input.
+- **Garbage-collected.** String results (`substring`, `intToStr`, `charToStr`,
+  `toUpper`, `toLower`, `+` concatenation, `readFile`, `readLine`, ...) and
+  collection handles (`vecNew`, `mapNew`) are allocated through the Boehm GC
+  and reclaimed automatically when unreachable — nothing leaks by default.
+  `vecFree`/`mapFree`/`free(p)` remain for *eager* release of large buffers
+  (only free a buffer you own, and never use it afterward); under `--no-gc`
+  they become mandatory again.
 - **`len` is for arrays only** (see below); use `strLen` for strings.
 
 ---

--- a/docs/tocin-for-ai.md
+++ b/docs/tocin-for-ai.md
@@ -16,7 +16,7 @@ Tocin is a **statically typed, ahead-of-time compiled** language that lowers to 
 
 Semantics are **value semantics for scalars** (`int`, `float`, `bool` live in registers/stack slots) and **heap handles (opaque pointers) for everything else** — class/struct instances, strings (`char*`), arrays, dynamic collections (`vector`/`map`), channels, and `Option`/`Result` boxes. Heap memory is **garbage-collected** (Boehm GC, when the runtime is built with it — the default): unreachable allocations are reclaimed automatically, so long-running programs do not leak. `vecFree`/`mapFree`/`free` remain available for eager release of large buffers, but are optional.
 
-The compiler is **pragmatic, not a full type system**. Type inference is local and shallow: a `let` with an initializer infers the variable's LLVM type from that initializer's value; function parameters and return types are explicitly annotated (or the return type is inferred from the body). Mixed int/float arithmetic **does** auto-promote the int operand to `float` (e.g. `3.0 + 2` → `5.0`; `let x: float = 5;` → `5.0`). Lambdas **do** capture enclosing locals **by value** (a snapshot), and the resulting closures can be returned/escape with independent state. `break` and `continue` **work** in every loop form. Some keywords still exist in the lexer but are **not implemented** in the parser/codegen — notably most ownership keywords (`switch`, `defer`, `break`, and `continue` are all implemented). Treat the verified feature set in this document as the real language.
+The compiler is **pragmatic, not a full type system**. Type inference is local and shallow: a `let` with an initializer infers the variable's LLVM type from that initializer's value; function parameters and return types are explicitly annotated (or the return type is inferred from the body). Mixed int/float arithmetic **does** auto-promote the int operand to `float` (e.g. `3.0 + 2` → `5.0`; `let x: float = 5;` → `5.0`). Lambdas **do** capture enclosing locals — reads are by-value snapshots, writes share the cell (visible outside) — and read-capturing closures can be returned/escape with independent state. `break` and `continue` **work** in every loop form. Some keywords still exist in the lexer but are **not implemented** in the parser/codegen — notably most ownership keywords (`switch`, `defer`, `break`, and `continue` are all implemented). Treat the verified feature set in this document as the real language.
 
 Key runtime facts:
 - `int` = 64-bit signed (`i64`). `float` = 64-bit (`double`). `bool` = `i1`.
@@ -38,6 +38,7 @@ declaration    ::= varDecl | funcDecl | externDecl | classDecl | enumDecl
 varDecl        ::= ("let" | "const") IDENT (":" type)? ("=" expression)? ";"
                  | ("let" | "const") "(" IDENT ("," IDENT)* ")" "=" expression ";"  // tuple destructuring
 funcDecl       ::= ("def" | "async" "def") IDENT typeParams? "(" params ")" retType? "{" block "}"
+                 // a function whose body contains `yield expr;` is a generator (eager: collects yields, for-iterable)
 externDecl     ::= "extern" "def" IDENT typeParams? "(" params ")" retType? ";"     // no body
 classDecl      ::= ("class" | "struct") IDENT typeParams? "{" classMember* "}"
 classMember    ::= varDecl | funcDecl | IDENT ":" type ("=" expression)? ";"?       // field or method
@@ -49,7 +50,9 @@ implDecl       ::= "impl" (IDENT "for")? IDENT typeParams? "{" funcDecl* "}"
 importStmt     ::= "import" (STRING | IDENT ("." IDENT)*) ";"?
 
 typeParams     ::= "<" IDENT (":" type)? ("," IDENT (":" type)?)* ">"               // constraint parsed, ignored
-params         ::= ( ("self" (":" type)?) | (IDENT ":" type "..."?) ) ("," ...)*     // every non-self param MUST have a type; trailing "..." = variadic
+params         ::= ( ("self" (":" type)?) | (IDENT ":" type ("=" expression)? "..."?) ) ("," ...)*
+                 // every non-self param MUST have a type; trailing "..." = variadic;
+                 // "= expr" gives a trailing param a default (type annotation still required)
 retType        ::= ("->" | ":") type
 
 statement      ::= ifStmt | whileStmt | forStmt | "{" block "}" | returnStmt
@@ -72,7 +75,8 @@ type           ::= "(" (type ("," type)*)? ")" "->" type            // function 
                  | IDENT ("|" type)*                                // union type (parsed; treated as opaque ptr)
 
 expression     ::= assignment
-assignment     ::= elvis (("="|"+="|"-="|"*="|"/="|"%=") assignment)?   // target: var | obj.field | arr[i]
+assignment     ::= ternary (("="|"+="|"-="|"*="|"/="|"%=") assignment)?  // target: var | obj.field | arr[i]
+ternary        ::= elvis ("?" expression ":" ternary)?                   // C-style conditional, right-assoc
 elvis          ::= or (("?:"|"??") or)*
 or             ::= and ("||" and)*
 and            ::= bitOr ("&&" bitOr)*
@@ -102,21 +106,22 @@ primary        ::= INT | FLOAT | STRING | "true" | "false" | "None" | IDENT
 **Operator precedence**, lowest to highest (this is the recursive-descent chain in `parser.cpp` and is authoritative):
 
 1. `=` assignment, and compound assignment `+= -= *= /= %=` (right-assoc; compound desugars to `x = x OP y`)
-2. `?:` `??` (elvis / null-coalescing)
-3. `||` or `or` (logical OR — both spellings work)
-4. `&&` or `and` (logical AND — both spellings work)
-5. `|` (bitwise OR)
-6. `^` (bitwise XOR)
-7. `&` (bitwise AND)
-8. `==` `!=`
-9. `<` `<=` `>` `>=`
-10. `<<` `>>` (bit shifts)
-11. `+` `-`
-12. `*` `/` `%`
-13. unary `!` `-` `~`, `await`, `new`, `delete`, prefix `<-`
-14. postfix: call `()`, member `.`, safe member `?.`, force-unwrap `!!`, index `[]`, channel send `<-`
+2. `cond ? a : b` (C-style ternary conditional; right-assoc — `1 ? 2 : 0 ? 3 : 4` is `1 ? 2 : (0 ? 3 : 4)` = 2; only the taken branch evaluates)
+3. `?:` `??` (elvis / null-coalescing)
+4. `||` or `or` (logical OR — both spellings work)
+5. `&&` or `and` (logical AND — both spellings work)
+6. `|` (bitwise OR)
+7. `^` (bitwise XOR)
+8. `&` (bitwise AND)
+9. `==` `!=`
+10. `<` `<=` `>` `>=`
+11. `<<` `>>` (bit shifts)
+12. `+` `-`
+13. `*` `/` `%`
+14. unary `!` `-` `~`, `await`, `new`, `delete`, prefix `<-`
+15. postfix: call `()`, member `.`, safe member `?.`, force-unwrap `!!`, index `[]`, channel send `<-`
 
-> Both symbolic (`&&` `||`) and keyword (`and` `or`) forms of the logical operators work and are equivalent. Logical NOT is `!` only — the word `not` is **not** an operator. There is no ternary `?:` in the C sense; `?:` is the Kotlin-style elvis operator (null-coalescing). The power operator `**` and `++`/`--` are not implemented.
+> Both symbolic (`&&` `||`) and keyword (`and` `or`) forms of the logical operators work and are equivalent. Logical NOT is `!` only — the word `not` is **not** an operator. The **C-style ternary `cond ? a : b` is implemented** (see level 2); the *adjacent* two-character `?:` (no middle expression) is the Kotlin-style elvis operator (null-coalescing). The power operator `**` and `++`/`--` are not implemented.
 
 ---
 
@@ -144,19 +149,19 @@ primary        ::= INT | FLOAT | STRING | "true" | "false" | "None" | IDENT
 | `true` / `false` | Boolean literals. |
 | `None` | The null pointer; the empty `Option`; matches `case None:`. |
 | `and` / `or` | Logical AND/OR. The symbolic forms `&&` / `||` also work and are equivalent. (NOT: use `!`; the word `not` is not an operator.) |
-| `lambda` | Anonymous function value (body is a single expression). **Captures enclosing locals by value** (snapshot at creation); closures may be returned and escape. |
+| `lambda` | Anonymous function value (body is a single expression). Captures enclosing locals: **reads snapshot by value; writes share the cell** (an assignment to a captured local is visible outside after the closure runs). Read-capturing closures may be returned and escape. |
 | `self` | Method receiver (first parameter). |
 | `throw` / `try` / `catch` / `finally` | Exceptions (integer/handle payload via setjmp/longjmp). |
 | `go` | Spawn a goroutine (OS thread): `go f(args);`. |
 | `channel` | Channel type/constructor: `channel<int>()`. |
 | `select` | Wait on multiple channel receives. |
 | `<-` | Channel send (`ch <- v;`) and receive (`<-ch`). |
-| `async` / `await` | Parsed; async functions get a wrapper. Prefer goroutines+channels for real concurrency. |
+| `async` / `await` | Work with **eager** semantics: the async body runs on the calling path and `await f` yields the completed result (composes correctly; no true suspension — the M:N scheduler is future work). Prefer goroutines+channels for real parallelism. |
 | `new` / `delete` | `new` allocates; rarely needed (constructors via `ClassName(...)`). |
 
 ### Lexer keywords that are NOT implemented (do NOT use — they will fail to compile)
 
-`panic`, `recover`, `assert`, `yield`, `generator`, `coroutine`, `spawn`, `join`, `mutex`/`lock`/`unlock`, `atomic`, `volatile`, `move`/`borrow`, `constexpr`, `inline`, `export`, `module`, `namespace`, `package`, `using`, `with`, `super`, `as`, `is`, `instanceof`, `typeof`, `where`, `pub`/`priv`/`static`/`final`/`abstract`/`virtual`/`override`, `null`, `undefined`, `from`. Several of these are reserved words, so they also can't be used as identifiers. (`break`, `continue`, `switch`, and `defer` **are** implemented.)
+`panic`, `recover`, `assert`, `generator`, `coroutine`, `spawn`, `join`, `mutex`/`lock`/`unlock`, `atomic`, `volatile`, `move`/`borrow`, `constexpr`, `inline`, `export`, `module`, `namespace`, `package`, `using`, `with`, `super`, `as`, `is`, `instanceof`, `typeof`, `where`, `pub`/`priv`/`static`/`final`/`abstract`/`virtual`/`override`, `null`, `undefined`, `from`. Several of these are reserved words, so they also can't be used as identifiers. (`break`, `continue`, `switch`, `defer`, and `yield` **are** implemented — a `def` whose body contains `yield expr;` is a generator: calling it eagerly collects the yielded values into a sequence that `for x in gen(...)` iterates.)
 
 > **`break`/`continue` are fully implemented** in every loop (`for i in a..b`, `for v in arr`, `while`): unlabeled they affect the innermost loop, and a loop may carry a label (`outer: for ...`) so `break outer;` / `continue outer;` target it. **Use `None`, never `null`** (`null` is reserved and rejected as a value).
 
@@ -681,7 +686,7 @@ def main() -> int {
 }
 ```
 - Lambda syntax: `lambda (params) -> ReturnType <single-expression>`. The body is **one expression**, not a block. The `-> ReturnType` is recommended (defaults to a null/None type if omitted).
-- **Lambdas capture enclosing locals by value** — a snapshot taken when the lambda is created. The captured copy is independent (mutating the outer variable afterward does not change it), and the closure may be **returned and escape** its defining scope carrying its own state. Capture is by value only; there is no capture by reference.
+- **Lambda capture is by value for reads, by reference for writes.** A read-only capture is a snapshot taken at creation (mutating the outer variable afterward does not change it), and such a closure may be **returned and escape** its defining scope carrying its own state. A closure that *assigns* a captured local shares the cell — the write is visible outside after the call (escaping a write-capturing closure is not supported).
 
 ### Higher-order function over a collection
 ```tocin
@@ -801,8 +806,9 @@ This loop uses boolean flags for illustration, but `break`/`continue` (including
 ## 7. Idioms and conventions
 
 - **Every program needs `def main()`.** Annotate it `-> int` and `return` an int; that int becomes the process exit code. `return 0;` for success.
-- **Run with** `./build/tocin file.to --run`; compile to a binary with `-o name` (extension picks format: `.ll` IR, `.s` asm, `.o` object, otherwise an executable). `--dump-ir` prints LLVM IR. Default optimization is `-O2`; use `-O3 --native` for maximum speed on the build machine (`--native` enables host-CPU features — POPCNT/AVX — and is not portable to older CPUs).
-- **Type checking is strict by default:** undeclared identifiers, wrong argument counts, clear operator/return-type violations, and assignment to undeclared variables are compile ERRORS that block codegen (with `file:line:col` locations). `--permissive` prints them but compiles anyway (not recommended; kept for migration).
+- **Run with** `./build/tocin file.to --run`; compile to a binary with `-o name` (extension picks format: `.ll` IR, `.s` asm, `.o` object, otherwise an executable). `--dump-ir` prints LLVM IR. Default optimization is `-O2`; use `-O3 --native` for maximum speed on the build machine (`--native` enables host-CPU features — POPCNT/AVX — and is not portable to older CPUs). Subcommands: `tocin check file.to` (typecheck only, exit 0 if clean), `tocin new name` (scaffold main.to/README/.gitignore), `tocin doc file.to` (Markdown API docs from signatures + the `//` comment block above each declaration).
+- **Type checking is strict by default:** undeclared identifiers, wrong argument counts (builtins included), clear operator/return-type violations, assignment to undeclared variables, and assignment to a `const` (`T013`) are compile ERRORS that block codegen — rendered with the source line, a caret underline, `did you mean '…'?` suggestions, and an `N errors generated.` summary. `--permissive` prints them but compiles anyway (not recommended; kept for migration).
+- **Runtime traps instead of UB:** integer division/modulo by zero and out-of-bounds indexing abort with `panic: <msg> at file:line:col` (exit 134) rather than corrupting memory (`--freestanding` omits the bounds checks).
 - **Whole-program optimization is automatic** when producing an executable or running with `--run`: everything except `main` is internalized, so unused functions are eliminated and cross-function inlining/specialization is unrestricted. Pure computations on compile-time-known inputs may be **folded at compile time** (like C/Rust at -O3) — benchmark with runtime-derived inputs.
 - **Naming:** functions/variables/fields `lowerCamelCase`; types/classes/enums/traits `UpperCamelCase`; enum members `UpperCamelCase`. (Conventional, not enforced.)
 - **Booleans as ints:** stdlib and idiomatic code represent truth as `int` `0`/`1` (e.g. `mapHasStr` returns `1`/`0`, `isPrime` returns `1`/`0`). Compare explicitly: `if mapHasStr(m, k) == 1 { ... }`.
@@ -817,12 +823,12 @@ This loop uses boolean flags for illustration, but `break`/`continue` (including
 
 ## 8. GOTCHAS / PITFALLS (read before writing — each is verified)
 
-1. **`break` / `continue` work in every loop** (`for i in a..b`, `for v in arr`, `while`). Unlabeled, they affect the **innermost** loop; a loop may carry a label (`outer: for ...`) and `break outer;` / `continue outer;` target it. (`switch` aliases `match`; `defer` runs LIFO at function return. Still unimplemented: `panic`, `assert`, `yield`, ownership keywords — see §3.)
+1. **`break` / `continue` work in every loop** (`for i in a..b`, `for v in arr`, `while`). Unlabeled, they affect the **innermost** loop; a loop may carry a label (`outer: for ...`) and `break outer;` / `continue outer;` target it. (`switch` aliases `match`; `defer` runs LIFO at function return; `yield` makes a `def` an eager generator. Still unimplemented: `panic`, `assert`, ownership keywords — see §3.)
 2. **Use `None`, not `null`.** `null` is a reserved word the parser doesn't accept as a value (`Expected expression`). The empty value is `None` (the null pointer).
 3. **`len` is for array literals only.** `len("hello")` returns garbage (it reads the first 8 bytes of the string as an i64 "length"). For strings use **`strLen`**. `len` works on `[1,2,3]` and `list<int>` params; `vecLen` works on `vector` handles; `mapLen` on `map` handles.
 4. **Mixed int/float arithmetic auto-promotes the int to float.** `5 + 3.0` → `8.0`; `10 / 4.0` → `2.5`. Two ints stay int and `/` truncates (`5 / 2` → `2`). To force float division of two ints, make one a float (`x * 1.0 / y`).
 5. **Collection/map/channel handle parameters need an opaque annotation.** Untyped params are a parse error (every parameter must be `name: Type`). Annotate handles as `v: vector`, `m: map`, or `ch: channel<int>`. Any non-collection type name lowers to an opaque pointer, so `vector`/`map` are just conventions that happen to work.
-6. **Lambdas capture enclosing locals BY VALUE** (a snapshot at creation). Mutating the original after capture does not change the captured copy, and a closure may be returned and outlive its defining scope with independent state. Captured variables are read-only inside the lambda for the purpose of affecting the outside. Lambda bodies are a **single expression**, not a block: `lambda (x: int) -> int x + n`.
+6. **Lambda capture: reads are BY-VALUE snapshots, writes SHARE the cell.** A closure that only reads a captured local snapshots it at creation (mutating the original afterward doesn't change what it sees). A closure that *assigns* a captured local (`lambda () -> int count = count + 1`) shares the variable, so the write is visible in the enclosing scope after the call. Escaping a *write*-capturing closure past its defining frame is not supported; read-capturing closures may be returned and escape. Lambda bodies are a **single expression**, not a block: `lambda (x: int) -> int x + n`.
 7. **Function-valued locals are usually callable without an annotation.** `let f = inc; f(6)`, `let f = lambda (x: int) -> int x+1; f(6)`, and `let f = makeAdder(10); f(7)` all work — the signature is recovered from the right-hand side (a named function, a lambda, or a function whose declared return type is itself a function type). An explicit `let f: (int) -> int = ...` is only needed when the initializer is too opaque for that inference.
 8. **Collection / Option / channel / thrown payloads are 64-bit slots.** They are designed for `int`. Pointers/strings stored *as elements* are bit-cast to/from `i64`; they round-trip as raw addresses but there is no element type tracking, so this is fragile (e.g. don't expect a string read back from a `vector` to format correctly without care). Prefer storing ints; for string-keyed lookups use the dedicated `mapPutStr`/`mapGetStr`.
 9. **`None` is a null pointer.** `?:`, `?.`, `!!`, and `case None:` all hinge on null. `x!!` on a null value calls `abort()` and kills the process. `?:`/`?.` only do anything meaningful when the left side is a pointer type (class/Option/string); on a non-pointer they are effectively identity.

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -1072,9 +1072,13 @@ sum of squares = 14
 ### Capturing closures
 
 A lambda can use the local variables of the function it is defined in, not just
-its own parameters — this makes it a *closure*. The capture is **by value**: the
-lambda takes a snapshot of each captured variable at the moment it is created.
-Changing the original variable afterwards does not change what the lambda saw.
+its own parameters — this makes it a *closure*. Capture works two ways:
+
+- a lambda that only **reads** a captured variable takes a **by-value
+  snapshot** at the moment it is created — changing the original afterwards
+  does not change what the lambda saw;
+- a lambda that **assigns** to a captured variable **shares it** — the write
+  is visible in the enclosing scope after the lambda runs.
 
 ```tocin
 def main() {
@@ -1120,12 +1124,25 @@ add10(1)  = 11
 add100(1) = 101
 ```
 
+Writing to a captured variable shares it instead — handy for counters and
+accumulators:
+
+```tocin
+def main() -> int {
+    let count = 0;
+    let inc = lambda () -> int count = count + 1;   // assigns the capture
+    inc(); inc(); inc();
+    println("count = {}", count);   // 3 — visible out here
+    return 0;
+}
+```
+
 A few things worth knowing:
 
-> **Capture is by value, not by reference.** A closure can read the snapshot it
-> captured, but it cannot reach back and mutate the caller's variable, and
-> later changes to that variable are not seen by the closure. If you need shared
-> mutable state, pass it explicitly (for example a `vector` handle).
+> **Read captures are snapshots; write captures are shared.** A closure that
+> only reads sees the value from creation time; one that assigns mutates the
+> caller's variable. A *write*-capturing closure must not outlive the function
+> that created it (returning read-capturing closures, as above, is fine).
 >
 > **A function-typed local may be annotated, but doesn't have to be.** Storing a
 > returned function in `let f = chooser(1);` works with or without the
@@ -1361,18 +1378,22 @@ practical limitations in mind:
   using it on a string yields a garbage number.
 - Collection handles are opaque: annotate parameters with the type names
   `vector` and `map`, and use the `vec*`/`map*` functions to work with them.
-- Lambdas **capture by value** — they snapshot the surrounding locals they use,
-  so mutating the original afterwards (or trying to mutate it from inside the
-  lambda) has no effect. For shared mutable state, pass a handle explicitly.
+- Lambdas capture surrounding locals **by value for reads** (a snapshot —
+  mutating the original afterwards has no effect on the closure) and **by
+  reference for writes** (assigning a captured variable inside the lambda is
+  visible outside). See "Capturing closures" above.
 - Nested `def` functions **cannot capture** their parent's locals; use a
   `lambda` when you need capture.
-- There is **no automatic memory management (no GC)** yet: heap allocations such
-  as concatenated strings, array literals, closures, vectors, and maps are not
-  freed automatically, so long-running programs leak. Free vectors and maps
-  manually with `vecFree`/`mapFree` when you can.
-- `switch` and `defer` are **not** implemented — use `match` / `case` for
-  multi-way branching. There is also no `**` power operator and no `++`/`--`;
-  use `pow`/`x * x` and `x += 1` / `x -= 1` instead.
+- Memory is **garbage-collected** (Boehm GC): concatenated strings, array
+  literals, closures, vectors, and maps are reclaimed automatically when
+  unreachable. `vecFree`/`mapFree`/`free` remain for eager release of very
+  large buffers.
+- `switch` (an alias of `match`) and `defer` (run a statement at function
+  return) **are** implemented. There is no `**` power operator and no
+  `++`/`--`; use `pow`/`x * x` and `x += 1` / `x -= 1` instead.
+- Division or modulo by zero and out-of-bounds indexing don't corrupt memory —
+  they abort with a message like
+  `panic: integer division by zero at file.to:4:16`.
 
 When in doubt, do what this tutorial did: write the smallest program that
 exercises the feature, run it with `--run`, and check the output.
@@ -1385,6 +1406,21 @@ You can now write real Tocin: variables and functions, control flow,
 collections and strings, classes with traits and generics, error handling with
 `throw`/`try` and with `Option`/`Result`, null-safe references, first-class
 functions, concurrency, files, modules, macros, and C interop.
+
+A few features this tutorial didn't tour, all covered in the reference:
+
+- **Ternary conditionals** — `let m = a > b ? a : b;`
+  ([reference §3](language-reference.md#3-operators--precedence)).
+- **Default parameter values** — `def f(a: int, b: int = 10)`
+  ([reference §5](language-reference.md#5-functions)).
+- **Generators** — a `def` containing `yield` produces a `for`-iterable
+  sequence ([reference §5](language-reference.md#5-functions)).
+- **`async` / `await`** (eager semantics today) and the low-level **kernel
+  primitives** (volatile loads/stores, `fence()`, inline `asm`)
+  ([reference §14, §21](language-reference.md#14-concurrency)).
+- **Project tooling** — `tocin new` scaffolds a project, `tocin check`
+  typechecks without compiling, `tocin doc` generates API docs
+  ([reference §19](language-reference.md#19-compilation--execution)).
 
 To go deeper:
 

--- a/installer/README.md
+++ b/installer/README.md
@@ -8,10 +8,15 @@ producing and publishing the release packages.
 
 | File | Role |
 |---|---|
+| `build-all.sh` | **One-command builder** — produces every installer this platform can make (Linux: `.tar.gz` + `.run` + `.deb`; macOS: `.pkg` + `.dmg`). |
 | `linux/Build-TocinInstaller.sh` | **Turnkey Linux builder** — bootstraps the toolchain, builds, bundles, and packages in one run (see below). |
 | `windows/Build-TocinInstaller.ps1` | **Turnkey Windows builder** — bootstraps the toolchain, builds, and packages in one run (see below). |
 | `package.sh` | Build a Linux/macOS tarball (`dist/tocin-<ver>-<os>-<arch>.tar.gz`); `--bundle-libs` for the self-contained flavor. |
 | `package.ps1` | Build a Windows zip when the toolchain is *already* installed. |
+| `linux/make-run.sh` | Build the self-extracting Linux `.run` installer from the staged tarball. |
+| `linux/make-deb.sh` | Turn the staged payload into a Debian/Ubuntu `.deb` (GUI install via the software center). |
+| `macos/make-pkg.sh` | Build the macOS `.pkg` and a `.dmg` wrapping it (run on macOS). |
+| `make-link-recipe.sh` | Build the self-contained native-link bundle so `tocin file.to -o app` links without a system gcc/clang. |
 | `install.sh` | Per-user installer that ships *inside* each Unix tarball. |
 | `install.ps1` | Per-user installer for Windows (also a download bootstrap). |
 | `get-tocin.sh` | `curl \| sh` bootstrap: download the latest release + install. |

--- a/stdlib/std/linq.to
+++ b/stdlib/std/linq.to
@@ -1,9 +1,9 @@
 // Tocin standard library: LINQ-style collection operations over int lists.
 //
-// Tocin does not yet have first-class lambdas, so transforms come in two forms:
-//   * reductions/aggregations that return a scalar, and
-//   * `*Into` transforms that write into a caller-allocated destination list.
-// Booleans are represented as int (0/1), matching std.list / std.math.
+// These are the allocation-light variants: reductions/aggregations that
+// return a scalar, and `*Into` transforms that write into a caller-allocated
+// destination list. For higher-order map/filter/fold with lambda callbacks,
+// use std.functional. Booleans are int (0/1), matching std.list / std.math.
 
 // ---- Reductions / aggregations ----
 


### PR DESCRIPTION
## What

A full documentation reconciliation: every doc now describes the compiler **as it actually behaves today**. 28 files, +1,691 / −4,497 lines (the deletions are almost entirely fictional content).

Two independent audits swept all ~30 docs against the codebase; every claim that survived was verified against `build/tocin` — **every new example was executed**, every stdlib function name mentioned was checked against `stdlib/` source and the builtin registry, and a link check found zero dead relative links afterward.

## Updated in place (flagship docs)

- **README** — strict caret diagnostics, runtime traps, ternary + default parameters, eager async/await, the 34-module stdlib, kernel primitives with real `asm` syntax, the 12-kernel benchmark standing (geomean ties Rust, fastest on 5/12), `check`/`new`/`doc` tooling, bundled-`ld.lld` linking, LLVM 18–22, fixed repo URLs, pruned stale roadmap items.
- **language-reference** — ternary (grammar + precedence + verified associativity), default parameters, generators (eager), async section, read/write closure-capture asymmetry, enforced `const` (T013) and trait bounds (T016), trait objects, Boehm-GC memory model, full CLI table + subcommands, new Diagnostics and Runtime-traps sections, corrected keyword tables (`log`/`warn`/`error`… unreserved; `switch`/`defer`/`yield` active), new networking/time/hash/random and raw-memory/kernel-primitive builtin sections, rewritten Limitations (dropped: no-GC, const-unenforced, no-defer, trait-bounds-ignored; added: nested generic-of-generic gap).
- **tutorial** — capture asymmetry with a runnable counter example, GC, switch/defer, traps, and a pointer list for features it doesn't tour.
- **tocin-for-ai** — ternary in the grammar/precedence chain, default params, generators, eager async, capture asymmetry, subcommands, `const`/builtin-arity strictness, trap bullet.
- **stdlib-reference** — "there is no garbage collector"/leak guidance replaced with actual GC semantics; `strFromAddr` round-trip note.
- **capability-report** — the single-benchmark "~9% of C" claim replaced with the current 12-kernel C/C++/Rust standing.
- **INSTALL.md** — the Notes section no longer contradicts the bundled-linker story.

## Rewritten from scratch

The old content documented things that never existed (a `tocin build`/`tocin init` CLI, `tocin-pkg`/`tocin-fmt` binaries, `Math.*`/`collections.*`/`system.*` namespaces, method-chained LINQ, a Python-style evaluating REPL, a generational GC, DEB/RPM/AppImage/Homebrew packaging):

- **02_Getting_Started** — real install paths + the actual CLI.
- **04_Standard_Library / STDLIB_GUIDE / LINQ** — grounded in the 34 real modules; every function name source-verified, every example run (including a real `std.testing` test file).
- **INTERPRETER_GUIDE** — now "Running Tocin Programs": JIT/AOT + an honest description of what the REPL does (compiles + dumps IR; doesn't evaluate).
- **INSTALLER_GUIDE** — matches the real `installer/` scripts and artifacts.
- **INTEGRATION_GUIDE** — interop status matrix; includes a **verified** Tocin-`.o`-linked-into-C example (`nm` shows plain `T tadd`; C program runs).
- **ARCHITECTURE** — the real pipeline (no interpreter/bytecode VM), PassBuilder + TargetMachine optimization, Boehm GC, OS-thread goroutines, testing + distribution architecture.
- **docs/README** — the index now lists the docs that exist (dead links to QUICK_START/LEXER_PARSER_ENHANCEMENTS/FINAL_REPORT removed).

## Mechanical fixes

`fn` → `def` and `.tc` → `.to` across LANGUAGE_FEATURES/OPTION_RESULT_TYPES/TRAITS/CONCURRENCY; anonymous `go func(){}` → named-function spawns; `!` → `!!` in NULL_SAFETY; BUILDING (LLVM 18–22, V8 status, clone URL); CONTRIBUTING (CI reality; no coverage claim); PERFORMANCE (dead link, no-TCO note); 05_Advanced_Topics (design-sketch disclaimers); installer/README (`build-all.sh` + helpers). One code comment: `stdlib/std/linq.to` no longer claims lambdas don't exist.

## Notable discovery (not fixed here)

While verifying, found that a generic class instantiated with **another generic class** (`Box<Box<int>>` annotation → segfault; `Box(Box(21))` inference → type error) doesn't work, while generics over plain classes (`Box<W>`) do. Documented honestly in the reference's Limitations; worth a compiler fix in a follow-up.

## Verification

- JIT stdlib suite: all suites pass; lli suite: 145/145.
- All new doc examples executed against `build/tocin` (ternary associativity, default params, generators, async, const T013 error output, write-capturing closures, `clamp`, panic output, `tocin new` output, C-links-Tocin-object).
- Zero dead relative `.md` links across `docs/`, README, INSTALL, CONTRIBUTING, installer/README.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Fih5HHhUzVNkusdaXHoSdu)_