### PR TITLE
codegen: typed MMIO structs (mmio struct + mmioAt) for driver work

### DIFF
--- a/docs/kernel-development.md
+++ b/docs/kernel-development.md
@@ -106,6 +106,39 @@ def outb(port: int, val: int) { asm("outb %al, %dx", "{ax},{dx}", val, port); }
 def inb(port: int) -> int      { return asm("inb %dx, %al", "={ax},{dx}", port); }
 ```
 
+## Typed device registers: `mmio struct`
+
+Manual `volatileStore32(base, offset, v)` calls are error-prone — the offsets
+are magic numbers. An **`mmio struct`** names a memory-mapped register block as
+a struct with sized fields (`u8`/`u16`/`u32`/`u64`, laid out in C order), and
+lowers **every field access to a volatile load/store** at the physical base.
+Get a typed handle from an address with `mmioAt(addr)`:
+
+```tocin
+mmio struct Uart {
+    thr: u32;      // offset 0x00
+    ier: u32;      // offset 0x04
+    iir_fcr: u32;  // offset 0x08
+    lcr: u32;      // offset 0x0C
+    lsr: u32;      // offset 0x14  (0x10 is mcr, elided here for brevity)
+}
+
+def putc(base: int, ch: int) {
+    let u: Uart = mmioAt(base);        // typed view at a physical address
+    while (u.lsr & 0x20) == 0 { }      // volatile read — polls the real register
+    u.thr = ch;                        // volatile write
+}
+```
+
+`u.thr = ch` emits `store volatile i32`, and `u.lsr` emits `load volatile i32`,
+each at the field's true offset — no elision, no reordering, no manual offset
+arithmetic. `mmio struct` works in `--freestanding` (it needs no runtime), and
+the sized fields interoperate with default `int` (i64) values in arithmetic and
+comparisons. Because LLVM integers are sign-agnostic, `u8`/`u16`/`u32`/`u64`
+are width aliases of `i8`/`i16`/`i32`/`i64`; mixed-width integer operands are
+sign-extended to the wider type. A full driver is in
+[`examples/kernel/mmio_uart.to`](../examples/kernel/mmio_uart.to).
+
 ## Raw memory and globals
 
 `alloc` / `free` / `memcpy` / `memset` / `ptrAdd` and the width-typed
@@ -132,7 +165,8 @@ kernel.elf -serial stdio`).
 
 **Provided:** freestanding objects, cross-target codegen (triple/CPU/features/
 code-model/reloc/red-zone), `naked`/`interrupt` functions, module-level asm,
-constrained inline asm, volatile MMIO, raw memory, a bundled linker, and the C
+constrained inline asm, volatile MMIO with typed `mmio struct` register blocks
+(sized `u8`/`u16`/`u32`/`u64` fields), raw memory, a bundled linker, and the C
 ABI (`extern def`) so Tocin objects link into C/asm and vice-versa.
 
 **Still your job** (as in C): the boot trampoline, paging/long-mode setup for

--- a/docs/language-reference.md
+++ b/docs/language-reference.md
@@ -141,7 +141,8 @@ identifier by a token-level preprocessing pass (see [§15](#15-macros)).
 | Tocin | LLVM | Description |
 |---|---|---|
 | `int` (alias `i64`) | `i64` | 64-bit signed integer. The default integer type. |
-| `i32`, `i16`, `i8` | `i32`/`i16`/`i8` | Sized integers (mainly for FFI). |
+| `i32`, `i16`, `i8` | `i32`/`i16`/`i8` | Sized integers (FFI, MMIO registers, packed layouts). |
+| `u64`, `u32`, `u16`, `u8` | `i64`/`i32`/`i16`/`i8` | Width aliases of the sized ints (LLVM integers are sign-agnostic). Mixed-width integer operands sign-extend to the wider type. |
 | `float` (alias `f64`) | `double` | 64-bit IEEE float. The default float type. |
 | `f32` (alias `float32`) | `float` | 32-bit IEEE float. |
 | `bool` | `i1` | `true` / `false`. |
@@ -711,6 +712,27 @@ Class instances are reference values (opaque pointers). A class-typed variable
 may hold `None` (see [§12](#12-null-safety)).
 
 Generic classes (`class C<T>`) are covered in [§8](#8-generics).
+
+### `mmio struct` — memory-mapped device registers
+
+A struct declared `mmio struct` models a block of hardware registers: it uses a
+C field layout (sized `u8`/`u16`/`u32`/`u64` fields at their natural offsets),
+and **every field read/write lowers to a *volatile* load/store** — never
+elided, merged, or reordered, as hardware requires. Obtain a typed handle at a
+physical address with the `mmioAt(addr)` builtin:
+
+```tocin
+mmio struct Uart { data: u32; status: u32; control: u32; }
+
+def putc(base: int, ch: int) {
+    let u: Uart = mmioAt(base);      // typed view at a physical address
+    while (u.status & 0x20) == 0 { } // volatile register read
+    u.data = ch;                     // volatile register write
+}
+```
+
+`mmio struct` needs no runtime, so it works under `--freestanding` for kernel
+and driver code. See [kernel-development.md](kernel-development.md).
 
 ---
 
@@ -1701,6 +1723,11 @@ At most one `=`-output constraint is allowed; templates use AT&T syntax with
 `$0`, `$1`, … operands. Combined with `--freestanding` these are the
 primitives for MMIO device registers and kernel work — see
 `tests/jit/kernel_primitives.to` for a runnable tour.
+
+For **typed** register access, `mmioAt(addr)` returns a typed handle to an
+`mmio struct` at a physical address, so device registers are named fields with
+volatile access instead of raw offsets (see the `mmio struct` subsection in
+§6). `mmioAt` is the typed counterpart to the raw `volatile{Load,Store}*`.
 
 **Module-level assembly.** `asmModule("...")` emits assembly verbatim into the
 module, outside any function — for a Multiboot header, an `_start` entry point,

--- a/docs/tocin-for-ai.md
+++ b/docs/tocin-for-ai.md
@@ -384,6 +384,15 @@ Two calling styles:
 | `fence()` | `() -> int` | full sequentially-consistent hardware memory barrier |
 | `asm("tmpl")` | template literal | raw side-effecting assembly, no operands (`asm("cli")`, `asm("hlt")`) |
 | `asm(tmpl, constraints, args...)` | literals + ints | constrained assembly (LLVM/GCC syntax, AT&T dialect): at most one leading `"=..."` output, one constraint per input, `~{...}` clobbers. Returns the output operand (or 0). Examples: `let t = asm("rdtsc", "={ax},~{dx}")`, `let s = asm("lea 100($1), $0", "=r,r", x)`, `asm("outb %b1, %w0", "{dx},{ax}", port, val)` |
+| `asmModule("...")` | template literal | emit assembly at module scope (outside functions): multiboot header, `_start`, GDT stubs. Accretes in source order. |
+| `mmioAt(addr)` | `(int) -> ptr` | typed handle to an `mmio struct` at a physical address: `let u: Uart = mmioAt(0x10000000)`. Field access on it is volatile (see below). |
+
+**`mmio struct` — typed device registers.** `mmio struct Name { data: u32; status: u32; ... }` declares a memory-mapped register block: C field layout with sized fields (`u8`/`u16`/`u32`/`u64`, width-aliases of `i8`/`i16`/`i32`/`i64`), and **every field load/store is volatile**. Combine with `mmioAt(addr)`:
+```tocin
+mmio struct Uart { data: u32; status: u32; }
+def putc(base: int, ch: int) { let u: Uart = mmioAt(base); while (u.status & 0x20) == 0 { } u.data = ch; }
+```
+Needs no runtime → works under `--freestanding`. Sized-int fields interoperate with `int` (i64) literals in arithmetic/comparisons (mixed integer widths sign-extend to the wider type). Plain (non-`mmio`) structs keep normal non-volatile field access.
 
 **Option / Result / channels**
 | Builtin | Signature | Returns |

--- a/examples/kernel/mmio_uart.to
+++ b/examples/kernel/mmio_uart.to
@@ -1,0 +1,69 @@
+// mmio_uart.to — a memory-mapped 16550 UART driver written with an `mmio struct`.
+//
+// Many platforms (ARM, RISC-V, embedded x86) expose the UART as a block of
+// memory-mapped registers rather than x86 I/O ports. An `mmio struct` models
+// that block directly: field access lowers to *volatile* loads/stores at the
+// physical base, so reads/writes are never elided, merged, or reordered — the
+// contract hardware registers require. This is the typed alternative to manual
+// `volatileStore32(base, offset, v)` calls.
+//
+// Build (freestanding, no libc/GC/runtime):
+//   tocin mmio_uart.to --freestanding --target-triple x86_64-unknown-none \
+//         --reloc static --no-red-zone -o mmio_uart.o
+//
+// Link mmio_uart.o into your kernel and call uartPuts() with a raw byte buffer.
+
+// A 16550-style UART with 32-bit, 4-byte-spaced registers (reg-shift 2), the
+// common memory-mapped layout. Sized fields (u32) give an exact C layout, so
+// each register sits at its true offset: thr=0x00, ier=0x04, ... scratch=0x1C.
+mmio struct Uart16550 {
+    thr_rbr: u32;   // 0x00  THR (write) / RBR (read) / DLL (when DLAB=1)
+    ier_dlh: u32;   // 0x04  IER / DLH
+    iir_fcr: u32;   // 0x08  IIR (read) / FCR (write)
+    lcr: u32;       // 0x0C  line control
+    mcr: u32;       // 0x10  modem control
+    lsr: u32;       // 0x14  line status
+    msr: u32;       // 0x18  modem status
+    scratch: u32;   // 0x1C  scratch
+}
+
+// Program the UART for 8-N-1 at the divisor `div`, FIFOs enabled.
+def uartInit(base: int, div: int) {
+    let u: Uart16550 = mmioAt(base);
+    u.ier_dlh = 0;         // mask interrupts
+    u.lcr = 0x80;          // DLAB=1: divisor latch accessible
+    u.thr_rbr = div;       // divisor low
+    u.ier_dlh = 0;         // divisor high
+    u.lcr = 0x03;          // DLAB=0, 8 bits, no parity, 1 stop
+    u.iir_fcr = 0xC7;      // enable + clear FIFOs, 14-byte trigger
+    u.mcr = 0x0B;          // DTR, RTS, OUT2
+}
+
+// Poll the Transmit-Holding-Register-Empty bit (LSR bit 5), then write a byte.
+def uartPutc(base: int, ch: int) {
+    let u: Uart16550 = mmioAt(base);
+    // Spin until the transmit holding register is empty.
+    while (u.lsr & 0x20) == 0 { }
+    u.thr_rbr = ch;
+}
+
+// Write `n` bytes from a raw buffer (freestanding: no string type).
+def uartPuts(base: int, buf: int, n: int) {
+    let i = 0;
+    while i < n {
+        uartPutc(base, loadByte(buf, i));
+        i = i + 1;
+    }
+}
+
+// Demo entry: assumes a UART mapped at 0x1000_0000 (adjust per platform).
+def main() -> int {
+    let base = 0x10000000;
+    uartInit(base, 1);         // divisor 1
+    let msg = alloc(3);
+    storeByte(msg, 0, 72);     // 'H'
+    storeByte(msg, 1, 105);    // 'i'
+    storeByte(msg, 2, 10);     // '\n'
+    uartPuts(base, msg, 3);
+    return 0;
+}

--- a/src/ast/ast.h
+++ b/src/ast/ast.h
@@ -698,6 +698,9 @@ namespace ast
         std::vector<TypePtr> interfaces;           // Implemented interfaces/traits
         std::vector<StmtPtr> fields;
         std::vector<StmtPtr> methods;
+        // `mmio struct`: a memory-mapped device register block. Field accesses
+        // are lowered to volatile loads/stores (for hardware registers).
+        bool isMmio = false;
 
         bool isGeneric() const { return !typeParameters.empty(); }
     };

--- a/src/codegen/ir_generator.cpp
+++ b/src/codegen/ir_generator.cpp
@@ -238,20 +238,22 @@ llvm::Type *IRGenerator::getLLVMType(ast::TypePtr type)
         if (bound != typeBindings.end())
             return bound->second;
 
-        // Check for basic type names
-        if (typeName == "int" || typeName == "i64")
+        // Check for basic type names. Sized ints (u*/i* — LLVM integers are
+        // sign-agnostic, so u32 and i32 share a width) are the field types for
+        // MMIO register structs and packed on-disk/on-wire layouts.
+        if (typeName == "int" || typeName == "i64" || typeName == "u64" || typeName == "usize" || typeName == "isize")
         {
             return llvm::Type::getInt64Ty(context);
         }
-        else if (typeName == "i32")
+        else if (typeName == "i32" || typeName == "u32")
         {
             return llvm::Type::getInt32Ty(context);
         }
-        else if (typeName == "i16")
+        else if (typeName == "i16" || typeName == "u16")
         {
             return llvm::Type::getInt16Ty(context);
         }
-        else if (typeName == "i8")
+        else if (typeName == "i8" || typeName == "u8")
         {
             return llvm::Type::getInt8Ty(context);
         }
@@ -1907,6 +1909,13 @@ void IRGenerator::visitCallExpr(ast::CallExpr *expr)
                 // that address back into a usable string value (no copy).
                 auto a = slot(0); if (!a) return;
                 lastValue = builder.CreateIntToPtr(a, ptrb, "s.fromaddr"); return; }
+            if (funcName == "mmioAt" && na == 1) {
+                // Treat an integer physical/virtual address as a typed struct
+                // pointer: `let u: Uart = mmioAt(0x10000000);`. The result is an
+                // opaque pointer; the `let`'s declared (mmio) struct type gives
+                // field access its layout and makes the loads/stores volatile.
+                auto a = slot(0); if (!a) return;
+                lastValue = builder.CreateIntToPtr(a, ptrb, "mmio.at"); return; }
             if (funcName == "bufToStr" && na == 2) {    // copy n bytes -> NUL-terminated string
                 // The missing piece for O(n) string building: assemble bytes in
                 // a raw buffer (data/strbuf) then materialize one string, instead
@@ -3820,6 +3829,7 @@ void IRGenerator::visitClassStmt(ast::ClassStmt *stmt)
 
     info.classType = structType;
     info.baseClass = nullptr;
+    info.isMmio = stmt->isMmio;
     classTypes[stmt->name] = info;
 
     // Generate each method (with an implicit leading 'this' parameter).
@@ -5074,7 +5084,12 @@ void IRGenerator::visitGetExpr(ast::GetExpr *expr)
             // Get a pointer to the field (using the known struct type)
             llvm::Value *fieldPtr = builder.CreateGEP(
                 structType, object, indices, "field." + expr->name);
-            lastValue = builder.CreateLoad(fieldType, fieldPtr);
+            llvm::LoadInst *ld = builder.CreateLoad(fieldType, fieldPtr);
+            // mmio struct: hardware register read must be volatile (never
+            // elided, hoisted, or merged with adjacent accesses).
+            if (classInfo.isMmio)
+                ld->setVolatile(true);
+            lastValue = ld;
             return;
         }
         else
@@ -5178,7 +5193,10 @@ void IRGenerator::visitSetExpr(ast::SetExpr *expr)
         llvm::ConstantInt::get(llvm::Type::getInt32Ty(context), 0),
         llvm::ConstantInt::get(llvm::Type::getInt32Ty(context), (unsigned)fieldIndex)};
     llvm::Value *fieldPtr = builder.CreateGEP(structType, object, indices, "field." + expr->name);
-    builder.CreateStore(val, fieldPtr);
+    llvm::StoreInst *st = builder.CreateStore(val, fieldPtr);
+    // mmio struct: hardware register write must be volatile.
+    if (info.isMmio)
+        st->setVolatile(true);
     lastValue = val;
 }
 
@@ -5662,6 +5680,7 @@ void IRGenerator::registerClassType(ast::ClassStmt *stmt)
         structType->setBody(fieldTypes);
     info.classType = structType;
     info.baseClass = nullptr;
+    info.isMmio = stmt->isMmio;
     classTypes[stmt->name] = info;
 }
 
@@ -6438,6 +6457,20 @@ void IRGenerator::visitBinaryExpr(ast::BinaryExpr *expr)
     } else if ((left->getType()->isFloatTy() || left->getType()->isDoubleTy()) &&
                right->getType()->isIntegerTy() && !right->getType()->isIntegerTy(1)) {
         right = builder.CreateSIToFP(right, left->getType(), "promote");
+    }
+    // Mixed integer widths: reconcile to the wider type before the op. Without
+    // this, mixing a sized field (i8/i16/i32, e.g. a u32 MMIO register) with a
+    // default `int` (i64) literal produces a type-mismatched icmp/add that fails
+    // verification. Sign-extend to match the language's signed integer model.
+    else if (left->getType()->isIntegerTy() && right->getType()->isIntegerTy() &&
+             !left->getType()->isIntegerTy(1) && !right->getType()->isIntegerTy(1) &&
+             left->getType() != right->getType()) {
+        unsigned lw = left->getType()->getIntegerBitWidth();
+        unsigned rw = right->getType()->getIntegerBitWidth();
+        if (lw < rw)
+            left = builder.CreateSExt(left, right->getType(), "iwiden");
+        else
+            right = builder.CreateSExt(right, left->getType(), "iwiden");
     }
 
     // Handle different operators

--- a/src/codegen/ir_generator.h
+++ b/src/codegen/ir_generator.h
@@ -30,6 +30,10 @@ namespace codegen
         std::vector<std::string> memberNames; // Names of class members
         llvm::StructType *baseClass;          // Base class type (if any)
         std::map<std::string, llvm::Type *> memberTypes;
+        // `mmio struct`: a memory-mapped device register block. Every field
+        // load/store is emitted volatile (never elided, merged, or reordered),
+        // which is mandatory for hardware registers.
+        bool isMmio = false;
     };
 
     // Structure to hold generic instance information

--- a/src/parser/parser.cpp
+++ b/src/parser/parser.cpp
@@ -95,6 +95,17 @@ namespace parser
                 consume(lexer::TokenType::DEF, "Expected 'def' after 'extern'");
                 return methodDeclaration(/*allowNoBody=*/true);
             }
+            // `mmio struct Name { ... }`: a memory-mapped register block whose
+            // field accesses lower to volatile loads/stores. `mmio` is a
+            // contextual keyword (an identifier) recognized only before
+            // struct/class, so it stays usable as an ordinary name elsewhere.
+            if (check(lexer::TokenType::IDENTIFIER) && peek().value == "mmio" &&
+                (checkNext(lexer::TokenType::STRUCT) || checkNext(lexer::TokenType::CLASS)))
+            {
+                advance(); // consume 'mmio'
+                advance(); // consume 'struct'/'class'
+                return classDeclaration(/*isMmio=*/true);
+            }
             if (match(lexer::TokenType::CLASS) || match(lexer::TokenType::STRUCT))
             {
                 return classDeclaration();
@@ -289,7 +300,7 @@ namespace parser
         return std::make_shared<ast::BlockStmt>(tok, stmts);
     }
 
-    ast::StmtPtr Parser::classDeclaration()
+    ast::StmtPtr Parser::classDeclaration(bool isMmio)
     {
         auto name = consume(lexer::TokenType::IDENTIFIER, "Expected class name");
         std::vector<ast::TypeParameter> typeParams = parseTypeParameters();
@@ -330,11 +341,15 @@ namespace parser
             }
         }
         consume(lexer::TokenType::RIGHT_BRACE, "Expected '}' after class body");
+        std::shared_ptr<ast::ClassStmt> cls;
         if (!typeParams.empty())
-            return std::make_shared<ast::ClassStmt>(name, name.value, typeParams,
-                                                    nullptr, std::vector<ast::TypePtr>{},
-                                                    fields, methods);
-        return std::make_shared<ast::ClassStmt>(name, name.value, fields, methods);
+            cls = std::make_shared<ast::ClassStmt>(name, name.value, typeParams,
+                                                   nullptr, std::vector<ast::TypePtr>{},
+                                                   fields, methods);
+        else
+            cls = std::make_shared<ast::ClassStmt>(name, name.value, fields, methods);
+        cls->isMmio = isMmio;
+        return cls;
     }
 
     std::shared_ptr<ast::FunctionStmt> Parser::methodDeclaration(bool allowNoBody)

--- a/src/parser/parser.h
+++ b/src/parser/parser.h
@@ -68,7 +68,7 @@ namespace parser
         ast::StmtPtr declaration();
         ast::StmtPtr varDeclaration();
         ast::StmtPtr functionDeclaration();
-        ast::StmtPtr classDeclaration();
+        ast::StmtPtr classDeclaration(bool isMmio = false);
         ast::StmtPtr traitDeclaration();
         ast::StmtPtr implDeclaration();
         ast::StmtPtr enumDeclaration();

--- a/src/type/builtin_names.h
+++ b/src/type/builtin_names.h
@@ -48,7 +48,7 @@ namespace type_checker
             {"range", {}},
             // raw memory (systems/kernel fast path)
             {"alloc", {1}}, {"free", {1}}, {"memcpy", {3}}, {"memset", {3}},
-            {"bufToStr", {2}}, {"strFromAddr", {1}},
+            {"bufToStr", {2}}, {"strFromAddr", {1}}, {"mmioAt", {1}},
             {"newArray", {1}}, {"zeros", {1}}, {"newFloatArray", {1}},
             {"ptrAdd", {2}}, {"loadByte", {2}}, {"storeByte", {3}},
             {"loadInt", {2}}, {"storeInt", {3}},

--- a/tests/kernel_codegen_test.sh
+++ b/tests/kernel_codegen_test.sh
@@ -86,4 +86,48 @@ if [ -f "$KDIR/kernel.to" ]; then
     fi
 fi
 
+# --- 5. mmio struct: volatile field access + C layout + runtime correctness ---
+cat > "$TMP/mmio.to" <<'EOF'
+mmio struct Uart { data: u32; status: u32; control: u32; baud: u32; }
+def main() -> int {
+    let base = alloc(16);
+    let u: Uart = mmioAt(base);
+    u.control = 1;
+    u.baud = 115200;
+    u.data = 65;
+    let sum = u.control + u.data;          // widen i32+i32; == 66
+    if (u.status == 0) { sum = sum + 1; }  // sized-field vs i64 literal -> 67
+    if (u.baud != 115200) { return 1; }
+    return sum;
+}
+EOF
+# 5a. IR: field accesses must be volatile, layout must be four i32s (offsets 0/4/8/12).
+if "$TOCIN" "$TMP/mmio.to" -o "$TMP/mmio.ll" 2>"$TMP/mmio.err"; then
+    nv_load=$(grep -c 'load volatile' "$TMP/mmio.ll")
+    nv_store=$(grep -c 'store volatile' "$TMP/mmio.ll")
+    if [ "$nv_load" -ge 1 ] && [ "$nv_store" -ge 1 ] && \
+       grep -q '%Uart = type { i32, i32, i32, i32 }' "$TMP/mmio.ll"; then
+        pass "mmio struct: volatile field access + C layout"
+    else
+        bad "mmio struct: non-volatile access or wrong layout ($nv_load loads, $nv_store stores)"
+    fi
+else
+    bad "mmio struct: compilation failed"; cat "$TMP/mmio.err"
+fi
+# 5b. runtime: fields land at distinct offsets and read back correctly (exit 67).
+"$TOCIN" "$TMP/mmio.to" --run >/dev/null 2>&1
+rc=$?
+if [ "$rc" -eq 67 ]; then
+    pass "mmio struct: runtime field read/write (exit 67)"
+else
+    bad "mmio struct: runtime wrong (exit $rc, expected 67)"
+fi
+# 5c. mmio structs work freestanding (the actual kernel/driver use case).
+if "$TOCIN" "$TMP/mmio.to" --freestanding --target-triple x86_64-unknown-none \
+      -o "$TMP/mmio_fs.o" 2>"$TMP/mmiofs.err"; then
+    pass "mmio struct: freestanding object"
+else
+    bad "mmio struct: freestanding failed"; cat "$TMP/mmiofs.err"
+fi
+
 exit $fail


### PR DESCRIPTION
## What

Closes the biggest remaining bare-metal ergonomics gap: **typed, volatile access to memory-mapped device registers**. Drivers can now address a hardware register block as a named struct instead of manual `(base, offset)` volatile calls.

```tocin
mmio struct Uart { data: u32; status: u32; control: u32; }

def putc(base: int, ch: int) {
    let u: Uart = mmioAt(base);        // typed view at a physical address
    while (u.status & 0x20) == 0 { }   // -> load volatile i32
    u.data = ch;                       // -> store volatile i32
}
```

## Changes

- **`mmio struct`** — a memory-mapped register block. C field layout (sized `u8`/`u16`/`u32`/`u64` at natural offsets), and **every field load/store lowers to a volatile access** (never elided, merged, or reordered). Plain structs are unchanged (non-volatile). `mmio` is a *contextual* keyword — recognized only before `struct`/`class`, so it stays usable as an ordinary identifier.
- **`mmioAt(addr)`** — returns a typed handle to an `mmio struct` at a physical address (`inttoptr`). Types as `UNKNOWN`, so it assigns to any annotated struct type with no type-checker surgery.
- **`u8`/`u16`/`u32`/`u64`/`usize`/`isize`** — width aliases of the sized ints (LLVM integers are sign-agnostic).
- **Mixed integer-width reconciliation** in the binary-op codegen — a sized field (`i32`) now interoperates with default `int` (`i64`) literals in arithmetic/comparisons by sign-extending the narrower operand to the wider. Previously this produced a type-mismatched `icmp`/`add` that failed verification, which made sized-int fields nearly unusable.

## Verification

- **New MMIO tests** in `tests/kernel_codegen_test.sh` (now 7/7): volatile field access + `{ i32, i32, i32, i32 }` C layout in the IR; runtime read/write over a heap buffer (fields land at distinct offsets, exit 67); and a freestanding object.
- **Driver example**: `examples/kernel/mmio_uart.to` — a memory-mapped 16550 UART, compiles `--freestanding` for `x86_64-unknown-none` (verified: 1 volatile load for the LSR poll + 8 volatile stores, `%Uart16550 = type { i32 ×8 }`).
- **No regressions** — the integer-width change touches every integer binary op, so it was the risk to watch: C++ unit tests 6/6, lli suite 145/145, JIT stdlib suite green, non-`mmio` structs verified to keep **zero** volatile accesses. `mmio` still works as a normal identifier.

## Docs

`docs/kernel-development.md` (new "Typed device registers" section + capabilities update), `docs/language-reference.md` (sized-type rows, `mmio struct` subsection, `mmioAt` in the builtin reference), `docs/tocin-for-ai.md` (builtin table + `mmio struct` spec).

## Context

This is the follow-up to the OS-enablement work merged in #39 (cross-compilation, `naked`/`interrupt`, module asm, bootable kernel). It knocks out gap #2 (typed pointers / repr-C for MMIO) from the OS suitability assessment. The one remaining item from that list is general freestanding value aggregates (structs returned/passed by value without the runtime allocator).

## Note on CI

CI has been failing on all recent PRs with an account-side runner signature (jobs die in 3–5s before a runner provisions; GitGuardian passes on its own infra). Everything here was verified locally. Worth clearing the GitHub Actions billing/spending-limit setting so master gets real signal.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Fih5HHhUzVNkusdaXHoSdu)_